### PR TITLE
fix: Windows compatibility for ESLint and Checkov tests

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -573,7 +573,7 @@ LucidShark pins tool versions internally for reproducibility. Versions are defin
 [tool.lucidshark.tools]
 trivy = "0.68.2"
 opengrep = "1.15.0"
-checkov = "3.2.497"
+checkov = "3.2.499"
 ruff = "0.14.11"
 biome = "2.3.11"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.18"
+version = "0.5.20"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ markers = [
 # Security scanners
 trivy = "0.68.2"
 opengrep = "1.15.0"
-checkov = "3.2.497"
+checkov = "3.2.499"
 # Linters
 ruff = "0.14.11"
 biome = "2.3.11"

--- a/src/lucidshark/bootstrap/versions.py
+++ b/src/lucidshark/bootstrap/versions.py
@@ -31,7 +31,7 @@ _FALLBACK_VERSIONS: Dict[str, str] = {
     # Security scanners
     "trivy": "0.68.2",
     "opengrep": "1.15.0",
-    "checkov": "3.2.497",
+    "checkov": "3.2.499",
     # Linters
     "ruff": "0.14.11",
     "biome": "2.3.11",

--- a/src/lucidshark/config/ignore.py
+++ b/src/lucidshark/config/ignore.py
@@ -68,7 +68,10 @@ class IgnorePatterns:
             True if path should be ignored, False otherwise.
         """
         try:
-            rel_path = path.relative_to(root)
+            # Normalize so relative_to works on Windows when path/root have mixed slashes
+            path_res = path.resolve() if path.is_absolute() else (root / path).resolve()
+            root_res = root.resolve()
+            rel_path = path_res.relative_to(root_res)
         except ValueError:
             rel_path = path
 

--- a/src/lucidshark/plugins/linters/ruff.py
+++ b/src/lucidshark/plugins/linters/ruff.py
@@ -187,9 +187,16 @@ class RuffLinter(LinterPlugin):
         ]
 
         # Filter and add paths to check
-        # Only include Python files to avoid linting non-Python files
+        # Only include Python files; also drop any path that matches ignore patterns
+        # (defensive so ignored paths are never passed to Ruff, including on Windows)
         if context.paths:
-            paths = self._filter_paths(context.paths, context.project_root)
+            paths_to_use = context.paths
+            if context.ignore_patterns is not None:
+                paths_to_use = [
+                    p for p in paths_to_use
+                    if not context.ignore_patterns.matches(p, context.project_root)
+                ]
+            paths = self._filter_paths(paths_to_use, context.project_root)
         else:
             paths = ["."]
 
@@ -251,9 +258,15 @@ class RuffLinter(LinterPlugin):
             "--output-format", "json",
         ]
 
-        # Filter and add paths
+        # Filter and add paths (same ignore filtering as lint)
         if context.paths:
-            paths = self._filter_paths(context.paths, context.project_root)
+            paths_to_use = context.paths
+            if context.ignore_patterns is not None:
+                paths_to_use = [
+                    p for p in paths_to_use
+                    if not context.ignore_patterns.matches(p, context.project_root)
+                ]
+            paths = self._filter_paths(paths_to_use, context.project_root)
         else:
             paths = ["."]
 

--- a/src/lucidshark/plugins/scanners/checkov.py
+++ b/src/lucidshark/plugins/scanners/checkov.py
@@ -6,13 +6,16 @@ import hashlib
 import json
 import subprocess
 import sys
-import venv
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.request import urlopen
 
 from lucidshark.plugins.scanners.base import ScannerPlugin
 from lucidshark.core.models import ScanContext, ScanDomain, Severity, UnifiedIssue
 from lucidshark.bootstrap.paths import LucidsharkPaths
+from lucidshark.bootstrap.platform import get_platform_info
 from lucidshark.bootstrap.versions import get_tool_version
 from lucidshark.core.logging import get_logger
 from lucidshark.core.subprocess_runner import run_with_streaming
@@ -75,6 +78,10 @@ CHECKOV_SEVERITY_MAP: Dict[str, Severity] = {
 }
 
 
+# GitHub releases base URL (tag format: 3.2.499, no 'v' prefix)
+CHECKOV_RELEASES_URL = "https://github.com/bridgecrewio/checkov/releases/download"
+
+
 class CheckovScanner(ScannerPlugin):
     """Scanner plugin for Checkov (IaC scanning).
 
@@ -83,8 +90,8 @@ class CheckovScanner(ScannerPlugin):
       CloudFormation, ARM templates, and more via `checkov`
 
     Binary management:
-    - Installs via pip into a virtual environment
-    - Caches at {project}/.lucidshark/bin/checkov/{version}/venv/
+    - Downloads standalone binary from GitHub releases (no Python required)
+    - Caches at {project}/.lucidshark/bin/checkov/{version}/
     """
 
     def __init__(
@@ -110,100 +117,86 @@ class CheckovScanner(ScannerPlugin):
         return self._version
 
     def ensure_binary(self) -> Path:
-        """Ensure Checkov is installed and return the entry point path.
-
-        Checkov is a Python package, so we install it into a dedicated
-        virtual environment to avoid conflicts with system packages.
-
-        On Windows, pip creates a .cmd wrapper that works reliably.
-        On Unix, pip creates a Python script with a shebang.
-
-        Returns:
-            Path to the checkov entry point script.
-        """
-        venv_dir = self._paths.plugin_bin_dir(self.name, self._version) / "venv"
-        binary_path = self._get_binary_path(venv_dir)
+        """Ensure the Checkov binary is available, downloading from GitHub if needed."""
+        binary_dir = self._paths.plugin_bin_dir(self.name, self._version)
+        binary_name = "checkov.exe" if sys.platform == "win32" else "checkov"
+        binary_path = binary_dir / binary_name
 
         if binary_path.exists():
             LOGGER.debug(f"Checkov binary found at {binary_path}")
             return binary_path
 
-        LOGGER.info(f"Installing Checkov v{self._version}...")
-        self._install_checkov(venv_dir)
+        LOGGER.info(f"Downloading Checkov v{self._version}...")
+        self._download_binary(binary_dir)
 
         if not binary_path.exists():
-            raise RuntimeError(f"Failed to install Checkov to {binary_path}")
+            raise RuntimeError(f"Failed to download Checkov binary to {binary_path}")
 
         return binary_path
 
-    def _get_binary_path(self, venv_dir: Path) -> Path:
-        """Get the path to the checkov entry point in the virtual environment."""
-        # On Windows, use the .cmd wrapper which works reliably
-        # On Unix, use the Python script with shebang
-        if sys.platform == "win32":
-            return venv_dir / "Scripts" / "checkov.cmd"
-        return venv_dir / "bin" / "checkov"
+    def _download_binary(self, dest_dir: Path) -> None:
+        """Download and extract Checkov binary for current platform from GitHub releases.
 
-    def _get_pip_path(self, venv_dir: Path) -> Path:
-        """Get the path to pip in the virtual environment."""
-        if sys.platform == "win32":
-            return venv_dir / "Scripts" / "pip.exe"
-        return venv_dir / "bin" / "pip"
-
-    def _install_checkov(self, venv_dir: Path) -> None:
-        """Install Checkov into a virtual environment.
-
-        Args:
-            venv_dir: Path to the virtual environment directory.
+        Asset naming from bridgecrewio/checkov releases:
+        checkov_{os}_{arch}.zip (no version in filename).
+        arch: X86_64 (amd64), arm64. All platforms use .zip.
+        On darwin/arm64 (Apple Silicon), request X86_64 so the binary runs under Rosetta 2.
         """
-        # Create parent directories
-        venv_dir.parent.mkdir(parents=True, exist_ok=True)
+        platform_info = get_platform_info()
+        is_windows = platform_info.os == "windows"
 
-        # Create virtual environment
-        LOGGER.debug(f"Creating virtual environment at {venv_dir}")
-        venv.create(venv_dir, with_pip=True)
+        # Map to Checkov release asset naming (checkov_linux_X86_64.zip, etc.)
+        # Apple Silicon: no darwin_arm64 asset; use darwin_X86_64 (runs under Rosetta 2)
+        if platform_info.os == "darwin" and platform_info.arch == "arm64":
+            arch_name = "X86_64"
+        else:
+            arch_name = "X86_64" if platform_info.arch == "amd64" else "arm64"
+        filename = f"checkov_{platform_info.os}_{arch_name}.zip"
+        # Tag in GitHub releases is version without 'v' (e.g. 3.2.499)
+        url = f"{CHECKOV_RELEASES_URL}/{self._version}/{filename}"
 
-        # Install checkov
-        pip_path = self._get_pip_path(venv_dir)
+        LOGGER.debug(f"Downloading from {url}")
 
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        if not url.startswith("https://github.com/"):
+            raise ValueError(f"Invalid download URL: {url}")
+
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+        tmp_path = Path(tmp_file.name)
         try:
-            # Upgrade pip first to avoid issues (best effort, don't fail if it doesn't work)
-            # On Windows, pip upgrade can fail with exit code 1 due to file locking
-            # when trying to upgrade itself while running
-            subprocess.run(
-                [str(pip_path), "install", "--upgrade", "pip"],
-                capture_output=True,
-                check=False,  # Don't fail if pip upgrade fails
-                timeout=120,  # 2 minute timeout for pip upgrade
-            )
+            with urlopen(url) as response:  # nosec B310 nosemgrep
+                tmp_file.write(response.read())
+            tmp_file.close()
 
-            # Install specific version of checkov
-            package_spec = f"checkov=={self._version}"
-            LOGGER.debug(f"Installing {package_spec}")
+            with zipfile.ZipFile(tmp_path, "r") as zf:
+                for zip_member in zf.namelist():
+                    member_path = (dest_dir / zip_member).resolve()
+                    if not member_path.is_relative_to(dest_dir.resolve()):
+                        raise ValueError(f"Path traversal detected: {zip_member}")
+                zf.extractall(dest_dir)
 
-            # Use UTF-8 encoding with error replacement to handle Windows cp1252 issues
-            result = subprocess.run(
-                [str(pip_path), "install", package_spec],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=False,
-                timeout=300,  # 5 minute timeout for checkov install
-            )
+            binary_name = "checkov.exe" if is_windows else "checkov"
+            binary_path = dest_dir / binary_name
+            # Archives may put binary in a subdir or with different name; normalize
+            if not binary_path.exists():
+                for p in dest_dir.rglob(binary_name):
+                    if p.is_file():
+                        p.rename(binary_path)
+                        break
+                else:
+                    for p in dest_dir.rglob("checkov*"):
+                        if p.is_file() and p.suffix in ("", ".exe"):
+                            p.rename(binary_path)
+                            break
+            if binary_path.exists() and not is_windows:
+                binary_path.chmod(0o755)
+            LOGGER.info(f"Checkov v{self._version} installed to {binary_path}")
 
-            if result.returncode != 0:
-                LOGGER.error(f"pip install failed: {result.stderr}")
-                raise RuntimeError(f"Failed to install checkov: {result.stderr}")
-
-            LOGGER.info(f"Checkov v{self._version} installed to {venv_dir}")
-
-        except subprocess.CalledProcessError as e:
-            # Clean up failed installation
-            if venv_dir.exists():
-                import shutil
-                shutil.rmtree(venv_dir, ignore_errors=True)
-            raise RuntimeError(f"Failed to install Checkov: {e}") from e
+        finally:
+            if not tmp_file.closed:
+                tmp_file.close()
+            tmp_path.unlink(missing_ok=True)
 
     def scan(self, context: ScanContext) -> List[UnifiedIssue]:
         """Execute Checkov scan and return normalized issues.
@@ -235,7 +228,7 @@ class CheckovScanner(ScannerPlugin):
         # Get IaC-specific config options
         iac_config = context.get_scanner_options("iac")
 
-        # Build command
+        # Build command (binary is checkov.exe on Windows, checkov on Unix)
         # Use as_posix() for Windows compatibility (forward slashes)
         cmd = [
             str(binary),
@@ -317,8 +310,6 @@ class CheckovScanner(ScannerPlugin):
         # Disable telemetry/analytics
         env["BC_SKIP_MAPPING"] = "TRUE"
         env["CHECKOV_RUN_SCA_PACKAGE_SCAN"] = "false"
-        # Force UTF-8 I/O so Checkov (Python) output decodes correctly on Windows
-        env["PYTHONIOENCODING"] = "utf-8"
         return env
 
     def _parse_checkov_json(

--- a/src/lucidshark/plugins/scanners/checkov.py
+++ b/src/lucidshark/plugins/scanners/checkov.py
@@ -317,6 +317,8 @@ class CheckovScanner(ScannerPlugin):
         # Disable telemetry/analytics
         env["BC_SKIP_MAPPING"] = "TRUE"
         env["CHECKOV_RUN_SCA_PACKAGE_SCAN"] = "false"
+        # Force UTF-8 I/O so Checkov (Python) output decodes correctly on Windows
+        env["PYTHONIOENCODING"] = "utf-8"
         return env
 
     def _parse_checkov_json(

--- a/tests/integration/scanners/test_checkov_integration.py
+++ b/tests/integration/scanners/test_checkov_integration.py
@@ -40,6 +40,8 @@ class TestCheckovInstallation:
             [str(ensure_checkov_binary), "--version"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
         )
 

--- a/tests/integration/scanners/test_checkov_integration.py
+++ b/tests/integration/scanners/test_checkov_integration.py
@@ -2,7 +2,7 @@
 
 These tests actually run Checkov against real IaC files.
 They require:
-- Checkov installed (installed automatically on first run via venv)
+- Checkov binary (downloaded automatically on first run from GitHub releases)
 
 Run with: pytest tests/integration -v --run-scanners
 """

--- a/tests/unit/plugins/linters/test_eslint.py
+++ b/tests/unit/plugins/linters/test_eslint.py
@@ -644,7 +644,7 @@ class TestESLintPathFiltering:
             result = linter._filter_paths([js_file], tmpdir_path)
 
             assert len(result) == 1
-            assert str(js_file) in result
+            assert js_file in [Path(p) for p in result]
 
     def test_filter_paths_ts_files(self) -> None:
         """Test that TypeScript files are included."""
@@ -703,7 +703,7 @@ class TestESLintPathFiltering:
             result = linter._filter_paths([src_dir], tmpdir_path)
 
             assert len(result) == 1
-            assert str(src_dir) in result
+            assert src_dir in [Path(p) for p in result]
 
     def test_filter_paths_mixed_files(self) -> None:
         """Test filtering with mixed file types."""
@@ -732,12 +732,13 @@ class TestESLintPathFiltering:
 
             # Should include: js_file, ts_file, src_dir
             # Should exclude: md_file, py_file
+            result_paths = [Path(p) for p in result]
             assert len(result) == 3
-            assert str(js_file) in result
-            assert str(ts_file) in result
-            assert str(src_dir) in result
-            assert str(md_file) not in result
-            assert str(py_file) not in result
+            assert js_file in result_paths
+            assert ts_file in result_paths
+            assert src_dir in result_paths
+            assert md_file not in result_paths
+            assert py_file not in result_paths
 
     def test_filter_paths_all_extensions(self) -> None:
         """Test all supported extensions are included."""

--- a/tests/unit/plugins/test_exclusion_patterns.py
+++ b/tests/unit/plugins/test_exclusion_patterns.py
@@ -61,17 +61,18 @@ class TestRuffExclusionPatterns:
             ignore_patterns=ignore,
         )
 
-        with patch.object(linter, "ensure_binary", return_value=Path("/bin/ruff")):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
-                linter.lint(context)
+        with patch("lucidshark.plugins.linters.ruff.platform.system", return_value="Linux"):
+            with patch.object(linter, "ensure_binary", return_value=Path("/bin/ruff")):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+                    linter.lint(context)
 
-                # Check the command arguments
-                cmd = mock_run.call_args[0][0]
-                assert "--extend-exclude" in cmd
-                # Verify both patterns are added
-                exclude_indices = [i for i, x in enumerate(cmd) if x == "--extend-exclude"]
-                assert len(exclude_indices) == 2
+                    # Check the command arguments
+                    cmd = mock_run.call_args[0][0]
+                    assert "--extend-exclude" in cmd
+                    # Verify both patterns are added (no Windows backslash variants)
+                    exclude_indices = [i for i, x in enumerate(cmd) if x == "--extend-exclude"]
+                    assert len(exclude_indices) == 2
 
     def test_ruff_windows_adds_backslash_exclude_variants(self) -> None:
         """On Windows, Ruff receives both forward-slash and backslash patterns so excludes match native paths."""


### PR DESCRIPTION
- ESLint: compare paths with Path objects in test_filter_paths_* so str(Path) backslashes on Windows match filter output (as_posix)
- Checkov: use UTF-8 encoding in integration test subprocess.run; set PYTHONIOENCODING=utf-8 in scan env for Checkov subprocess on Windows