### PR TITLE
fix: resolve node_modules binaries on Windows via .cmd wrappers

### DIFF
--- a/src/lucidshark/plugins/coverage/istanbul.py
+++ b/src/lucidshark/plugins/coverage/istanbul.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from lucidshark.core.logging import get_logger
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -88,8 +89,8 @@ class IstanbulPlugin(CoveragePlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_nyc = self._project_root / "node_modules" / ".bin" / "nyc"
-            if node_nyc.exists():
+            node_nyc = resolve_node_bin(self._project_root, "nyc")
+            if node_nyc:
                 return node_nyc
 
         # Check system PATH
@@ -155,8 +156,8 @@ class IstanbulPlugin(CoveragePlugin):
         # Check for jest or npm test
         jest_path = None
         if self._project_root:
-            node_jest = self._project_root / "node_modules" / ".bin" / "jest"
-            if node_jest.exists():
+            node_jest = resolve_node_bin(self._project_root, "jest")
+            if node_jest:
                 jest_path = node_jest
 
         if not jest_path:

--- a/src/lucidshark/plugins/linters/biome.py
+++ b/src/lucidshark/plugins/linters/biome.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 from lucidshark.bootstrap.paths import LucidsharkPaths
 from lucidshark.bootstrap.versions import get_tool_version
 from lucidshark.core.logging import get_logger
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -90,8 +91,8 @@ class BiomeLinter(LinterPlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_biome = self._project_root / "node_modules" / ".bin" / "biome"
-            if node_biome.exists():
+            node_biome = resolve_node_bin(self._project_root, "biome")
+            if node_biome:
                 return node_biome
 
         # Check system PATH

--- a/src/lucidshark/plugins/linters/eslint.py
+++ b/src/lucidshark/plugins/linters/eslint.py
@@ -20,6 +20,7 @@ from lucidshark.core.models import (
     ToolDomain,
     UnifiedIssue,
 )
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.subprocess_runner import run_with_streaming
 from lucidshark.plugins.linters.base import FixResult, LinterPlugin
 
@@ -103,8 +104,8 @@ class ESLintLinter(LinterPlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_eslint = self._project_root / "node_modules" / ".bin" / "eslint"
-            if node_eslint.exists():
+            node_eslint = resolve_node_bin(self._project_root, "eslint")
+            if node_eslint:
                 return node_eslint
 
         # Check system PATH

--- a/src/lucidshark/plugins/test_runners/jest.py
+++ b/src/lucidshark/plugins/test_runners/jest.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from lucidshark.core.logging import get_logger
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -85,8 +86,8 @@ class JestRunner(TestRunnerPlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_jest = self._project_root / "node_modules" / ".bin" / "jest"
-            if node_jest.exists():
+            node_jest = resolve_node_bin(self._project_root, "jest")
+            if node_jest:
                 return node_jest
 
         # Check system PATH

--- a/src/lucidshark/plugins/test_runners/karma.py
+++ b/src/lucidshark/plugins/test_runners/karma.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from lucidshark.core.logging import get_logger
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -85,8 +86,8 @@ class KarmaRunner(TestRunnerPlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_karma = self._project_root / "node_modules" / ".bin" / "karma"
-            if node_karma.exists():
+            node_karma = resolve_node_bin(self._project_root, "karma")
+            if node_karma:
                 return node_karma
 
         # Check system PATH

--- a/src/lucidshark/plugins/test_runners/playwright.py
+++ b/src/lucidshark/plugins/test_runners/playwright.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from lucidshark.core.logging import get_logger
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -87,8 +88,8 @@ class PlaywrightRunner(TestRunnerPlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_playwright = self._project_root / "node_modules" / ".bin" / "playwright"
-            if node_playwright.exists():
+            node_playwright = resolve_node_bin(self._project_root, "playwright")
+            if node_playwright:
                 return node_playwright
 
         # Check system PATH

--- a/src/lucidshark/plugins/type_checkers/pyright.py
+++ b/src/lucidshark/plugins/type_checkers/pyright.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 from lucidshark.bootstrap.paths import LucidsharkPaths
 from lucidshark.bootstrap.versions import get_tool_version
 from lucidshark.core.logging import get_logger
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -99,8 +100,8 @@ class PyrightChecker(TypeCheckerPlugin):
 
         # Check project node_modules
         if self._project_root:
-            node_pyright = self._project_root / "node_modules" / ".bin" / "pyright"
-            if node_pyright.exists():
+            node_pyright = resolve_node_bin(self._project_root, "pyright")
+            if node_pyright:
                 return node_pyright
 
         # Check system PATH (npm or pip installed)

--- a/src/lucidshark/plugins/type_checkers/typescript.py
+++ b/src/lucidshark/plugins/type_checkers/typescript.py
@@ -20,6 +20,7 @@ from lucidshark.core.models import (
     ToolDomain,
     UnifiedIssue,
 )
+from lucidshark.core.paths import resolve_node_bin
 from lucidshark.plugins.type_checkers.base import TypeCheckerPlugin
 
 LOGGER = get_logger(__name__)
@@ -96,8 +97,8 @@ class TypeScriptChecker(TypeCheckerPlugin):
         """
         # Check project node_modules first
         if self._project_root:
-            node_tsc = self._project_root / "node_modules" / ".bin" / "tsc"
-            if node_tsc.exists():
+            node_tsc = resolve_node_bin(self._project_root, "tsc")
+            if node_tsc:
                 return node_tsc
 
         # Check system PATH

--- a/tests/integration/projects/conftest.py
+++ b/tests/integration/projects/conftest.py
@@ -101,7 +101,7 @@ def run_lucidshark(
     project_path: Path,
     domains: list[str] | None = None,
     extra_args: list[str] | None = None,
-    timeout: int = 120,
+    timeout: int = 300,
     all_files: bool = True,
 ) -> ScanResult:
     """Run lucidshark CLI against a project and return parsed results.
@@ -279,8 +279,14 @@ def _setup_node_modules(project_path: Path) -> Path:
 
     print(f"\n[Setup] Running npm install in {project_path}...")
 
+    # Use shutil.which to resolve the full path to npm (needed on Windows
+    # where npm is a .cmd file and subprocess.run won't find it without shell=True)
+    npm_bin = shutil.which("npm")
+    if not npm_bin:
+        pytest.skip("npm not found in PATH")
+
     result = subprocess.run(
-        ["npm", "install"],
+        [npm_bin, "install"],
         cwd=project_path,
         capture_output=True,
         text=True,


### PR DESCRIPTION
On Windows, node_modules/.bin entries are shell scripts that cannot be executed directly by subprocess