### PR TITLE
Add full Java support with JaCoCo, Maven, and SpotBugs plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AI writes code → LucidShark checks → AI fixes → repeat
 
 - **AI-native** - MCP integration with Claude Code and Cursor. Structured feedback that AI agents can act on directly.
 
-- **Unified pipeline** - Linting, type checking, security (SAST/SCA/IaC), tests, and coverage in one tool. Stop configuring 5+ separate tools.
+- **Unified pipeline** - Linting, type checking, security (SAST/SCA/IaC), tests, coverage, and duplication detection in one tool. Stop configuring 5+ separate tools.
 
 - **Open source & extensible** - Apache 2.0 licensed. Add your own tools via the plugin system.
 
@@ -130,13 +130,13 @@ Configures both Claude Code and Cursor.
 | Domain | Tools | What It Catches |
 |--------|-------|-----------------|
 | **Linting** | Ruff, ESLint, Biome, Checkstyle | Style issues, code smells |
-| **Type Checking** | mypy, pyright, TypeScript | Type errors |
+| **Type Checking** | mypy, pyright, TypeScript, SpotBugs | Type errors, static analysis bugs |
 | **Security (SAST)** | OpenGrep | Code vulnerabilities |
 | **Security (SCA)** | Trivy | Dependency vulnerabilities |
 | **Security (IaC)** | Checkov | Infrastructure misconfigurations |
 | **Security (Container)** | Trivy | Container image vulnerabilities |
-| **Testing** | pytest, Jest, Karma (Angular), Playwright (E2E) | Test failures |
-| **Coverage** | coverage.py, Istanbul | Coverage gaps |
+| **Testing** | pytest, Jest, Karma (Angular), Playwright (E2E), Maven/Gradle (JUnit) | Test failures |
+| **Coverage** | coverage.py, Istanbul, JaCoCo | Coverage gaps |
 | **Duplication** | Duplo | Code clones, duplicate blocks |
 
 All results are normalized to a common format.
@@ -203,7 +203,7 @@ lucidshark init --all                     # Configure all AI tools
 lucidshark autoconfigure [--ci github|gitlab|bitbucket] [--non-interactive]
 
 # Run quality pipeline
-lucidshark scan [--linting] [--type-checking] [--sca] [--sast] [--iac] [--container] [--testing] [--coverage] [--all]
+lucidshark scan [--linting] [--type-checking] [--sca] [--sast] [--iac] [--container] [--testing] [--coverage] [--duplication] [--all]
 lucidshark scan [--fix] [--stream] [--format table|json|sarif|summary]
 lucidshark scan [--fail-on critical|high|medium|low]
 
@@ -223,6 +223,7 @@ lucidshark status [--tools]
 | 1 | Issues found above threshold |
 | 2 | Tool execution error |
 | 3 | Configuration error |
+| 4 | Bootstrap/download failure |
 
 ## Development
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -571,8 +571,9 @@ pipeline:
 
   coverage:
     enabled: true
-    tools: [coverage_py]  # Required: coverage_py for Python, istanbul for JS/TS
+    tools: [coverage_py]  # Required: coverage_py for Python, istanbul for JS/TS, jacoco for Java
     threshold: 80  # Fail if coverage below this
+    # extra_args: ["-DskipITs"]  # For Java: extra Maven/Gradle arguments
 
   duplication:
     enabled: true
@@ -631,8 +632,9 @@ output:
 | `testing.enabled` | bool | false | Enable test execution |
 | `testing.tools` | array | (auto) | Test frameworks |
 | `coverage.enabled` | bool | false | Enable coverage analysis |
-| `coverage.tools` | array | **required** | Coverage tools (coverage_py, istanbul) |
+| `coverage.tools` | array | **required** | Coverage tools (coverage_py, istanbul, jacoco) |
 | `coverage.threshold` | int | 80 | Coverage percentage threshold |
+| `coverage.extra_args` | array | [] | Extra Maven/Gradle arguments (Java only) |
 | `duplication.enabled` | bool | false | Enable duplication detection |
 | `duplication.threshold` | float | 10.0 | Max allowed duplication percentage |
 | `duplication.min_lines` | int | 4 | Minimum lines for a duplicate block |
@@ -932,6 +934,7 @@ All linting tools support the `files` parameter for partial scanning.
 | Jest | JavaScript, TypeScript | ✅ Yes |
 | Karma | JavaScript, TypeScript (Angular) | ❌ No (config-based) |
 | Playwright | JavaScript, TypeScript (E2E) | ✅ Yes |
+| Maven | Java (JUnit/TestNG) | ❌ No (project-wide) |
 
 **Note:** While test runners support running specific test files, it's recommended to run the full test suite before commits to catch regressions.
 
@@ -941,8 +944,19 @@ All linting tools support the `files` parameter for partial scanning.
 |------|-----------|--------------|
 | coverage.py | Python | ⚠️ Partial (filter output) |
 | Istanbul/nyc | JavaScript, TypeScript | ⚠️ Partial (filter output) |
+| JaCoCo | Java | ❌ No (project-wide) |
 
 **Note:** Coverage tools run the full test suite but can filter the coverage report to show only changed files.
+
+**Java Coverage (JaCoCo):** For Java projects with integration tests that require Docker or external services, use `extra_args` to skip them:
+```yaml
+pipeline:
+  coverage:
+    enabled: true
+    tools: [jacoco]
+    threshold: 80
+    extra_args: ["-DskipITs", "-Ddocker.skip=true"]
+```
 
 ### Duplication Detection
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -263,6 +263,7 @@ pipeline:
     threshold: 80
     tools:
       - name: coverage_py
+    # extra_args: ["-DskipITs", "-Ddocker.skip=true"]  # For Java: skip integration tests
 
   duplication:
     enabled: true
@@ -491,7 +492,8 @@ pipeline:
     enabled: boolean
     threshold: number  # Default: 80
     tools:
-      - name: string  # coverage_py for Python, istanbul for JS/TS
+      - name: string  # coverage_py for Python, istanbul for JS/TS, jacoco for Java
+    extra_args: [string]  # Extra arguments for Maven/Gradle (Java only)
 
   duplication:
     enabled: boolean

--- a/lucidshark.yml
+++ b/lucidshark.yml
@@ -32,7 +32,7 @@ pipeline:
 
   duplication:
     enabled: true
-    threshold: 10.0
+    threshold: 5.0
     min_lines: 7
     tools: [duplo]
     exclude:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,16 +99,19 @@ table = "lucidshark.plugins.reporters.table_reporter:TableReporter"
 mypy = "lucidshark.plugins.type_checkers.mypy:MypyChecker"
 pyright = "lucidshark.plugins.type_checkers.pyright:PyrightChecker"
 typescript = "lucidshark.plugins.type_checkers.typescript:TypeScriptChecker"
+spotbugs = "lucidshark.plugins.type_checkers.spotbugs:SpotBugsChecker"
 
 [project.entry-points."lucidshark.test_runners"]
 pytest = "lucidshark.plugins.test_runners.pytest:PytestRunner"
 jest = "lucidshark.plugins.test_runners.jest:JestRunner"
 karma = "lucidshark.plugins.test_runners.karma:KarmaRunner"
 playwright = "lucidshark.plugins.test_runners.playwright:PlaywrightRunner"
+maven = "lucidshark.plugins.test_runners.maven:MavenTestRunner"
 
 [project.entry-points."lucidshark.coverage"]
 coverage_py = "lucidshark.plugins.coverage.coverage_py:CoveragePyPlugin"
 istanbul = "lucidshark.plugins.coverage.istanbul:IstanbulPlugin"
+jacoco = "lucidshark.plugins.coverage.jacoco:JaCoCoPlugin"
 
 [project.entry-points."lucidshark.duplication"]
 duplo = "lucidshark.plugins.duplication.duplo:DuploPlugin"
@@ -139,5 +142,6 @@ biome = "2.3.14"
 checkstyle = "13.2.0"
 # Type checkers
 pyright = "1.1.408"
+spotbugs = "4.9.8"
 # Duplication detection
 duplo = "0.1.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ jsonpointer==3.0.0
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 langchain-anthropic==1.3.2
-langchain-core==1.2.9
+langchain-core==1.2.11
 langchain-ollama==1.0.1
 langchain-openai==1.1.7
 langsmith==0.6.9

--- a/src/lucidshark/cli/commands/init.py
+++ b/src/lucidshark/cli/commands/init.py
@@ -27,104 +27,114 @@ LUCIDSHARK_MCP_ARGS = ["serve", "--mcp"]
 # Claude skill content for proactive lucidshark usage
 LUCIDSHARK_SKILL_CONTENT = """---
 name: lucidshark
-description: Code quality scanning with LucidShark. Use after completing code changes, before commits, or when user asks to check code quality.
+description: "PROACTIVE code quality scanning. ALWAYS run after: writing/editing ANY code, fixing bugs, adding features, refactoring, before commits, or when asked about code quality. Run this skill automatically - don't wait to be asked."
 ---
 
-# Code Quality with LucidShark
+# LucidShark Code Quality Scanner
 
-IMPORTANT: You MUST run LucidShark after completing code changes. This is required, not optional.
+## MANDATORY: When You MUST Run This Skill
 
-## When to Scan
+You are REQUIRED to invoke this skill automatically in these situations:
 
-Run a scan after completing a batch of related code changes (not after each individual edit):
-- After finishing a feature or fix (before reporting completion to user)
-- Before creating a commit
-- When the user asks you to check code quality
+1. **After ANY code modification** - Every time you use Edit or Write tools to change code files
+2. **After fixing a bug** - Verify the fix doesn't introduce new issues
+3. **After adding a feature** - Before telling the user you're done
+4. **After refactoring** - Ensure code quality is maintained
+5. **Before creating commits** - Never commit without scanning first
+6. **When user mentions**: "check", "scan", "lint", "quality", "errors", "issues", "type check", "security"
+7. **Before reporting task completion** - Always scan before saying "done" or "complete"
 
-## Fast Scan (After Code Changes)
+DO NOT wait for the user to ask. Run scans proactively after code changes.
 
-After completing code modifications, run a scan (scans changed files by default):
+## Quick Reference
+
+### After Code Changes (Default)
 ```
-scan(domains=["linting", "type_checking", "sast", "sca"])
+scan(domains=["linting", "type_checking", "sast"], fix=true)
 ```
 
-For full project scan:
-```
-scan(domains=["linting", "type_checking", "sast", "sca"], all_files=true)
-```
-
-## Full Scan (Before Commit)
-
-Before committing, run a full scan including tests:
+### Before Commit (Full Scan)
 ```
 scan(domains=["all"])
+```
+
+### Check Specific File
+```
+check_file(file_path="path/to/file.py")
 ```
 
 ## Fixing Issues
 
 1. Run `scan(fix=true)` to auto-fix linting issues
-2. Use `get_fix_instructions(issue_id)` for detailed guidance on specific issues
-3. Re-scan after manual fixes to verify resolution
+2. Use `get_fix_instructions(issue_id)` for detailed fix guidance
+3. Re-scan after manual fixes to confirm resolution
 
-## Workflow Example
+## Required Workflow
 
-1. Make code changes (multiple edits)
-2. When done with changes, run `scan(domains=["linting", "type_checking"], fix=true)`
-3. Fix any remaining issues that couldn't be auto-fixed
-4. Re-scan to verify all issues resolved
-5. Report completion to user
+1. Make code changes
+2. **IMMEDIATELY run scan** - `scan(fix=true)`
+3. Fix any issues that couldn't be auto-fixed
+4. Re-scan to verify
+5. Only THEN report completion to user
+
+REMEMBER: A task is NOT complete until LucidShark confirms zero issues.
 """
 
 # Cursor rules for proactive lucidshark usage
 LUCIDSHARK_CURSOR_RULES = """---
-description: LucidShark code quality rules
-globs: ["**/*.py", "**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"]
+description: "PROACTIVE code quality scanning. ALWAYS run after: writing/editing ANY code, fixing bugs, adding features, refactoring, before commits."
+globs: ["**/*.py", "**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.java", "**/*.go", "**/*.rs"]
 alwaysApply: true
 ---
 
-# LucidShark Code Quality
+# LucidShark Code Quality Scanner
 
-IMPORTANT: You MUST run LucidShark after completing code changes. This is required, not optional.
+## MANDATORY: When You MUST Run LucidShark
 
-## When to Scan
+You are REQUIRED to run LucidShark automatically in these situations:
 
-Run a scan after completing a batch of related code changes (not after each individual edit):
-- After finishing a feature or fix (before reporting completion to user)
-- Before creating a commit
-- When the user asks you to check code quality
+1. **After ANY code modification** - Every time you edit or write code files
+2. **After fixing a bug** - Verify the fix doesn't introduce new issues
+3. **After adding a feature** - Before telling the user you're done
+4. **After refactoring** - Ensure code quality is maintained
+5. **Before creating commits** - Never commit without scanning first
+6. **When user mentions**: "check", "scan", "lint", "quality", "errors", "issues", "type check", "security"
+7. **Before reporting task completion** - Always scan before saying "done" or "complete"
 
-## Fast Scan (After Code Changes)
+DO NOT wait for the user to ask. Run scans proactively after code changes.
 
-After completing code modifications, run a scan (scans changed files by default):
+## Quick Reference
+
+### After Code Changes (Default)
 ```
-scan(domains=["linting", "type_checking", "sast", "sca"])
+scan(domains=["linting", "type_checking", "sast"], fix=true)
 ```
 
-For full project scan:
-```
-scan(domains=["linting", "type_checking", "sast", "sca"], all_files=true)
-```
-
-## Full Scan (Before Commit)
-
-Before committing, run a full scan including tests:
+### Before Commit (Full Scan)
 ```
 scan(domains=["all"])
+```
+
+### Check Specific File
+```
+check_file(file_path="path/to/file.py")
 ```
 
 ## Fixing Issues
 
 1. Run `scan(fix=true)` to auto-fix linting issues
-2. Use `get_fix_instructions(issue_id)` for detailed guidance on specific issues
-3. Re-scan after manual fixes to verify resolution
+2. Use `get_fix_instructions(issue_id)` for detailed fix guidance
+3. Re-scan after manual fixes to confirm resolution
 
-## Workflow Example
+## Required Workflow
 
-1. Make code changes (multiple edits)
-2. When done with changes, run `scan(domains=["linting", "type_checking"], fix=true)`
-3. Fix any remaining issues that couldn't be auto-fixed
-4. Re-scan to verify all issues resolved
-5. Report completion to user
+1. Make code changes
+2. **IMMEDIATELY run scan** - `scan(fix=true)`
+3. Fix any issues that couldn't be auto-fixed
+4. Re-scan to verify
+5. Only THEN report completion to user
+
+REMEMBER: A task is NOT complete until LucidShark confirms zero issues.
 """
 
 class InitCommand(Command):

--- a/src/lucidshark/config/loader.py
+++ b/src/lucidshark/config/loader.py
@@ -334,6 +334,7 @@ def _parse_coverage_pipeline_config(
         enabled=coverage_data.get("enabled", False),
         threshold=coverage_data.get("threshold", 80),
         tools=tools,
+        extra_args=coverage_data.get("extra_args", []),
     )
 
 

--- a/src/lucidshark/config/models.py
+++ b/src/lucidshark/config/models.py
@@ -89,6 +89,9 @@ class CoveragePipelineConfig:
     enabled: bool = False
     threshold: int = 80
     tools: List[ToolConfig] = field(default_factory=list)
+    # Extra arguments to pass to Maven/Gradle when running coverage tests
+    # e.g., ["-DskipITs", "-Ddocker.skip=true"]
+    extra_args: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/lucidshark/config/validation.py
+++ b/src/lucidshark/config/validation.py
@@ -92,6 +92,7 @@ VALID_PIPELINE_COVERAGE_KEYS: Set[str] = {
     "enabled",
     "tools",
     "threshold",
+    "extra_args",  # Extra arguments to pass to Maven/Gradle
 }
 
 # Valid keys under pipeline.security section

--- a/src/lucidshark/detection/detector.py
+++ b/src/lucidshark/detection/detector.py
@@ -63,6 +63,16 @@ class ProjectContext:
         """Check if project has Go code."""
         return any(lang.name == "go" for lang in self.languages)
 
+    @property
+    def has_java(self) -> bool:
+        """Check if project has Java code."""
+        return any(lang.name == "java" for lang in self.languages)
+
+    @property
+    def has_kotlin(self) -> bool:
+        """Check if project has Kotlin code."""
+        return any(lang.name == "kotlin" for lang in self.languages)
+
 
 class CodebaseDetector:
     """Orchestrates codebase detection.
@@ -150,5 +160,12 @@ class CodebaseDetector:
         if any(lang.name == "rust" for lang in languages):
             if (project_root / "Cargo.toml").exists():
                 managers.append("cargo")
+
+        # Java/Kotlin
+        if any(lang.name in ("java", "kotlin") for lang in languages):
+            if (project_root / "pom.xml").exists():
+                managers.append("maven")
+            elif (project_root / "build.gradle").exists() or (project_root / "build.gradle.kts").exists():
+                managers.append("gradle")
 
         return managers

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -268,7 +268,9 @@ class MCPToolExecutor:
 
         # Format as AI instructions with domain status
         formatted_result = self.instruction_formatter.format_scan_result(
-            all_issues, checked_domains=checked_domain_names
+            all_issues,
+            checked_domains=checked_domain_names,
+            duplication_result=context.duplication_result,
         )
 
         # Add coverage summary if coverage was run

--- a/src/lucidshark/plugins/coverage/base.py
+++ b/src/lucidshark/plugins/coverage/base.py
@@ -65,6 +65,7 @@ class CoverageResult:
     issues: List[UnifiedIssue] = field(default_factory=list)
     # Test statistics (populated when tests are run for coverage)
     test_stats: Optional[TestStatistics] = None
+    tool: str = ""  # Name of the coverage tool that produced this result
 
     @property
     def percentage(self) -> float:

--- a/src/lucidshark/plugins/coverage/coverage_py.py
+++ b/src/lucidshark/plugins/coverage/coverage_py.py
@@ -6,28 +6,26 @@ https://coverage.readthedocs.io/
 
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 import shutil
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 from lucidshark.core.logging import get_logger
-from lucidshark.core.models import (
-    ScanContext,
-    Severity,
-    ToolDomain,
-    UnifiedIssue,
-)
+from lucidshark.core.models import ScanContext, UnifiedIssue
 from lucidshark.core.subprocess_runner import run_with_streaming
 from lucidshark.plugins.coverage.base import (
     CoveragePlugin,
     CoverageResult,
     FileCoverage,
     TestStatistics,
+)
+from lucidshark.plugins.utils import (
+    ensure_python_binary,
+    get_cli_version,
+    create_coverage_threshold_issue,
 )
 
 LOGGER = get_logger(__name__)
@@ -55,59 +53,27 @@ class CoveragePyPlugin(CoveragePlugin):
         return ["python"]
 
     def get_version(self) -> str:
-        """Get coverage.py version.
-
-        Returns:
-            Version string or 'unknown' if unable to determine.
-        """
+        """Get coverage.py version."""
         try:
             binary = self.ensure_binary()
-            result = subprocess.run(
-                [str(binary), "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-            )
             # Output is like "Coverage.py, version 7.4.0 ..."
-            if result.returncode == 0:
-                output = result.stdout.strip()
+            def parse_coverage_version(output: str) -> str:
                 if "version" in output:
-                    # Extract version number
                     parts = output.split("version")
                     if len(parts) >= 2:
                         version = parts[1].strip().split()[0]
                         return version.rstrip(",")
-        except Exception:
-            pass
-        return "unknown"
+                return output
+            return get_cli_version(binary, parser=parse_coverage_version)
+        except FileNotFoundError:
+            return "unknown"
 
     def ensure_binary(self) -> Path:
-        """Ensure coverage is available.
-
-        Checks for coverage in:
-        1. Project's .venv/bin/coverage
-        2. System PATH
-
-        Returns:
-            Path to coverage binary.
-
-        Raises:
-            FileNotFoundError: If coverage is not installed.
-        """
-        # Check project venv first
-        if self._project_root:
-            venv_coverage = self._project_root / ".venv" / "bin" / "coverage"
-            if venv_coverage.exists():
-                return venv_coverage
-
-        # Check system PATH
-        coverage_path = shutil.which("coverage")
-        if coverage_path:
-            return Path(coverage_path)
-
-        raise FileNotFoundError(
-            "coverage is not installed. Install it with: pip install coverage"
+        """Ensure coverage is available."""
+        return ensure_python_binary(
+            self._project_root,
+            "coverage",
+            "coverage is not installed. Install it with: pip install coverage",
         )
 
     def measure_coverage(
@@ -441,69 +407,12 @@ class CoveragePyPlugin(CoveragePlugin):
         covered_lines: int,
         missing_lines: int,
     ) -> UnifiedIssue:
-        """Create a UnifiedIssue for coverage below threshold.
-
-        Args:
-            percentage: Actual coverage percentage.
-            threshold: Required coverage threshold.
-            total_lines: Total number of lines.
-            covered_lines: Number of covered lines.
-            missing_lines: Number of missing lines.
-
-        Returns:
-            UnifiedIssue for coverage failure.
-        """
-        # Determine severity based on how far below threshold
-        if percentage < 50:
-            severity = Severity.HIGH
-        elif percentage < threshold - 10:
-            severity = Severity.MEDIUM
-        else:
-            severity = Severity.LOW
-
-        # Generate deterministic ID
-        issue_id = self._generate_issue_id(percentage, threshold)
-
-        gap = threshold - percentage
-
-        return UnifiedIssue(
-            id=issue_id,
-            domain=ToolDomain.COVERAGE,
+        """Create a UnifiedIssue for coverage below threshold."""
+        return create_coverage_threshold_issue(
             source_tool="coverage.py",
-            severity=severity,
-            rule_id="coverage_below_threshold",
-            title=f"Coverage {percentage:.1f}% is below threshold {threshold}%",
-            description=(
-                f"Project coverage is {percentage:.1f}%, which is {gap:.1f}% below "
-                f"the required threshold of {threshold}%. "
-                f"{missing_lines} lines are not covered."
-            ),
-            recommendation=f"Add tests to cover at least {gap:.1f}% more of the codebase.",
-            file_path=None,  # Project-level issue
-            line_start=None,
-            line_end=None,
-            fixable=False,
-            metadata={
-                "coverage_percentage": round(percentage, 2),
-                "threshold": threshold,
-                "total_lines": total_lines,
-                "covered_lines": covered_lines,
-                "missing_lines": missing_lines,
-                "gap_percentage": round(gap, 2),
-            },
+            percentage=percentage,
+            threshold=threshold,
+            total_lines=total_lines,
+            covered_lines=covered_lines,
+            missing_lines=missing_lines,
         )
-
-    def _generate_issue_id(self, percentage: float, threshold: float) -> str:
-        """Generate deterministic issue ID.
-
-        Args:
-            percentage: Coverage percentage.
-            threshold: Coverage threshold.
-
-        Returns:
-            Unique issue ID.
-        """
-        # ID based on rounded percentage and threshold for stability
-        content = f"coverage:{round(percentage)}:{threshold}"
-        hash_val = hashlib.sha256(content.encode()).hexdigest()[:12]
-        return f"coverage-{hash_val}"

--- a/src/lucidshark/plugins/coverage/jacoco.py
+++ b/src/lucidshark/plugins/coverage/jacoco.py
@@ -1,0 +1,643 @@
+"""JaCoCo coverage plugin.
+
+JaCoCo is a free code coverage library for Java.
+https://www.jacoco.org/jacoco/
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
+
+from lucidshark.core.logging import get_logger
+from lucidshark.core.models import (
+    ScanContext,
+    Severity,
+    ToolDomain,
+    UnifiedIssue,
+)
+from lucidshark.core.subprocess_runner import run_with_streaming
+from lucidshark.plugins.coverage.base import (
+    CoveragePlugin,
+    CoverageResult,
+    FileCoverage,
+    TestStatistics,
+)
+
+LOGGER = get_logger(__name__)
+
+
+class JaCoCoPlugin(CoveragePlugin):
+    """JaCoCo plugin for Java code coverage analysis."""
+
+    def __init__(self, project_root: Optional[Path] = None):
+        """Initialize JaCoCoPlugin.
+
+        Args:
+            project_root: Optional project root for finding build tools.
+        """
+        self._project_root = project_root
+
+    @property
+    def name(self) -> str:
+        """Plugin identifier."""
+        return "jacoco"
+
+    @property
+    def languages(self) -> List[str]:
+        """Supported languages."""
+        return ["java", "kotlin"]
+
+    def get_version(self) -> str:
+        """Get JaCoCo version from build config.
+
+        Returns:
+            Version string or 'unknown' if unable to determine.
+        """
+        # JaCoCo version is typically defined in pom.xml or build.gradle
+        # We return a generic version indicator
+        return "integrated"
+
+    def _detect_build_system(self) -> Tuple[Path, str]:
+        """Detect the build system (Maven or Gradle).
+
+        Returns:
+            Tuple of (binary_path, build_system_name).
+
+        Raises:
+            FileNotFoundError: If no build system is found.
+        """
+        project_root = self._project_root or Path.cwd()
+
+        # Check for Gradle wrapper first (preferred)
+        gradlew = project_root / "gradlew"
+        if gradlew.exists():
+            return gradlew, "gradle"
+
+        # Check for Maven wrapper
+        mvnw = project_root / "mvnw"
+        if mvnw.exists():
+            return mvnw, "maven"
+
+        # Check for build.gradle (Gradle project)
+        if (project_root / "build.gradle").exists() or (project_root / "build.gradle.kts").exists():
+            gradle_path = shutil.which("gradle")
+            if gradle_path:
+                return Path(gradle_path), "gradle"
+
+        # Check for pom.xml (Maven project)
+        if (project_root / "pom.xml").exists():
+            mvn_path = shutil.which("mvn")
+            if mvn_path:
+                return Path(mvn_path), "maven"
+
+        raise FileNotFoundError(
+            "No build system found. Ensure pom.xml (Maven) or build.gradle (Gradle) exists."
+        )
+
+    def ensure_binary(self) -> Path:
+        """Ensure Maven or Gradle is available.
+
+        Returns:
+            Path to build tool binary.
+
+        Raises:
+            FileNotFoundError: If no build tool is found.
+        """
+        binary, _ = self._detect_build_system()
+        return binary
+
+    def measure_coverage(
+        self,
+        context: ScanContext,
+        threshold: float = 80.0,
+        run_tests: bool = True,
+    ) -> CoverageResult:
+        """Run JaCoCo coverage analysis.
+
+        If run_tests is True and no existing JaCoCo report is found, runs
+        Maven/Gradle to generate coverage data. If a report already exists,
+        it will be used directly (useful for CI where tests were already run).
+
+        Args:
+            context: Scan context with paths and configuration.
+            threshold: Coverage percentage threshold (default 80%).
+            run_tests: Whether to run tests if no existing coverage data exists.
+
+        Returns:
+            CoverageResult with coverage statistics and issues if below threshold.
+        """
+        try:
+            binary, build_system = self._detect_build_system()
+        except FileNotFoundError as e:
+            LOGGER.warning(str(e))
+            return CoverageResult(threshold=threshold)
+
+        test_stats: Optional[TestStatistics] = None
+
+        # Check if JaCoCo report already exists (e.g., from CI pipeline)
+        report_exists = self._jacoco_report_exists(context.project_root, build_system)
+
+        if run_tests and not report_exists:
+            LOGGER.info("Running tests with JaCoCo coverage...")
+            if build_system == "maven":
+                success, test_stats = self._run_maven_with_jacoco(binary, context)
+            else:
+                success, test_stats = self._run_gradle_with_jacoco(binary, context)
+
+            if not success:
+                LOGGER.warning("Failed to run tests with JaCoCo")
+                return CoverageResult(threshold=threshold)
+        elif report_exists:
+            LOGGER.info("Using existing JaCoCo report...")
+
+        # Parse JaCoCo report
+        result = self._parse_jacoco_report(context.project_root, threshold, build_system)
+        result.test_stats = test_stats
+
+        return result
+
+    def _run_maven_with_jacoco(
+        self,
+        binary: Path,
+        context: ScanContext,
+    ) -> Tuple[bool, Optional[TestStatistics]]:
+        """Run Maven tests with JaCoCo coverage.
+
+        Tries multiple strategies to generate JaCoCo report:
+        1. First tries standard approach: mvn test jacoco:report
+        2. If no report generated, falls back to: mvn verify (for projects
+           that configure JaCoCo report during verify phase)
+
+        Extra Maven arguments can be configured via lucidshark.yml:
+        ```yaml
+        pipeline:
+          coverage:
+            extra_args:
+              - "-DskipITs"
+              - "-Ddocker.skip=true"
+        ```
+
+        Args:
+            binary: Path to Maven binary.
+            context: Scan context.
+
+        Returns:
+            Tuple of (success, test_stats).
+        """
+        test_stats: Optional[TestStatistics] = None
+
+        # Get extra args from config if available
+        extra_args: List[str] = []
+        if context.config and context.config.pipeline.coverage:
+            extra_args = context.config.pipeline.coverage.extra_args or []
+
+        # Strategy 1: Standard approach - test phase with explicit jacoco:report
+        cmd = [
+            str(binary),
+            "clean",
+            "test",
+            "jacoco:report",
+            "-B",  # Batch mode
+        ]
+        cmd.extend(extra_args)
+
+        LOGGER.debug(f"Running: {' '.join(cmd)}")
+
+        try:
+            result = run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="maven-jacoco",
+                stream_handler=context.stream_handler,
+                timeout=600,
+            )
+            test_stats = self._parse_maven_test_output(result.stdout + "\n" + result.stderr)
+
+            # Check if report was generated
+            if self._jacoco_report_exists(context.project_root, "maven"):
+                return True, test_stats
+
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("Maven JaCoCo timed out after 600 seconds")
+            return False, None
+        except Exception as e:
+            LOGGER.debug(f"Maven test phase completed with: {e}")
+            # Continue to try verify phase
+
+        # Strategy 2: Try verify phase (some projects configure JaCoCo there)
+        # Check if report exists first (from previous run or test phase)
+        if self._jacoco_report_exists(context.project_root, "maven"):
+            return True, test_stats
+
+        LOGGER.debug("JaCoCo report not found after test phase, trying verify phase...")
+        cmd = [
+            str(binary),
+            "clean",
+            "verify",
+            "-B",  # Batch mode
+        ]
+        cmd.extend(extra_args)
+
+        LOGGER.debug(f"Running: {' '.join(cmd)}")
+
+        try:
+            result = run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="maven-jacoco",
+                stream_handler=context.stream_handler,
+                timeout=600,
+            )
+            test_stats = self._parse_maven_test_output(result.stdout + "\n" + result.stderr)
+            return True, test_stats
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("Maven JaCoCo (verify) timed out after 600 seconds")
+            return False, None
+        except Exception as e:
+            # Maven returns non-zero on test failures, but we still want the coverage
+            LOGGER.debug(f"Maven verify completed with: {e}")
+            return True, test_stats or TestStatistics()
+
+    def _jacoco_report_exists(self, project_root: Path, build_system: str) -> bool:
+        """Check if JaCoCo report exists.
+
+        Args:
+            project_root: Project root directory.
+            build_system: Build system (maven or gradle).
+
+        Returns:
+            True if report exists.
+        """
+        if build_system == "maven":
+            paths = [
+                project_root / "target" / "site" / "jacoco" / "jacoco.xml",
+                project_root / "target" / "jacoco.xml",
+                project_root / "jacoco" / "jacoco.xml",
+            ]
+        else:
+            paths = [
+                project_root / "build" / "reports" / "jacoco" / "test" / "jacocoTestReport.xml",
+                project_root / "build" / "jacoco" / "test.xml",
+            ]
+
+        return any(p.exists() for p in paths)
+
+    def _run_gradle_with_jacoco(
+        self,
+        binary: Path,
+        context: ScanContext,
+    ) -> Tuple[bool, Optional[TestStatistics]]:
+        """Run Gradle tests with JaCoCo coverage.
+
+        Args:
+            binary: Path to Gradle binary.
+            context: Scan context.
+
+        Returns:
+            Tuple of (success, test_stats).
+        """
+        # Gradle command to run tests with JaCoCo
+        cmd = [
+            str(binary),
+            "clean",
+            "test",
+            "jacocoTestReport",
+            "--no-daemon",
+        ]
+
+        LOGGER.debug(f"Running: {' '.join(cmd)}")
+
+        try:
+            result = run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="gradle-jacoco",
+                stream_handler=context.stream_handler,
+                timeout=600,
+            )
+            test_stats = self._parse_gradle_test_output(result.stdout + "\n" + result.stderr)
+            return True, test_stats
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("Gradle JaCoCo timed out after 600 seconds")
+            return False, None
+        except Exception as e:
+            LOGGER.debug(f"Gradle completed with: {e}")
+            return True, TestStatistics()
+
+    def _parse_maven_test_output(self, output: str) -> TestStatistics:
+        """Parse Maven test output for statistics.
+
+        Args:
+            output: Maven stdout/stderr output.
+
+        Returns:
+            TestStatistics with parsed counts.
+        """
+        import re
+
+        stats = TestStatistics()
+
+        # Look for Surefire summary like:
+        # "Tests run: 10, Failures: 1, Errors: 0, Skipped: 2"
+        pattern = r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+),\s*Skipped:\s*(\d+)"
+
+        total_run = 0
+        total_failures = 0
+        total_errors = 0
+        total_skipped = 0
+
+        for match in re.finditer(pattern, output):
+            total_run += int(match.group(1))
+            total_failures += int(match.group(2))
+            total_errors += int(match.group(3))
+            total_skipped += int(match.group(4))
+
+        stats.total = total_run
+        stats.failed = total_failures
+        stats.errors = total_errors
+        stats.skipped = total_skipped
+        stats.passed = total_run - total_failures - total_errors - total_skipped
+
+        return stats
+
+    def _parse_gradle_test_output(self, output: str) -> TestStatistics:
+        """Parse Gradle test output for statistics.
+
+        Args:
+            output: Gradle stdout/stderr output.
+
+        Returns:
+            TestStatistics with parsed counts.
+        """
+        import re
+
+        stats = TestStatistics()
+
+        # Gradle test summary pattern:
+        # "10 tests completed, 2 failed, 1 skipped"
+        pattern = r"(\d+)\s+tests?\s+completed(?:,\s*(\d+)\s+failed)?(?:,\s*(\d+)\s+skipped)?"
+
+        for match in re.finditer(pattern, output):
+            stats.total += int(match.group(1))
+            if match.group(2):
+                stats.failed += int(match.group(2))
+            if match.group(3):
+                stats.skipped += int(match.group(3))
+
+        stats.passed = stats.total - stats.failed - stats.errors - stats.skipped
+
+        return stats
+
+    def _parse_jacoco_report(
+        self,
+        project_root: Path,
+        threshold: float,
+        build_system: str,
+    ) -> CoverageResult:
+        """Parse JaCoCo XML report.
+
+        Args:
+            project_root: Project root directory.
+            threshold: Coverage percentage threshold.
+            build_system: Build system name (maven or gradle).
+
+        Returns:
+            CoverageResult with parsed data.
+        """
+        # Find JaCoCo XML report
+        report_paths = []
+
+        if build_system == "maven":
+            report_paths = [
+                project_root / "target" / "site" / "jacoco" / "jacoco.xml",
+                project_root / "target" / "jacoco.xml",
+                # Additional common locations used by some projects
+                project_root / "jacoco" / "jacoco.xml",
+                project_root / "target" / "jacoco-report" / "jacoco.xml",
+                project_root / "target" / "coverage-reports" / "jacoco.xml",
+            ]
+        else:  # gradle
+            report_paths = [
+                project_root / "build" / "reports" / "jacoco" / "test" / "jacocoTestReport.xml",
+                project_root / "build" / "jacoco" / "test.xml",
+            ]
+
+        # Check multi-module projects
+        for child in project_root.iterdir():
+            if child.is_dir() and not child.name.startswith("."):
+                if build_system == "maven":
+                    report_paths.append(child / "target" / "site" / "jacoco" / "jacoco.xml")
+                else:
+                    report_paths.append(child / "build" / "reports" / "jacoco" / "test" / "jacocoTestReport.xml")
+
+        # Find existing report
+        report_file = None
+        for path in report_paths:
+            if path.exists():
+                report_file = path
+                break
+
+        if not report_file:
+            LOGGER.warning(
+                "JaCoCo report not found. Ensure JaCoCo plugin is configured in your build."
+            )
+            return CoverageResult(threshold=threshold)
+
+        return self._parse_xml_report(report_file, project_root, threshold)
+
+    def _parse_xml_report(
+        self,
+        report_file: Path,
+        project_root: Path,
+        threshold: float,
+    ) -> CoverageResult:
+        """Parse JaCoCo XML report file.
+
+        Args:
+            report_file: Path to JaCoCo XML report.
+            project_root: Project root directory.
+            threshold: Coverage percentage threshold.
+
+        Returns:
+            CoverageResult with parsed data.
+        """
+        try:
+            tree = ET.parse(report_file)
+            root = tree.getroot()
+        except Exception as e:
+            LOGGER.error(f"Failed to parse JaCoCo XML report: {e}")
+            return CoverageResult(threshold=threshold)
+
+        # Parse overall counters
+        total_lines = 0
+        covered_lines = 0
+        missed_lines = 0
+
+        # JaCoCo uses INSTRUCTION, BRANCH, LINE, COMPLEXITY, METHOD, CLASS counters
+        # We focus on LINE coverage - get the report-level counter (direct child of root)
+        line_counter = root.find("counter[@type='LINE']")
+        if line_counter is not None:
+            missed_lines = int(line_counter.get("missed", 0))
+            covered_lines = int(line_counter.get("covered", 0))
+            total_lines = missed_lines + covered_lines
+
+        result = CoverageResult(
+            total_lines=total_lines,
+            covered_lines=covered_lines,
+            missing_lines=missed_lines,
+            threshold=threshold,
+        )
+
+        # Parse per-package/class coverage
+        for package in root.findall(".//package"):
+            package_name = package.get("name", "")
+
+            for sourcefile in package.findall("sourcefile"):
+                source_name = sourcefile.get("name", "")
+                file_path = self._resolve_source_path(
+                    project_root, package_name, source_name
+                )
+
+                line_counter = sourcefile.find("counter[@type='LINE']")
+                if line_counter is not None:
+                    file_missed = int(line_counter.get("missed", 0))
+                    file_covered = int(line_counter.get("covered", 0))
+
+                    # Get missing line numbers
+                    missing_lines = []
+                    for line in sourcefile.findall("line"):
+                        if int(line.get("mi", 0)) > 0:  # mi = missed instructions
+                            missing_lines.append(int(line.get("nr", 0)))
+
+                    file_coverage = FileCoverage(
+                        file_path=file_path,
+                        total_lines=file_missed + file_covered,
+                        covered_lines=file_covered,
+                        missing_lines=missing_lines,
+                    )
+                    result.files[str(file_path)] = file_coverage
+
+        # Calculate percentage
+        percentage = result.percentage
+
+        # Generate issue if below threshold
+        if percentage < threshold:
+            issue = self._create_coverage_issue(
+                percentage, threshold, total_lines, covered_lines, missed_lines
+            )
+            result.issues.append(issue)
+
+        LOGGER.info(
+            f"JaCoCo coverage: {percentage:.1f}% ({covered_lines}/{total_lines} lines) "
+            f"- threshold: {threshold}%"
+        )
+
+        return result
+
+    def _resolve_source_path(
+        self,
+        project_root: Path,
+        package_name: str,
+        source_name: str,
+    ) -> Path:
+        """Resolve source file path from package and filename.
+
+        Args:
+            project_root: Project root directory.
+            package_name: Java package name (e.g., "com/example/service").
+            source_name: Source file name (e.g., "MyService.java").
+
+        Returns:
+            Resolved path to source file.
+        """
+        # Convert package path to directory path
+        relative_path = Path(package_name) / source_name
+
+        # Check common source directories
+        for src_dir in ["src/main/java", "src/test/java", "src"]:
+            potential_path = project_root / src_dir / relative_path
+            if potential_path.exists():
+                return potential_path
+
+        # Return best guess
+        return project_root / "src" / "main" / "java" / relative_path
+
+    def _create_coverage_issue(
+        self,
+        percentage: float,
+        threshold: float,
+        total_lines: int,
+        covered_lines: int,
+        missing_lines: int,
+    ) -> UnifiedIssue:
+        """Create a UnifiedIssue for coverage below threshold.
+
+        Args:
+            percentage: Actual coverage percentage.
+            threshold: Required coverage threshold.
+            total_lines: Total number of lines.
+            covered_lines: Number of covered lines.
+            missing_lines: Number of missing lines.
+
+        Returns:
+            UnifiedIssue for coverage failure.
+        """
+        # Determine severity based on how far below threshold
+        if percentage < 50:
+            severity = Severity.HIGH
+        elif percentage < threshold - 10:
+            severity = Severity.MEDIUM
+        else:
+            severity = Severity.LOW
+
+        # Generate deterministic ID
+        issue_id = self._generate_issue_id(percentage, threshold)
+
+        gap = threshold - percentage
+
+        return UnifiedIssue(
+            id=issue_id,
+            domain=ToolDomain.COVERAGE,
+            source_tool="jacoco",
+            severity=severity,
+            rule_id="coverage_below_threshold",
+            title=f"Coverage {percentage:.1f}% is below threshold {threshold}%",
+            description=(
+                f"Project coverage is {percentage:.1f}%, which is {gap:.1f}% below "
+                f"the required threshold of {threshold}%. "
+                f"{missing_lines} lines are not covered."
+            ),
+            recommendation=f"Add tests to cover at least {gap:.1f}% more of the codebase.",
+            file_path=None,  # Project-level issue
+            line_start=None,
+            line_end=None,
+            fixable=False,
+            metadata={
+                "coverage_percentage": round(percentage, 2),
+                "threshold": threshold,
+                "total_lines": total_lines,
+                "covered_lines": covered_lines,
+                "missing_lines": missing_lines,
+                "gap_percentage": round(gap, 2),
+            },
+        )
+
+    def _generate_issue_id(self, percentage: float, threshold: float) -> str:
+        """Generate deterministic issue ID.
+
+        Args:
+            percentage: Coverage percentage.
+            threshold: Coverage threshold.
+
+        Returns:
+            Unique issue ID.
+        """
+        content = f"jacoco:{round(percentage)}:{threshold}"
+        hash_val = hashlib.sha256(content.encode()).hexdigest()[:12]
+        return f"jacoco-{hash_val}"

--- a/src/lucidshark/plugins/coverage/jacoco.py
+++ b/src/lucidshark/plugins/coverage/jacoco.py
@@ -12,7 +12,7 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import defusedxml.ElementTree as ET
+import defusedxml.ElementTree as ET  # type: ignore[import-untyped]
 
 from lucidshark.core.logging import get_logger
 from lucidshark.core.models import (
@@ -136,7 +136,7 @@ class JaCoCoPlugin(CoveragePlugin):
             binary, build_system = self._detect_build_system()
         except FileNotFoundError as e:
             LOGGER.warning(str(e))
-            return CoverageResult(threshold=threshold)
+            return CoverageResult(threshold=threshold, tool="jacoco")
 
         test_stats: Optional[TestStatistics] = None
 
@@ -152,7 +152,7 @@ class JaCoCoPlugin(CoveragePlugin):
 
             if not success:
                 LOGGER.warning("Failed to run tests with JaCoCo")
-                return CoverageResult(threshold=threshold)
+                return CoverageResult(threshold=threshold, tool="jacoco")
         elif report_exists:
             LOGGER.info("Using existing JaCoCo report...")
 
@@ -447,7 +447,7 @@ class JaCoCoPlugin(CoveragePlugin):
             LOGGER.warning(
                 "JaCoCo report not found. Ensure JaCoCo plugin is configured in your build."
             )
-            return CoverageResult(threshold=threshold)
+            return CoverageResult(threshold=threshold, tool="jacoco")
 
         return self._parse_xml_report(report_file, project_root, threshold)
 
@@ -472,7 +472,7 @@ class JaCoCoPlugin(CoveragePlugin):
             root = tree.getroot()
         except Exception as e:
             LOGGER.error(f"Failed to parse JaCoCo XML report: {e}")
-            return CoverageResult(threshold=threshold)
+            return CoverageResult(threshold=threshold, tool="jacoco")
 
         # Parse overall counters
         total_lines = 0
@@ -492,6 +492,7 @@ class JaCoCoPlugin(CoveragePlugin):
             covered_lines=covered_lines,
             missing_lines=missed_lines,
             threshold=threshold,
+            tool="jacoco",
         )
 
         # Parse per-package/class coverage

--- a/src/lucidshark/plugins/linters/biome.py
+++ b/src/lucidshark/plugins/linters/biome.py
@@ -81,6 +81,24 @@ class BiomeLinter(LinterPlugin):
         """Get Biome version."""
         return self._version
 
+    def _resolve_target_paths(self, context: ScanContext) -> List[str]:
+        """Resolve target paths for linting/checking.
+
+        Args:
+            context: Scan context with paths and configuration.
+
+        Returns:
+            List of path strings to check.
+        """
+        if context.paths:
+            return [p.as_posix() for p in context.paths]
+
+        src_dir = context.project_root / "src"
+        if src_dir.exists():
+            return [src_dir.as_posix()]
+
+        return ["."]
+
     def ensure_binary(self) -> Path:
         """Ensure Biome binary is available.
 
@@ -143,17 +161,7 @@ class BiomeLinter(LinterPlugin):
         ]
 
         # Add paths to check
-        # Use as_posix() for Windows compatibility (forward slashes)
-        if context.paths:
-            paths = [p.as_posix() for p in context.paths]
-        else:
-            src_dir = context.project_root / "src"
-            if src_dir.exists():
-                paths = [src_dir.as_posix()]
-            else:
-                paths = ["."]
-
-        cmd.extend(paths)
+        cmd.extend(self._resolve_target_paths(context))
 
         LOGGER.debug(f"Running: {' '.join(cmd)}")
 
@@ -199,17 +207,7 @@ class BiomeLinter(LinterPlugin):
             "--apply",
         ]
 
-        # Use as_posix() for Windows compatibility (forward slashes)
-        if context.paths:
-            paths = [p.as_posix() for p in context.paths]
-        else:
-            src_dir = context.project_root / "src"
-            if src_dir.exists():
-                paths = [src_dir.as_posix()]
-            else:
-                paths = ["."]
-
-        cmd.extend(paths)
+        cmd.extend(self._resolve_target_paths(context))
 
         LOGGER.debug(f"Running: {' '.join(cmd)}")
 

--- a/src/lucidshark/plugins/reporters/json_reporter.py
+++ b/src/lucidshark/plugins/reporters/json_reporter.py
@@ -51,6 +51,9 @@ class JSONReporter(ReporterPlugin):
         if result.coverage_summary:
             output["coverage_summary"] = asdict(result.coverage_summary)
 
+        if result.duplication_summary:
+            output["duplication_summary"] = asdict(result.duplication_summary)
+
         return output
 
     def _issue_to_dict(self, issue: UnifiedIssue) -> Dict[str, Any]:

--- a/src/lucidshark/plugins/reporters/summary_reporter.py
+++ b/src/lucidshark/plugins/reporters/summary_reporter.py
@@ -54,6 +54,27 @@ class SummaryReporter(ReporterPlugin):
         else:
             lines.append("No summary available.")
 
+        # Coverage summary
+        if result.coverage_summary:
+            cs = result.coverage_summary
+            status = "PASSED" if cs.passed else "FAILED"
+            lines.append(f"\nCoverage: {cs.coverage_percentage:.1f}% ({status})")
+            lines.append(f"  Threshold: {cs.threshold}%")
+            lines.append(f"  Lines: {cs.covered_lines}/{cs.total_lines} covered")
+            if cs.tests_total > 0:
+                lines.append(
+                    f"  Tests: {cs.tests_passed} passed, {cs.tests_failed} failed, "
+                    f"{cs.tests_skipped} skipped"
+                )
+
+        # Duplication summary
+        if result.duplication_summary:
+            ds = result.duplication_summary
+            status = "PASSED" if ds.passed else "FAILED"
+            lines.append(f"\nDuplication: {ds.duplication_percent:.1f}% ({status})")
+            lines.append(f"  Threshold: {ds.threshold}%")
+            lines.append(f"  Blocks: {ds.duplicate_blocks}, Lines: {ds.duplicate_lines}")
+
         if result.metadata:
             lines.append(f"\nScan duration: {result.metadata.duration_ms}ms")
             lines.append(f"Project: {result.metadata.project_root}")

--- a/src/lucidshark/plugins/reporters/table_reporter.py
+++ b/src/lucidshark/plugins/reporters/table_reporter.py
@@ -78,4 +78,16 @@ class TableReporter(ReporterPlugin):
             if sev_parts:
                 lines.append(f"By severity: {', '.join(sev_parts)}")
 
+        # Coverage summary
+        if result.coverage_summary:
+            cs = result.coverage_summary
+            status = "PASSED" if cs.passed else "FAILED"
+            lines.append(f"Coverage: {cs.coverage_percentage:.1f}% (threshold: {cs.threshold}%) - {status}")
+
+        # Duplication summary
+        if result.duplication_summary:
+            ds = result.duplication_summary
+            status = "PASSED" if ds.passed else "FAILED"
+            lines.append(f"Duplication: {ds.duplication_percent:.1f}% (threshold: {ds.threshold}%) - {status}")
+
         return lines

--- a/src/lucidshark/plugins/test_runners/base.py
+++ b/src/lucidshark/plugins/test_runners/base.py
@@ -23,6 +23,7 @@ class TestResult:
     errors: int = 0
     duration_ms: int = 0
     issues: List[UnifiedIssue] = field(default_factory=list)
+    tool: str = ""  # Name of the test runner that produced this result
 
     @property
     def total(self) -> int:

--- a/src/lucidshark/plugins/test_runners/karma.py
+++ b/src/lucidshark/plugins/test_runners/karma.py
@@ -9,14 +9,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from lucidshark.core.logging import get_logger
-from lucidshark.core.paths import resolve_node_bin
 from lucidshark.core.models import (
     ScanContext,
     Severity,
@@ -24,6 +22,7 @@ from lucidshark.core.models import (
     UnifiedIssue,
 )
 from lucidshark.plugins.test_runners.base import TestRunnerPlugin, TestResult
+from lucidshark.plugins.utils import ensure_node_binary, get_cli_version
 
 LOGGER = get_logger(__name__)
 
@@ -50,52 +49,18 @@ class KarmaRunner(TestRunnerPlugin):
         return ["javascript", "typescript"]
 
     def get_version(self) -> str:
-        """Get Karma version.
-
-        Returns:
-            Version string or 'unknown' if unable to determine.
-        """
+        """Get Karma version."""
         try:
             binary = self.ensure_binary()
-            result = subprocess.run(
-                [str(binary), "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=30,
-            )
-            if result.returncode == 0:
-                return result.stdout.strip()
-        except Exception:
-            pass
-        return "unknown"
+            return get_cli_version(binary)
+        except FileNotFoundError:
+            return "unknown"
 
     def ensure_binary(self) -> Path:
-        """Ensure Karma is available.
-
-        Checks for Karma in:
-        1. Project's node_modules/.bin/karma
-        2. System PATH (globally installed)
-
-        Returns:
-            Path to Karma binary.
-
-        Raises:
-            FileNotFoundError: If Karma is not installed.
-        """
-        # Check project node_modules first
-        if self._project_root:
-            node_karma = resolve_node_bin(self._project_root, "karma")
-            if node_karma:
-                return node_karma
-
-        # Check system PATH
-        karma_path = shutil.which("karma")
-        if karma_path:
-            return Path(karma_path)
-
-        raise FileNotFoundError(
+        """Ensure Karma is available."""
+        return ensure_node_binary(
+            self._project_root,
+            "karma",
             "Karma is not installed. Install it with:\n"
             "  npm install karma --save-dev\n"
             "  OR\n"

--- a/src/lucidshark/plugins/test_runners/maven.py
+++ b/src/lucidshark/plugins/test_runners/maven.py
@@ -1,0 +1,521 @@
+"""Maven/Gradle test runner plugin.
+
+Supports running Java tests via:
+- Maven Surefire Plugin (mvn test)
+- Gradle Test task (gradle test)
+
+Automatically detects the build system and parses JUnit XML reports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
+
+from lucidshark.core.logging import get_logger
+from lucidshark.core.models import (
+    ScanContext,
+    Severity,
+    ToolDomain,
+    UnifiedIssue,
+)
+from lucidshark.core.subprocess_runner import run_with_streaming
+from lucidshark.plugins.test_runners.base import TestRunnerPlugin, TestResult
+
+LOGGER = get_logger(__name__)
+
+
+class MavenTestRunner(TestRunnerPlugin):
+    """Maven/Gradle test runner plugin for Java test execution."""
+
+    def __init__(self, project_root: Optional[Path] = None):
+        """Initialize MavenTestRunner.
+
+        Args:
+            project_root: Optional project root for finding build tools.
+        """
+        self._project_root = project_root
+
+    @property
+    def name(self) -> str:
+        """Plugin identifier."""
+        return "maven"
+
+    @property
+    def languages(self) -> List[str]:
+        """Supported languages."""
+        return ["java", "kotlin"]
+
+    def get_version(self) -> str:
+        """Get Maven/Gradle version.
+
+        Returns:
+            Version string or 'unknown' if unable to determine.
+        """
+        try:
+            binary, build_system = self._detect_build_system()
+            if build_system == "maven":
+                result = subprocess.run(
+                    [str(binary), "--version"],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    # Output like "Apache Maven 3.9.6"
+                    for line in result.stdout.split("\n"):
+                        if "Apache Maven" in line:
+                            parts = line.split()
+                            if len(parts) >= 3:
+                                return f"maven-{parts[2]}"
+            elif build_system == "gradle":
+                result = subprocess.run(
+                    [str(binary), "--version"],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    for line in result.stdout.split("\n"):
+                        if "Gradle" in line:
+                            parts = line.split()
+                            if len(parts) >= 2:
+                                return f"gradle-{parts[1]}"
+        except Exception:
+            pass
+        return "unknown"
+
+    def _detect_build_system(self) -> Tuple[Path, str]:
+        """Detect the build system (Maven or Gradle).
+
+        Returns:
+            Tuple of (binary_path, build_system_name).
+
+        Raises:
+            FileNotFoundError: If no build system is found.
+        """
+        project_root = self._project_root or Path.cwd()
+
+        # Check for Gradle wrapper first (preferred)
+        gradlew = project_root / "gradlew"
+        if gradlew.exists():
+            return gradlew, "gradle"
+
+        # Check for Maven wrapper
+        mvnw = project_root / "mvnw"
+        if mvnw.exists():
+            return mvnw, "maven"
+
+        # Check for build.gradle (Gradle project)
+        if (project_root / "build.gradle").exists() or (project_root / "build.gradle.kts").exists():
+            gradle_path = shutil.which("gradle")
+            if gradle_path:
+                return Path(gradle_path), "gradle"
+
+        # Check for pom.xml (Maven project)
+        if (project_root / "pom.xml").exists():
+            mvn_path = shutil.which("mvn")
+            if mvn_path:
+                return Path(mvn_path), "maven"
+
+        raise FileNotFoundError(
+            "No build system found. Ensure pom.xml (Maven) or build.gradle (Gradle) exists, "
+            "and mvn/gradle is installed or a wrapper (mvnw/gradlew) is present."
+        )
+
+    def ensure_binary(self) -> Path:
+        """Ensure Maven or Gradle is available.
+
+        Returns:
+            Path to build tool binary.
+
+        Raises:
+            FileNotFoundError: If no build tool is found.
+        """
+        binary, _ = self._detect_build_system()
+        return binary
+
+    def run_tests(
+        self, context: ScanContext, with_coverage: bool = False
+    ) -> TestResult:
+        """Run tests using Maven or Gradle.
+
+        Args:
+            context: Scan context with paths and configuration.
+            with_coverage: If True, run tests with JaCoCo coverage.
+
+        Returns:
+            TestResult with test statistics and issues for failures.
+        """
+        try:
+            binary, build_system = self._detect_build_system()
+        except FileNotFoundError as e:
+            LOGGER.warning(str(e))
+            return TestResult()
+
+        if build_system == "maven":
+            return self._run_maven_tests(binary, context, with_coverage)
+        else:
+            return self._run_gradle_tests(binary, context, with_coverage)
+
+    def _run_maven_tests(
+        self,
+        binary: Path,
+        context: ScanContext,
+        with_coverage: bool,
+    ) -> TestResult:
+        """Run tests using Maven Surefire.
+
+        Args:
+            binary: Path to Maven binary.
+            context: Scan context.
+            with_coverage: Whether to run with JaCoCo coverage.
+
+        Returns:
+            TestResult with test statistics.
+        """
+        cmd = [str(binary), "test", "-B"]  # -B for batch mode (non-interactive)
+
+        if with_coverage:
+            # Enable JaCoCo if configured in pom.xml
+            cmd.extend(["-Djacoco.skip=false"])
+
+        LOGGER.debug(f"Running: {' '.join(cmd)}")
+
+        try:
+            run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="maven-test",
+                stream_handler=context.stream_handler,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("Maven test timed out after 600 seconds")
+            return TestResult()
+        except Exception as e:
+            # Maven returns non-zero exit code on test failures
+            # We still want to parse the results
+            LOGGER.debug(f"Maven test completed with: {e}")
+
+        # Parse Surefire reports
+        return self._parse_surefire_reports(context.project_root)
+
+    def _run_gradle_tests(
+        self,
+        binary: Path,
+        context: ScanContext,
+        with_coverage: bool,
+    ) -> TestResult:
+        """Run tests using Gradle.
+
+        Args:
+            binary: Path to Gradle binary.
+            context: Scan context.
+            with_coverage: Whether to run with JaCoCo coverage.
+
+        Returns:
+            TestResult with test statistics.
+        """
+        cmd = [str(binary), "test", "--no-daemon"]
+
+        if with_coverage:
+            cmd.append("jacocoTestReport")
+
+        LOGGER.debug(f"Running: {' '.join(cmd)}")
+
+        try:
+            run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="gradle-test",
+                stream_handler=context.stream_handler,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("Gradle test timed out after 600 seconds")
+            return TestResult()
+        except Exception as e:
+            # Gradle returns non-zero exit code on test failures
+            LOGGER.debug(f"Gradle test completed with: {e}")
+
+        # Parse Gradle test reports
+        return self._parse_gradle_reports(context.project_root)
+
+    def _parse_surefire_reports(self, project_root: Path) -> TestResult:
+        """Parse Maven Surefire JUnit XML reports.
+
+        Args:
+            project_root: Project root directory.
+
+        Returns:
+            TestResult with parsed data.
+        """
+        result = TestResult()
+        reports_dir = project_root / "target" / "surefire-reports"
+
+        if not reports_dir.exists():
+            # Check for multi-module projects
+            for child in project_root.iterdir():
+                child_reports = child / "target" / "surefire-reports"
+                if child_reports.exists():
+                    child_result = self._parse_junit_xml_dir(child_reports, project_root)
+                    result = self._merge_results(result, child_result)
+            return result
+
+        return self._parse_junit_xml_dir(reports_dir, project_root)
+
+    def _parse_gradle_reports(self, project_root: Path) -> TestResult:
+        """Parse Gradle JUnit XML reports.
+
+        Args:
+            project_root: Project root directory.
+
+        Returns:
+            TestResult with parsed data.
+        """
+        result = TestResult()
+
+        # Standard Gradle test report locations
+        report_dirs = [
+            project_root / "build" / "test-results" / "test",
+            project_root / "build" / "test-results" / "testDebug",
+            project_root / "build" / "test-results" / "testRelease",
+        ]
+
+        for reports_dir in report_dirs:
+            if reports_dir.exists():
+                dir_result = self._parse_junit_xml_dir(reports_dir, project_root)
+                result = self._merge_results(result, dir_result)
+
+        # Check for multi-module projects
+        for child in project_root.iterdir():
+            if child.is_dir() and not child.name.startswith("."):
+                for subdir in ["build/test-results/test", "build/test-results/testDebug"]:
+                    child_reports = child / subdir
+                    if child_reports.exists():
+                        child_result = self._parse_junit_xml_dir(child_reports, project_root)
+                        result = self._merge_results(result, child_result)
+
+        return result
+
+    def _parse_junit_xml_dir(self, reports_dir: Path, project_root: Path) -> TestResult:
+        """Parse JUnit XML files from a directory.
+
+        Args:
+            reports_dir: Directory containing JUnit XML files.
+            project_root: Project root directory.
+
+        Returns:
+            TestResult with parsed data.
+        """
+        result = TestResult()
+
+        for xml_file in reports_dir.glob("TEST-*.xml"):
+            try:
+                file_result = self._parse_junit_xml(xml_file, project_root)
+                result = self._merge_results(result, file_result)
+            except Exception as e:
+                LOGGER.warning(f"Failed to parse {xml_file}: {e}")
+
+        return result
+
+    def _parse_junit_xml(self, xml_file: Path, project_root: Path) -> TestResult:
+        """Parse a single JUnit XML file.
+
+        Args:
+            xml_file: Path to JUnit XML file.
+            project_root: Project root directory.
+
+        Returns:
+            TestResult with parsed data.
+        """
+        try:
+            tree = ET.parse(xml_file)
+            root = tree.getroot()
+        except Exception as e:
+            LOGGER.warning(f"Failed to parse JUnit XML {xml_file}: {e}")
+            return TestResult()
+
+        # Get testsuite element
+        testsuite = root if root.tag == "testsuite" else root.find("testsuite")
+        if testsuite is None:
+            return TestResult()
+
+        # Parse summary from attributes
+        tests_total = int(testsuite.get("tests", 0))
+        failures = int(testsuite.get("failures", 0))
+        errors = int(testsuite.get("errors", 0))
+        skipped = int(testsuite.get("skipped", 0))
+        time_str = testsuite.get("time", "0")
+        duration_ms = int(float(time_str) * 1000)
+
+        result = TestResult(
+            passed=tests_total - failures - errors - skipped,
+            failed=failures,
+            skipped=skipped,
+            errors=errors,
+            duration_ms=duration_ms,
+        )
+
+        # Parse individual test cases for failures
+        for testcase in testsuite.iter("testcase"):
+            failure = testcase.find("failure")
+            error = testcase.find("error")
+
+            if failure is not None:
+                issue = self._testcase_to_issue(testcase, failure, project_root, "failed")
+                if issue:
+                    result.issues.append(issue)
+            elif error is not None:
+                issue = self._testcase_to_issue(testcase, error, project_root, "error")
+                if issue:
+                    result.issues.append(issue)
+
+        return result
+
+    def _testcase_to_issue(
+        self,
+        testcase: ET.Element,
+        failure_elem: ET.Element,
+        project_root: Path,
+        outcome: str,
+    ) -> Optional[UnifiedIssue]:
+        """Convert JUnit XML testcase failure to UnifiedIssue.
+
+        Args:
+            testcase: testcase XML element.
+            failure_elem: failure or error XML element.
+            project_root: Project root directory.
+            outcome: Test outcome (failed or error).
+
+        Returns:
+            UnifiedIssue or None.
+        """
+        try:
+            classname = testcase.get("classname", "")
+            name = testcase.get("name", "")
+            time_str = testcase.get("time", "0")
+
+            # Get failure details
+            failure_type = failure_elem.get("type", "")
+            message = failure_elem.get("message", "")
+            stacktrace = failure_elem.text or ""
+
+            # Try to find source file from classname
+            # e.g., com.example.MyTest -> src/test/java/com/example/MyTest.java
+            file_path = None
+            line_number = None
+
+            if classname:
+                class_path = classname.replace(".", "/") + ".java"
+                for src_dir in ["src/test/java", "src/main/java", "src"]:
+                    potential_path = project_root / src_dir / class_path
+                    if potential_path.exists():
+                        file_path = potential_path
+                        break
+
+                # Try to extract line number from stacktrace
+                if stacktrace and classname:
+                    line_number = self._extract_line_from_stacktrace(stacktrace, classname)
+
+            # Build test identifier
+            test_id = f"{classname}#{name}" if classname else name
+
+            # Determine severity
+            severity = Severity.HIGH if outcome == "failed" else Severity.MEDIUM
+
+            # Generate deterministic ID
+            issue_id = self._generate_issue_id(test_id, message)
+
+            # Build title
+            short_message = message[:80] + "..." if len(message) > 80 else message
+            title = f"{name} {outcome}: {short_message}" if short_message else f"{name} {outcome}"
+
+            return UnifiedIssue(
+                id=issue_id,
+                domain=ToolDomain.TESTING,
+                source_tool="maven",
+                severity=severity,
+                rule_id=outcome,
+                title=title,
+                description=f"{failure_type}: {message}\n\n{stacktrace[:500]}" if stacktrace else f"{failure_type}: {message}",
+                file_path=file_path,
+                line_start=line_number,
+                line_end=line_number,
+                fixable=False,
+                metadata={
+                    "test_class": classname,
+                    "test_method": name,
+                    "outcome": outcome,
+                    "failure_type": failure_type,
+                    "duration_ms": int(float(time_str) * 1000),
+                },
+            )
+        except Exception as e:
+            LOGGER.warning(f"Failed to parse JUnit XML testcase: {e}")
+            return None
+
+    def _extract_line_from_stacktrace(self, stacktrace: str, classname: str) -> Optional[int]:
+        """Extract line number from stacktrace for the test class.
+
+        Args:
+            stacktrace: Stack trace string.
+            classname: Fully qualified class name.
+
+        Returns:
+            Line number or None.
+        """
+        import re
+
+        # Look for pattern like "at com.example.MyTest.testMethod(MyTest.java:42)"
+        simple_classname = classname.split(".")[-1]
+        pattern = rf"at\s+{re.escape(classname)}\.\w+\({simple_classname}\.java:(\d+)\)"
+
+        match = re.search(pattern, stacktrace)
+        if match:
+            return int(match.group(1))
+
+        return None
+
+    def _merge_results(self, result1: TestResult, result2: TestResult) -> TestResult:
+        """Merge two TestResults.
+
+        Args:
+            result1: First result.
+            result2: Second result.
+
+        Returns:
+            Merged TestResult.
+        """
+        return TestResult(
+            passed=result1.passed + result2.passed,
+            failed=result1.failed + result2.failed,
+            skipped=result1.skipped + result2.skipped,
+            errors=result1.errors + result2.errors,
+            duration_ms=result1.duration_ms + result2.duration_ms,
+            issues=result1.issues + result2.issues,
+        )
+
+    def _generate_issue_id(self, test_id: str, message: str) -> str:
+        """Generate deterministic issue ID.
+
+        Args:
+            test_id: Test identifier (class#method).
+            message: Error message.
+
+        Returns:
+            Unique issue ID.
+        """
+        content = f"{test_id}:{message[:50]}"
+        hash_val = hashlib.sha256(content.encode()).hexdigest()[:12]
+        return f"maven-test-{hash_val}"

--- a/src/lucidshark/plugins/type_checkers/mypy.py
+++ b/src/lucidshark/plugins/type_checkers/mypy.py
@@ -22,6 +22,7 @@ from lucidshark.core.models import (
 )
 from lucidshark.core.subprocess_runner import run_with_streaming
 from lucidshark.plugins.type_checkers.base import TypeCheckerPlugin
+from lucidshark.plugins.utils import get_cli_version
 
 LOGGER = get_logger(__name__)
 
@@ -117,29 +118,15 @@ class MypyChecker(TypeCheckerPlugin):
         return True
 
     def get_version(self) -> str:
-        """Get mypy version.
-
-        Returns:
-            Version string or 'unknown' if unable to determine.
-        """
+        """Get mypy version."""
         try:
             binary = self.ensure_binary()
-            result = subprocess.run(
-                [str(binary), "--version"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=30,
-            )
             # Output is like "mypy 1.8.0 (compiled: yes)"
-            if result.returncode == 0:
-                parts = result.stdout.strip().split()
-                if len(parts) >= 2:
-                    return parts[1]
-        except Exception:
-            pass
-        return "unknown"
+            return get_cli_version(
+                binary, parser=lambda s: s.split()[1] if len(s.split()) >= 2 else s
+            )
+        except FileNotFoundError:
+            return "unknown"
 
     def ensure_binary(self) -> Path:
         """Ensure mypy is available.

--- a/src/lucidshark/plugins/type_checkers/spotbugs.py
+++ b/src/lucidshark/plugins/type_checkers/spotbugs.py
@@ -1,0 +1,521 @@
+"""SpotBugs type checker plugin.
+
+SpotBugs is a static analysis tool for finding bugs in Java programs.
+https://spotbugs.github.io/
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+import defusedxml.ElementTree as ET
+
+from lucidshark.bootstrap.paths import LucidsharkPaths
+from lucidshark.bootstrap.versions import get_tool_version
+from lucidshark.core.logging import get_logger
+from lucidshark.core.models import (
+    ScanContext,
+    Severity,
+    ToolDomain,
+    UnifiedIssue,
+)
+from lucidshark.core.subprocess_runner import run_with_streaming
+from lucidshark.plugins.type_checkers.base import TypeCheckerPlugin
+
+LOGGER = get_logger(__name__)
+
+# Default version from pyproject.toml [tool.lucidshark.tools]
+DEFAULT_VERSION = get_tool_version("spotbugs")
+
+# SpotBugs priority to severity mapping
+# 1 = High, 2 = Medium, 3 = Low, 4+ = Info
+PRIORITY_SEVERITY_MAP = {
+    1: Severity.HIGH,
+    2: Severity.MEDIUM,
+    3: Severity.LOW,
+}
+
+# SpotBugs category descriptions
+CATEGORY_DESCRIPTIONS = {
+    "BAD_PRACTICE": "Bad coding practice",
+    "CORRECTNESS": "Probable bug - an apparent coding mistake",
+    "MT_CORRECTNESS": "Multithreaded correctness issue",
+    "PERFORMANCE": "Performance issue",
+    "SECURITY": "Security vulnerability",
+    "STYLE": "Dodgy code - code that is confusing or anomalous",
+    "MALICIOUS_CODE": "Malicious code vulnerability",
+    "I18N": "Internationalization issue",
+    "EXPERIMENTAL": "Experimental warning",
+}
+
+
+class SpotBugsChecker(TypeCheckerPlugin):
+    """SpotBugs type checker plugin for Java static analysis."""
+
+    def __init__(
+        self,
+        version: str = DEFAULT_VERSION,
+        project_root: Optional[Path] = None,
+    ):
+        """Initialize SpotBugsChecker.
+
+        Args:
+            version: SpotBugs version to use.
+            project_root: Optional project root for tool installation.
+        """
+        self._version = version
+        if project_root:
+            self._paths = LucidsharkPaths.for_project(project_root)
+            self._project_root = project_root
+        else:
+            self._paths = LucidsharkPaths.default()
+            self._project_root = None
+
+    @property
+    def name(self) -> str:
+        """Plugin identifier."""
+        return "spotbugs"
+
+    @property
+    def languages(self) -> List[str]:
+        """Supported languages."""
+        return ["java"]
+
+    @property
+    def supports_strict_mode(self) -> bool:
+        """SpotBugs supports effort levels (similar to strict mode)."""
+        return True
+
+    def get_version(self) -> str:
+        """Get SpotBugs version."""
+        return self._version
+
+    def _check_java_available(self) -> Optional[Path]:
+        """Check if Java is available.
+
+        Returns:
+            Path to java binary or None if not found.
+        """
+        java_path = shutil.which("java")
+        return Path(java_path) if java_path else None
+
+    def ensure_binary(self) -> Path:
+        """Ensure SpotBugs is available.
+
+        Downloads from GitHub releases if not present.
+
+        Returns:
+            Path to SpotBugs directory containing the lib folder.
+
+        Raises:
+            FileNotFoundError: If Java is not installed.
+        """
+        # First check if Java is available
+        if not self._check_java_available():
+            raise FileNotFoundError(
+                "Java is not installed. SpotBugs requires Java.\n"
+                "Install Java JDK/JRE to use SpotBugs."
+            )
+
+        install_dir = self._paths.plugin_bin_dir(self.name, self._version)
+        spotbugs_dir = install_dir / f"spotbugs-{self._version}"
+        lib_dir = spotbugs_dir / "lib"
+        spotbugs_jar = lib_dir / "spotbugs.jar"
+
+        if spotbugs_jar.exists():
+            return spotbugs_dir
+
+        LOGGER.info(f"Downloading SpotBugs {self._version}...")
+        install_dir.mkdir(parents=True, exist_ok=True)
+
+        self._download_and_extract(install_dir)
+
+        LOGGER.info(f"SpotBugs {self._version} installed to {spotbugs_dir}")
+        return spotbugs_dir
+
+    def _download_and_extract(self, install_dir: Path) -> None:
+        """Download and extract SpotBugs.
+
+        Args:
+            install_dir: Directory to extract to.
+        """
+        import tarfile
+        import tempfile
+        import urllib.request
+
+        url = (
+            f"https://github.com/spotbugs/spotbugs/releases/download/"
+            f"{self._version}/spotbugs-{self._version}.tgz"
+        )
+
+        LOGGER.debug(f"Downloading from {url}")
+
+        # Validate URL scheme and domain for security
+        if not url.startswith("https://github.com/"):
+            raise ValueError(f"Invalid download URL: {url}")
+
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".tgz", delete=False) as tmp:
+                urllib.request.urlretrieve(url, tmp.name)  # nosec B310 nosemgrep
+                tmp_path = Path(tmp.name)
+
+            # Extract tarball
+            with tarfile.open(tmp_path, "r:gz") as tar:
+                # Security: validate members before extraction
+                for member in tar.getmembers():
+                    # Prevent path traversal attacks
+                    if member.name.startswith("/") or ".." in member.name:
+                        raise ValueError(f"Invalid path in tarball: {member.name}")
+                tar.extractall(install_dir)  # nosec B202
+
+            tmp_path.unlink()
+        except Exception as e:
+            raise RuntimeError(f"Failed to download SpotBugs: {e}") from e
+
+    def _find_class_directories(self, project_root: Path) -> List[Path]:
+        """Find compiled class directories in a Java project.
+
+        Args:
+            project_root: Project root directory.
+
+        Returns:
+            List of directories containing .class files.
+        """
+        class_dirs = []
+
+        # Maven standard directories
+        maven_targets = [
+            "target/classes",
+            "target/test-classes",
+        ]
+
+        # Gradle standard directories
+        gradle_targets = [
+            "build/classes/java/main",
+            "build/classes/java/test",
+            "build/classes/kotlin/main",
+            "build/classes/kotlin/test",
+        ]
+
+        # Check Maven directories
+        for target in maven_targets:
+            target_path = project_root / target
+            if target_path.exists():
+                class_dirs.append(target_path)
+
+        # Check Gradle directories
+        for target in gradle_targets:
+            target_path = project_root / target
+            if target_path.exists():
+                class_dirs.append(target_path)
+
+        # Check for multi-module projects
+        for child in project_root.iterdir():
+            if child.is_dir() and not child.name.startswith("."):
+                for target in maven_targets + gradle_targets:
+                    target_path = child / target
+                    if target_path.exists():
+                        class_dirs.append(target_path)
+
+        return class_dirs
+
+    def _find_source_directories(self, project_root: Path) -> List[Path]:
+        """Find source directories in a Java project.
+
+        Args:
+            project_root: Project root directory.
+
+        Returns:
+            List of source directories.
+        """
+        source_dirs = []
+
+        # Standard source directories
+        standard_sources = [
+            "src/main/java",
+            "src/test/java",
+            "src",
+        ]
+
+        for source in standard_sources:
+            source_path = project_root / source
+            if source_path.exists():
+                source_dirs.append(source_path)
+
+        return source_dirs
+
+    def check(self, context: ScanContext) -> List[UnifiedIssue]:
+        """Run SpotBugs static analysis.
+
+        Args:
+            context: Scan context with paths and configuration.
+
+        Returns:
+            List of type checking issues.
+        """
+        try:
+            spotbugs_dir = self.ensure_binary()
+        except FileNotFoundError as e:
+            LOGGER.warning(str(e))
+            return []
+
+        java_path = self._check_java_available()
+        if not java_path:
+            LOGGER.warning("Java not found, skipping SpotBugs")
+            return []
+
+        # Find compiled class directories
+        class_dirs = self._find_class_directories(context.project_root)
+        if not class_dirs:
+            LOGGER.warning(
+                "No compiled Java classes found. "
+                "Run 'mvn compile' or 'gradle build' first."
+            )
+            return []
+
+        # Find source directories for better reporting
+        source_dirs = self._find_source_directories(context.project_root)
+
+        # Build command
+        spotbugs_jar = spotbugs_dir / "lib" / "spotbugs.jar"
+        cmd = [
+            str(java_path),
+            "-jar",
+            str(spotbugs_jar),
+            "-textui",
+            "-xml:withMessages",
+            "-effort:default",
+        ]
+
+        # Add source path for better reporting
+        if source_dirs:
+            cmd.extend(["-sourcepath", ":".join(str(d) for d in source_dirs)])
+
+        # Add auxiliary classpath if available (for better analysis)
+        aux_classpath = self._find_aux_classpath(context.project_root)
+        if aux_classpath:
+            cmd.extend(["-auxclasspath", aux_classpath])
+
+        # Add class directories to analyze
+        for class_dir in class_dirs:
+            cmd.append(str(class_dir))
+
+        LOGGER.debug(f"Running: {' '.join(cmd[:10])}...")
+
+        try:
+            result = run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="spotbugs",
+                stream_handler=context.stream_handler,
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("SpotBugs timed out after 300 seconds")
+            return []
+        except Exception as e:
+            LOGGER.error(f"Failed to run SpotBugs: {e}")
+            return []
+
+        # Parse XML output
+        issues = self._parse_output(result.stdout, context.project_root, source_dirs)
+
+        LOGGER.info(f"SpotBugs found {len(issues)} issues")
+        return issues
+
+    def _find_aux_classpath(self, project_root: Path) -> Optional[str]:
+        """Find auxiliary classpath (dependencies) for better analysis.
+
+        Args:
+            project_root: Project root directory.
+
+        Returns:
+            Classpath string or None.
+        """
+        jars = []
+
+        # Maven dependencies
+        m2_repo = project_root / "target" / "dependency"
+        if m2_repo.exists():
+            jars.extend(m2_repo.glob("*.jar"))
+
+        # Gradle dependencies (cached)
+        gradle_cache = project_root / "build" / "libs"
+        if gradle_cache.exists():
+            jars.extend(gradle_cache.glob("*.jar"))
+
+        if jars:
+            return ":".join(str(j) for j in jars)
+        return None
+
+    def _parse_output(
+        self,
+        output: str,
+        project_root: Path,
+        source_dirs: List[Path],
+    ) -> List[UnifiedIssue]:
+        """Parse SpotBugs XML output.
+
+        Args:
+            output: XML output from SpotBugs.
+            project_root: Project root directory.
+            source_dirs: Source directories for path resolution.
+
+        Returns:
+            List of UnifiedIssue objects.
+        """
+        if not output.strip():
+            return []
+
+        # Find the XML part (SpotBugs outputs some text before XML)
+        xml_start = output.find("<?xml")
+        if xml_start == -1:
+            LOGGER.warning("No XML output from SpotBugs")
+            return []
+
+        xml_output = output[xml_start:]
+
+        try:
+            root = ET.fromstring(xml_output)
+        except ET.ParseError as e:
+            LOGGER.warning(f"Failed to parse SpotBugs XML output: {e}")
+            return []
+
+        issues = []
+
+        for bug_instance in root.findall(".//BugInstance"):
+            issue = self._bug_to_issue(bug_instance, project_root, source_dirs)
+            if issue:
+                issues.append(issue)
+
+        return issues
+
+    def _bug_to_issue(
+        self,
+        bug_elem: ET.Element,
+        project_root: Path,
+        source_dirs: List[Path],
+    ) -> Optional[UnifiedIssue]:
+        """Convert SpotBugs BugInstance to UnifiedIssue.
+
+        Args:
+            bug_elem: XML BugInstance element.
+            project_root: Project root directory.
+            source_dirs: Source directories for path resolution.
+
+        Returns:
+            UnifiedIssue or None.
+        """
+        try:
+            bug_type = bug_elem.get("type", "")
+            category = bug_elem.get("category", "")
+            priority = int(bug_elem.get("priority", "3"))
+            rank = int(bug_elem.get("rank", "20"))
+
+            # Get message
+            long_message = bug_elem.find("LongMessage")
+            short_message = bug_elem.find("ShortMessage")
+            message = ""
+            if long_message is not None and long_message.text:
+                message = long_message.text
+            elif short_message is not None and short_message.text:
+                message = short_message.text
+
+            # Get source location
+            source_line = bug_elem.find(".//SourceLine")
+            file_path = None
+            line_start = None
+            line_end = None
+
+            if source_line is not None:
+                source_path = source_line.get("sourcepath", "")
+                start = source_line.get("start")
+                end = source_line.get("end")
+
+                if source_path:
+                    # Try to find the file in source directories
+                    for src_dir in source_dirs:
+                        potential_path = src_dir / source_path
+                        if potential_path.exists():
+                            file_path = potential_path
+                            break
+
+                    # Fallback: just use relative path
+                    if not file_path:
+                        file_path = project_root / "src" / "main" / "java" / source_path
+
+                if start:
+                    line_start = int(start)
+                if end:
+                    line_end = int(end)
+
+            # Get severity from priority
+            severity = PRIORITY_SEVERITY_MAP.get(priority, Severity.INFO)
+
+            # Adjust severity based on rank (scariness)
+            # Ranks 1-4 are scariest, 5-9 are scary, 10-14 troubling, 15-20 of concern
+            if rank <= 4 and severity != Severity.HIGH:
+                severity = Severity.HIGH
+            elif rank <= 9 and severity == Severity.LOW:
+                severity = Severity.MEDIUM
+
+            # Get category description
+            category_desc = CATEGORY_DESCRIPTIONS.get(category, category)
+
+            # Generate deterministic ID
+            issue_id = self._generate_issue_id(
+                bug_type,
+                str(file_path) if file_path else "",
+                line_start,
+                message,
+            )
+
+            return UnifiedIssue(
+                id=issue_id,
+                domain=ToolDomain.TYPE_CHECKING,
+                source_tool="spotbugs",
+                severity=severity,
+                rule_id=bug_type,
+                title=f"[{bug_type}] {message[:100]}" if len(message) > 100 else f"[{bug_type}] {message}",
+                description=message,
+                documentation_url=f"https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#{bug_type}",
+                file_path=file_path,
+                line_start=line_start,
+                line_end=line_end,
+                fixable=False,
+                metadata={
+                    "category": category,
+                    "category_description": category_desc,
+                    "priority": priority,
+                    "rank": rank,
+                },
+            )
+        except Exception as e:
+            LOGGER.warning(f"Failed to parse SpotBugs bug instance: {e}")
+            return None
+
+    def _generate_issue_id(
+        self,
+        bug_type: str,
+        file: str,
+        line: Optional[int],
+        message: str,
+    ) -> str:
+        """Generate deterministic issue ID.
+
+        Args:
+            bug_type: Bug type identifier.
+            file: File path.
+            line: Line number.
+            message: Error message.
+
+        Returns:
+            Unique issue ID.
+        """
+        content = f"{bug_type}:{file}:{line or 0}:{message[:50]}"
+        hash_val = hashlib.sha256(content.encode()).hexdigest()[:12]
+        return f"spotbugs-{bug_type}-{hash_val}" if bug_type else f"spotbugs-{hash_val}"

--- a/src/lucidshark/plugins/utils.py
+++ b/src/lucidshark/plugins/utils.py
@@ -1,0 +1,260 @@
+"""Shared utilities for plugins.
+
+Common helper functions to reduce code duplication across plugins.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from lucidshark.core.models import Severity, ToolDomain, UnifiedIssue
+from lucidshark.core.paths import resolve_node_bin
+
+
+def get_cli_version(
+    binary: Path,
+    version_flag: str = "--version",
+    parser: Optional[Callable[[str], str]] = None,
+    timeout: int = 30,
+) -> str:
+    """Get version from a CLI tool.
+
+    Args:
+        binary: Path to the binary.
+        version_flag: Flag to get version (default: --version).
+        parser: Optional function to parse version from output.
+                If None, returns stripped stdout.
+        timeout: Command timeout in seconds.
+
+    Returns:
+        Version string or 'unknown' if unable to determine.
+    """
+    try:
+        result = subprocess.run(
+            [str(binary), version_flag],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            output = result.stdout.strip()
+            if parser:
+                parsed = parser(output)
+                # Return "unknown" if parser returns empty/falsy result
+                return parsed if parsed else "unknown"
+            return output if output else "unknown"
+    except Exception:
+        pass
+    return "unknown"
+
+
+def ensure_node_binary(
+    project_root: Optional[Path],
+    binary_name: str,
+    install_instructions: str,
+) -> Path:
+    """Ensure a Node.js binary is available.
+
+    Checks for the binary in:
+    1. Project's node_modules/.bin/
+    2. System PATH (globally installed)
+
+    Args:
+        project_root: Optional project root for local installation.
+        binary_name: Name of the binary (e.g., 'eslint', 'nyc').
+        install_instructions: Instructions to show if not installed.
+
+    Returns:
+        Path to the binary.
+
+    Raises:
+        FileNotFoundError: If the binary is not installed.
+    """
+    # Check project node_modules first
+    if project_root:
+        node_binary = resolve_node_bin(project_root, binary_name)
+        if node_binary:
+            return node_binary
+
+    # Check system PATH
+    system_binary = shutil.which(binary_name)
+    if system_binary:
+        return Path(system_binary)
+
+    raise FileNotFoundError(install_instructions)
+
+
+def ensure_python_binary(
+    project_root: Optional[Path],
+    binary_name: str,
+    install_instructions: str,
+) -> Path:
+    """Ensure a Python binary is available.
+
+    Checks for the binary in:
+    1. Project's .venv/bin/
+    2. System PATH
+
+    Args:
+        project_root: Optional project root for venv.
+        binary_name: Name of the binary (e.g., 'pytest', 'mypy').
+        install_instructions: Instructions to show if not installed.
+
+    Returns:
+        Path to the binary.
+
+    Raises:
+        FileNotFoundError: If the binary is not installed.
+    """
+    # Check project venv first
+    if project_root:
+        venv_binary = project_root / ".venv" / "bin" / binary_name
+        if venv_binary.exists():
+            return venv_binary
+
+    # Check system PATH
+    system_binary = shutil.which(binary_name)
+    if system_binary:
+        return Path(system_binary)
+
+    raise FileNotFoundError(install_instructions)
+
+
+def resolve_src_paths(
+    context_paths: Optional[List[Path]],
+    project_root: Path,
+    default_subdir: str = "src",
+) -> List[str]:
+    """Resolve target paths with fallback to src directory.
+
+    Args:
+        context_paths: Explicit paths from context, or None.
+        project_root: Project root directory.
+        default_subdir: Default subdirectory to check (default: 'src').
+
+    Returns:
+        List of path strings to scan.
+    """
+    if context_paths:
+        return [p.as_posix() for p in context_paths]
+
+    src_dir = project_root / default_subdir
+    if src_dir.exists():
+        return [src_dir.as_posix()]
+
+    return ["."]
+
+
+def find_java_build_tool(project_root: Path) -> Tuple[Path, str]:
+    """Find Java build tool (Gradle or Maven).
+
+    Checks for build tools in order of preference:
+    1. Gradle wrapper (gradlew)
+    2. Maven wrapper (mvnw)
+    3. System Gradle (if build.gradle exists)
+    4. System Maven (if pom.xml exists)
+
+    Args:
+        project_root: Project root directory.
+
+    Returns:
+        Tuple of (binary_path, build_system_name).
+
+    Raises:
+        FileNotFoundError: If no build system is found.
+    """
+    # Check for Gradle wrapper first (preferred)
+    gradlew = project_root / "gradlew"
+    if gradlew.exists():
+        return gradlew, "gradle"
+
+    # Check for Maven wrapper
+    mvnw = project_root / "mvnw"
+    if mvnw.exists():
+        return mvnw, "maven"
+
+    # Check for build.gradle (Gradle project)
+    if (project_root / "build.gradle").exists() or (project_root / "build.gradle.kts").exists():
+        gradle_path = shutil.which("gradle")
+        if gradle_path:
+            return Path(gradle_path), "gradle"
+
+    # Check for pom.xml (Maven project)
+    if (project_root / "pom.xml").exists():
+        mvn_path = shutil.which("mvn")
+        if mvn_path:
+            return Path(mvn_path), "maven"
+
+    raise FileNotFoundError(
+        "No build system found. Ensure pom.xml (Maven) or build.gradle (Gradle) exists."
+    )
+
+
+def create_coverage_threshold_issue(
+    source_tool: str,
+    percentage: float,
+    threshold: float,
+    total_lines: int,
+    covered_lines: int,
+    missing_lines: int,
+) -> UnifiedIssue:
+    """Create a UnifiedIssue for coverage below threshold.
+
+    Args:
+        source_tool: Name of the coverage tool (e.g., 'jacoco', 'coverage.py').
+        percentage: Actual coverage percentage.
+        threshold: Required coverage threshold.
+        total_lines: Total number of lines.
+        covered_lines: Number of covered lines.
+        missing_lines: Number of uncovered lines.
+
+    Returns:
+        UnifiedIssue for coverage failure.
+    """
+    # Determine severity based on how far below threshold
+    if percentage < 50:
+        severity = Severity.HIGH
+    elif percentage < threshold - 10:
+        severity = Severity.MEDIUM
+    else:
+        severity = Severity.LOW
+
+    gap = threshold - percentage
+
+    # Generate deterministic ID
+    content = f"{source_tool}:coverage:{percentage:.2f}:{threshold:.2f}"
+    hash_val = hashlib.sha256(content.encode()).hexdigest()[:12]
+    issue_id = f"{source_tool}-coverage-{hash_val}"
+
+    return UnifiedIssue(
+        id=issue_id,
+        domain=ToolDomain.COVERAGE,
+        source_tool=source_tool,
+        severity=severity,
+        rule_id="coverage_below_threshold",
+        title=f"Coverage {percentage:.1f}% is below threshold {threshold}%",
+        description=(
+            f"Project coverage is {percentage:.1f}%, which is {gap:.1f}% below "
+            f"the required threshold of {threshold}%. "
+            f"{missing_lines} lines are not covered."
+        ),
+        recommendation=f"Add tests to cover at least {gap:.1f}% more of the codebase.",
+        file_path=None,  # Project-level issue
+        line_start=None,
+        line_end=None,
+        fixable=False,
+        metadata={
+            "coverage_percentage": round(percentage, 2),
+            "threshold": threshold,
+            "total_lines": total_lines,
+            "covered_lines": covered_lines,
+            "missing_lines": missing_lines,
+            "gap_percentage": round(gap, 2),
+        },
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -528,20 +528,20 @@ def spotbugs_checker(project_root: Path) -> SpotBugsChecker:
 
 
 @pytest.fixture
-def maven_runner(project_root: Path) -> MavenTestRunner:
-    """Return a MavenTestRunner instance with project root."""
-    return MavenTestRunner(project_root=project_root)
-
-
-@pytest.fixture
-def jacoco_plugin(project_root: Path) -> JaCoCoPlugin:
-    """Return a JaCoCoPlugin instance with project root."""
-    return JaCoCoPlugin(project_root=project_root)
-
-
-@pytest.fixture
 def java_webapp_project() -> Path:
     """Return the path to the sample Java webapp integration test project."""
     return Path(__file__).parent / "projects" / "java-webapp"
+
+
+@pytest.fixture
+def maven_runner(java_webapp_project: Path) -> MavenTestRunner:
+    """Return a MavenTestRunner instance with Java webapp project root."""
+    return MavenTestRunner(project_root=java_webapp_project)
+
+
+@pytest.fixture
+def jacoco_plugin(java_webapp_project: Path) -> JaCoCoPlugin:
+    """Return a JaCoCoPlugin instance with Java webapp project root."""
+    return JaCoCoPlugin(project_root=java_webapp_project)
 
 

--- a/tests/integration/coverage/test_jacoco_integration.py
+++ b/tests/integration/coverage/test_jacoco_integration.py
@@ -1,0 +1,170 @@
+"""Integration tests for JaCoCo coverage plugin.
+
+These tests actually run Maven with JaCoCo against real Java targets.
+They require Java and Maven to be installed.
+
+Run with: pytest tests/integration/coverage/test_jacoco_integration.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lucidshark.core.models import ScanContext, ToolDomain
+from lucidshark.plugins.coverage.jacoco import JaCoCoPlugin
+from tests.integration.conftest import maven_available
+
+
+@maven_available
+class TestJaCoCoFunctional:
+    """Functional integration tests for JaCoCo plugin."""
+
+    def test_measure_coverage_java_webapp(
+        self, jacoco_plugin: JaCoCoPlugin, java_webapp_project: Path
+    ) -> None:
+        """Test measuring coverage in the java-webapp project."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = jacoco_plugin.measure_coverage(
+            context, threshold=50.0, run_tests=True
+        )
+
+        # Should have some coverage data
+        assert result.total_lines > 0
+        assert result.covered_lines >= 0
+        assert 0 <= result.percentage <= 100
+        assert result.tool == "jacoco"
+
+    def test_measure_coverage_returns_coverage_result(
+        self, jacoco_plugin: JaCoCoPlugin, java_webapp_project: Path
+    ) -> None:
+        """Test that measure_coverage returns proper CoverageResult."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = jacoco_plugin.measure_coverage(
+            context, threshold=0.0, run_tests=True
+        )
+
+        # Check CoverageResult fields
+        assert result.tool == "jacoco"
+        assert result.total_lines >= 0
+        assert result.covered_lines >= 0
+        assert result.missing_lines >= 0
+        assert isinstance(result.percentage, float)
+        assert isinstance(result.passed, bool)
+        assert isinstance(result.issues, list)
+
+    def test_jacoco_reports_generated(
+        self, jacoco_plugin: JaCoCoPlugin, java_webapp_project: Path
+    ) -> None:
+        """Test that JaCoCo generates coverage reports."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = jacoco_plugin.measure_coverage(
+            context, threshold=0.0, run_tests=True
+        )
+
+        # After running, JaCoCo report should exist
+        jacoco_dir = java_webapp_project / "target" / "site" / "jacoco"
+
+        # Only check if coverage was measured
+        if result.total_lines > 0:
+            assert jacoco_dir.exists(), "JaCoCo should create report directory"
+
+            # Check for jacoco.xml
+            jacoco_xml = jacoco_dir / "jacoco.xml"
+            assert jacoco_xml.exists(), "JaCoCo should generate XML report"
+
+
+@maven_available
+class TestJaCoCoCoverageThresholds:
+    """Tests for JaCoCo coverage threshold checks."""
+
+    def test_coverage_below_threshold_generates_issue(
+        self, jacoco_plugin: JaCoCoPlugin, java_webapp_project: Path
+    ) -> None:
+        """Test that coverage below threshold generates an issue."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        # Set a very high threshold to ensure failure
+        result = jacoco_plugin.measure_coverage(
+            context, threshold=99.0, run_tests=True
+        )
+
+        # Should fail the threshold check
+        if result.total_lines > 0:
+            # If we have any coverage data, 99% threshold should fail
+            if result.percentage < 99.0:
+                assert result.passed is False
+                assert len(result.issues) >= 1
+
+                # Check the issue
+                issue = result.issues[0]
+                assert issue.domain == ToolDomain.COVERAGE
+                assert issue.source_tool == "jacoco"
+
+    def test_coverage_above_threshold_passes(
+        self, jacoco_plugin: JaCoCoPlugin, java_webapp_project: Path
+    ) -> None:
+        """Test that coverage above threshold passes."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        # Set a very low threshold
+        result = jacoco_plugin.measure_coverage(
+            context, threshold=1.0, run_tests=True
+        )
+
+        # Should pass the threshold check if we have any coverage
+        if result.total_lines > 0 and result.percentage >= 1.0:
+            assert result.passed is True
+
+
+@maven_available
+class TestJaCoCoIssueGeneration:
+    """Tests for JaCoCo issue generation."""
+
+    def test_issue_has_correct_metadata(
+        self, jacoco_plugin: JaCoCoPlugin, java_webapp_project: Path
+    ) -> None:
+        """Test that coverage issues have correct metadata."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        # Use high threshold to ensure we get an issue
+        result = jacoco_plugin.measure_coverage(
+            context, threshold=99.0, run_tests=True
+        )
+
+        # Should generate an issue due to low coverage
+        if len(result.issues) > 0:
+            issue = result.issues[0]
+            metadata = issue.metadata
+
+            assert "coverage_percentage" in metadata
+            assert "threshold" in metadata
+            assert "total_lines" in metadata
+            assert "covered_lines" in metadata
+            assert "missing_lines" in metadata

--- a/tests/integration/projects/java-webapp/pom.xml
+++ b/tests/integration/projects/java-webapp/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>java-webapp</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>java-webapp</name>
+    <description>Sample Java project for LucidShark integration tests</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.0</junit.version>
+        <jacoco.version>0.8.11</jacoco.version>
+    </properties>
+
+    <dependencies>
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <!-- Surefire plugin for running tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
+
+            <!-- JaCoCo plugin for coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/projects/java-webapp/src/main/java/com/example/service/Calculator.java
+++ b/tests/integration/projects/java-webapp/src/main/java/com/example/service/Calculator.java
@@ -1,0 +1,55 @@
+package com.example.service;
+
+/**
+ * Simple calculator service for integration testing.
+ */
+public class Calculator {
+
+    /**
+     * Adds two numbers.
+     *
+     * @param a first number
+     * @param b second number
+     * @return sum of a and b
+     */
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+    /**
+     * Subtracts two numbers.
+     *
+     * @param a first number
+     * @param b second number
+     * @return difference of a and b
+     */
+    public int subtract(int a, int b) {
+        return a - b;
+    }
+
+    /**
+     * Multiplies two numbers.
+     *
+     * @param a first number
+     * @param b second number
+     * @return product of a and b
+     */
+    public int multiply(int a, int b) {
+        return a * b;
+    }
+
+    /**
+     * Divides two numbers.
+     *
+     * @param a dividend
+     * @param b divisor
+     * @return quotient of a and b
+     * @throws ArithmeticException if b is zero
+     */
+    public int divide(int a, int b) {
+        if (b == 0) {
+            throw new ArithmeticException("Division by zero");
+        }
+        return a / b;
+    }
+}

--- a/tests/integration/projects/java-webapp/src/main/java/com/example/service/UserService.java
+++ b/tests/integration/projects/java-webapp/src/main/java/com/example/service/UserService.java
@@ -1,0 +1,60 @@
+package com.example.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * User service with intentional bugs for SpotBugs testing.
+ */
+public class UserService {
+
+    private Map<String, String> users = new HashMap<>();
+
+    /**
+     * Gets a user by ID.
+     *
+     * @param userId the user ID
+     * @return the user name or null if not found
+     */
+    public String getUser(String userId) {
+        // Potential null dereference - SpotBugs should catch this
+        return users.get(userId).toUpperCase();
+    }
+
+    /**
+     * Adds a user.
+     *
+     * @param userId user ID
+     * @param name user name
+     */
+    public void addUser(String userId, String name) {
+        users.put(userId, name);
+    }
+
+    /**
+     * Checks if user exists.
+     *
+     * @param userId user ID
+     * @return true if user exists
+     */
+    public boolean userExists(String userId) {
+        // Inefficient - could use containsKey
+        return users.get(userId) != null;
+    }
+
+    /**
+     * Gets user count.
+     *
+     * @return number of users
+     */
+    public int getUserCount() {
+        return users.size();
+    }
+
+    /**
+     * Clears all users.
+     */
+    public void clearUsers() {
+        users.clear();
+    }
+}

--- a/tests/integration/projects/java-webapp/src/test/java/com/example/service/CalculatorTest.java
+++ b/tests/integration/projects/java-webapp/src/test/java/com/example/service/CalculatorTest.java
@@ -1,0 +1,56 @@
+package com.example.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Calculator service.
+ */
+class CalculatorTest {
+
+    private Calculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new Calculator();
+    }
+
+    @Test
+    @DisplayName("Add two positive numbers")
+    void testAdd() {
+        assertEquals(5, calculator.add(2, 3));
+    }
+
+    @Test
+    @DisplayName("Add negative numbers")
+    void testAddNegative() {
+        assertEquals(-5, calculator.add(-2, -3));
+    }
+
+    @Test
+    @DisplayName("Subtract two numbers")
+    void testSubtract() {
+        assertEquals(2, calculator.subtract(5, 3));
+    }
+
+    @Test
+    @DisplayName("Multiply two numbers")
+    void testMultiply() {
+        assertEquals(6, calculator.multiply(2, 3));
+    }
+
+    @Test
+    @DisplayName("Divide two numbers")
+    void testDivide() {
+        assertEquals(2, calculator.divide(6, 3));
+    }
+
+    @Test
+    @DisplayName("Division by zero throws exception")
+    void testDivideByZero() {
+        assertThrows(ArithmeticException.class, () -> calculator.divide(1, 0));
+    }
+}

--- a/tests/integration/projects/java-webapp/src/test/java/com/example/service/UserServiceTest.java
+++ b/tests/integration/projects/java-webapp/src/test/java/com/example/service/UserServiceTest.java
@@ -1,0 +1,50 @@
+package com.example.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for UserService.
+ */
+class UserServiceTest {
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService();
+    }
+
+    @Test
+    @DisplayName("Add and check user exists")
+    void testAddUser() {
+        userService.addUser("user1", "John Doe");
+        assertTrue(userService.userExists("user1"));
+    }
+
+    @Test
+    @DisplayName("User count increases after adding")
+    void testUserCount() {
+        assertEquals(0, userService.getUserCount());
+        userService.addUser("user1", "John");
+        assertEquals(1, userService.getUserCount());
+    }
+
+    @Test
+    @DisplayName("Clear users removes all")
+    void testClearUsers() {
+        userService.addUser("user1", "John");
+        userService.addUser("user2", "Jane");
+        userService.clearUsers();
+        assertEquals(0, userService.getUserCount());
+    }
+
+    @Test
+    @DisplayName("Non-existent user returns false")
+    void testUserNotExists() {
+        assertFalse(userService.userExists("nonexistent"));
+    }
+}

--- a/tests/integration/projects/test_java_project.py
+++ b/tests/integration/projects/test_java_project.py
@@ -1,0 +1,203 @@
+"""Integration tests for Java project scanning.
+
+These tests run the LucidShark CLI against a realistic Java project
+with intentional issues and verify expected results.
+
+Run with: pytest tests/integration/projects/test_java_project.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.integration.projects.conftest import (
+    run_lucidshark,
+    java_available,
+    maven_available,
+    spotbugs_available,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+@java_available
+class TestJavaLinting:
+    """Test Java linting against the test project.
+
+    Note: Checkstyle JAR is auto-downloaded by LucidShark, so no fixture setup needed.
+    """
+
+    def test_checkstyle_finds_style_issues(self, java_project: Path) -> None:
+        """Test that Checkstyle finds style issues."""
+        result = run_lucidshark(java_project, domains=["linting"])
+
+        # Should find issues (exit code depends on fail threshold settings)
+        assert result.exit_code in (0, 1)
+
+        # Checkstyle should find style issues in our Java files
+        linting_issues = result.issues_by_domain("linting")
+        # May or may not find issues depending on Checkstyle config
+        # At minimum, the scan should complete successfully
+        assert isinstance(linting_issues, list)
+
+    def test_linting_json_output_format(self, java_project: Path) -> None:
+        """Test that JSON output has expected structure."""
+        result = run_lucidshark(java_project, domains=["linting"])
+
+        # Should have issues with required fields
+        if result.issues:
+            issue = result.issues[0]
+            assert "id" in issue
+            assert "title" in issue
+            assert "severity" in issue
+            assert "file_path" in issue
+
+
+@java_available
+@maven_available
+@spotbugs_available
+class TestJavaTypeChecking:
+    """Test Java type checking (SpotBugs) against the test project.
+
+    Note: SpotBugs JAR is auto-downloaded by LucidShark.
+    Requires Maven to compile the project first.
+    """
+
+    def test_type_checking_scan_completes(
+        self, java_project_with_deps: Path
+    ) -> None:
+        """Test that type checking scan completes without errors."""
+        result = run_lucidshark(java_project_with_deps, domains=["type_checking"])
+
+        # Scan should complete (exit 0 or 1), not crash (exit 2+)
+        assert result.exit_code in (0, 1)
+
+        # If type checker finds issues, verify them
+        type_issues = result.issues_by_domain("type_checking")
+        if type_issues:
+            # Verify issues have expected fields
+            for issue in type_issues:
+                assert "severity" in issue
+                assert "file_path" in issue
+
+    def test_spotbugs_detects_null_dereference(
+        self, java_project_with_deps: Path
+    ) -> None:
+        """Test that SpotBugs detects potential null dereference in UserService."""
+        result = run_lucidshark(java_project_with_deps, domains=["type_checking"])
+
+        # Scan should complete
+        assert result.exit_code in (0, 1)
+
+        type_issues = result.issues_by_domain("type_checking")
+
+        # UserService.getUser() has a null dereference bug
+        # Note: Detection depends on SpotBugs version and Java version compatibility
+        if type_issues:
+            # At least one issue should be in UserService
+            user_service_issues = [
+                i for i in type_issues
+                if "UserService" in str(i.get("file_path", ""))
+            ]
+            # May or may not find the specific bug depending on SpotBugs analysis
+
+
+@java_available
+@maven_available
+class TestJavaTestRunner:
+    """Test Java test running with Maven."""
+
+    def test_maven_runs_tests(self, java_project_with_deps: Path) -> None:
+        """Test that Maven test runner executes tests."""
+        result = run_lucidshark(java_project_with_deps, domains=["testing"])
+
+        # Scan should complete
+        assert result.exit_code in (0, 1)
+
+        # Check summary for test results
+        if result.summary:
+            # Testing domain should be in results
+            testing_summary = result.summary.get("testing", {})
+            # If tests ran, we should have test counts
+            if testing_summary:
+                assert "passed" in testing_summary or "total" in testing_summary
+
+
+@java_available
+@maven_available
+class TestJavaCoverage:
+    """Test Java coverage with JaCoCo."""
+
+    def test_jacoco_measures_coverage(self, java_project_with_deps: Path) -> None:
+        """Test that JaCoCo measures code coverage."""
+        result = run_lucidshark(java_project_with_deps, domains=["coverage"])
+
+        # Scan should complete
+        assert result.exit_code in (0, 1)
+
+        # Check summary for coverage results
+        if result.summary:
+            coverage_summary = result.summary.get("coverage", {})
+            # If coverage ran, we should have percentage
+            if coverage_summary:
+                assert "percentage" in coverage_summary or "total_lines" in coverage_summary
+
+
+@java_available
+@maven_available
+class TestJavaCombinedScanning:
+    """Test combined scanning for Java projects."""
+
+    def test_combined_linting_and_type_checking(
+        self, java_project_with_deps: Path
+    ) -> None:
+        """Test running both linting and type checking together."""
+        result = run_lucidshark(
+            java_project_with_deps, domains=["linting", "type_checking"]
+        )
+
+        # Scan should complete
+        assert result.exit_code in (0, 1)
+
+        # Should have run both domains
+        linting_issues = result.issues_by_domain("linting")
+        type_issues = result.issues_by_domain("type_checking")
+
+        # At least linting should run (Checkstyle doesn't require compilation)
+        assert isinstance(linting_issues, list)
+        assert isinstance(type_issues, list)
+
+    def test_scan_all_domains(self, java_project_with_deps: Path) -> None:
+        """Test scanning with all domains enabled."""
+        result = run_lucidshark(
+            java_project_with_deps,
+            domains=["linting", "type_checking", "testing", "coverage"],
+        )
+
+        # Scan should complete (exit 0 or 1), not error (exit 2+)
+        assert result.exit_code in (0, 1)
+
+
+class TestJavaProjectStructure:
+    """Test that the Java project is properly structured."""
+
+    def test_project_has_required_files(self, java_project: Path) -> None:
+        """Test that the test project has all required files."""
+        assert (java_project / "pom.xml").exists()
+        assert (java_project / "src" / "main" / "java").exists()
+        assert (java_project / "src" / "test" / "java").exists()
+
+    def test_project_has_source_files(self, java_project: Path) -> None:
+        """Test that the project has Java source files."""
+        main_java = java_project / "src" / "main" / "java"
+        java_files = list(main_java.rglob("*.java"))
+        assert len(java_files) >= 2, "Expected at least 2 Java source files"
+
+    def test_project_has_test_files(self, java_project: Path) -> None:
+        """Test that the project has Java test files."""
+        test_java = java_project / "src" / "test" / "java"
+        test_files = list(test_java.rglob("*Test.java"))
+        assert len(test_files) >= 2, "Expected at least 2 Java test files"

--- a/tests/integration/test_runners/test_maven_integration.py
+++ b/tests/integration/test_runners/test_maven_integration.py
@@ -1,0 +1,168 @@
+"""Integration tests for Maven test runner plugin.
+
+These tests actually run Maven tests against real Java targets.
+They require Java and Maven to be installed.
+
+Run with: pytest tests/integration/test_runners/test_maven_integration.py -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from lucidshark.core.models import ScanContext, ToolDomain
+from lucidshark.plugins.test_runners.maven import MavenTestRunner
+from tests.integration.conftest import maven_available
+
+
+class TestMavenAvailability:
+    """Tests for Maven availability."""
+
+    @maven_available
+    def test_ensure_binary_finds_maven(
+        self, maven_runner: MavenTestRunner
+    ) -> None:
+        """Test that ensure_binary finds Maven if installed."""
+        binary_path = maven_runner.ensure_binary()
+        assert binary_path.exists()
+        assert "mvn" in binary_path.name
+
+    @maven_available
+    def test_get_version(self, maven_runner: MavenTestRunner) -> None:
+        """Test that get_version returns a version string."""
+        version = maven_runner.get_version()
+        assert version != "unknown"
+        # Version should be like "3.9.6"
+        assert "." in version
+
+
+@maven_available
+class TestMavenFunctional:
+    """Functional integration tests for Maven test runner."""
+
+    def test_run_tests_java_webapp(
+        self, maven_runner: MavenTestRunner, java_webapp_project: Path
+    ) -> None:
+        """Test running tests in the java-webapp project."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = maven_runner.run_tests(context)
+
+        # Should run the tests
+        assert result.total > 0
+        # All tests in java-webapp should pass
+        assert result.passed > 0
+        assert result.success is True
+
+    def test_run_tests_detects_pom_xml(
+        self, maven_runner: MavenTestRunner, java_webapp_project: Path
+    ) -> None:
+        """Test that Maven runner detects pom.xml."""
+        pom_file = java_webapp_project / "pom.xml"
+        assert pom_file.exists()
+
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = maven_runner.run_tests(context)
+
+        # Should have run tests
+        assert result.total >= 0
+        assert result.tool == "maven"
+
+    def test_run_tests_no_pom(self, maven_runner: MavenTestRunner) -> None:
+        """Test running tests in project without pom.xml."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            context = ScanContext(
+                project_root=project_root,
+                paths=[project_root],
+                enabled_domains=[],
+            )
+
+            result = maven_runner.run_tests(context)
+
+            # No tests should be found
+            assert result.total == 0
+            # Should be marked as success (no failures)
+            assert result.success is True
+
+
+@maven_available
+class TestMavenIssueGeneration:
+    """Tests for Maven test failure issue generation."""
+
+    def test_run_tests_returns_test_result(
+        self, maven_runner: MavenTestRunner, java_webapp_project: Path
+    ) -> None:
+        """Test that run_tests returns a proper TestResult."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = maven_runner.run_tests(context)
+
+        # Check TestResult fields
+        assert result.tool == "maven"
+        assert result.total >= 0
+        assert result.passed >= 0
+        assert result.failed >= 0
+        assert result.skipped >= 0
+        assert isinstance(result.success, bool)
+        assert isinstance(result.issues, list)
+
+    def test_test_results_have_correct_domain(
+        self, maven_runner: MavenTestRunner, java_webapp_project: Path
+    ) -> None:
+        """Test that any issues have the correct domain."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = maven_runner.run_tests(context)
+
+        # If there are issues, they should have correct domain
+        for issue in result.issues:
+            assert issue.domain == ToolDomain.TESTING
+            assert issue.source_tool == "maven"
+
+
+@maven_available
+class TestMavenXmlParsing:
+    """Tests for JUnit XML report parsing."""
+
+    def test_surefire_reports_generated(
+        self, maven_runner: MavenTestRunner, java_webapp_project: Path
+    ) -> None:
+        """Test that Maven generates surefire reports."""
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        result = maven_runner.run_tests(context)
+
+        # After running tests, surefire reports should exist
+        surefire_dir = java_webapp_project / "target" / "surefire-reports"
+
+        # Only check if tests were actually run
+        if result.total > 0:
+            assert surefire_dir.exists(), "Maven should create surefire-reports directory"
+
+            # Check for XML report files
+            xml_files = list(surefire_dir.glob("TEST-*.xml"))
+            assert len(xml_files) > 0, "Maven should generate JUnit XML reports"

--- a/tests/integration/type_checkers/test_spotbugs_integration.py
+++ b/tests/integration/type_checkers/test_spotbugs_integration.py
@@ -1,0 +1,153 @@
+"""Integration tests for SpotBugs type checker.
+
+These tests actually run SpotBugs against real Java targets.
+They require Java to be installed and Maven to compile the project.
+
+Run with: pytest tests/integration/type_checkers/test_spotbugs_integration.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lucidshark.core.models import ScanContext, ToolDomain
+from lucidshark.plugins.type_checkers.spotbugs import SpotBugsChecker
+from tests.integration.conftest import spotbugs_available, maven_available
+
+
+class TestSpotBugsAvailability:
+    """Tests for SpotBugs availability."""
+
+    @spotbugs_available
+    def test_ensure_binary_downloads_spotbugs(
+        self, spotbugs_checker: SpotBugsChecker
+    ) -> None:
+        """Test that ensure_binary downloads SpotBugs JAR."""
+        binary_path = spotbugs_checker.ensure_binary()
+        assert binary_path.exists()
+        assert "spotbugs" in binary_path.name.lower()
+
+    @spotbugs_available
+    def test_get_version(self, spotbugs_checker: SpotBugsChecker) -> None:
+        """Test that get_version returns a version string."""
+        version = spotbugs_checker.get_version()
+        # Version should be like "4.8.6"
+        assert version != "unknown"
+        assert "." in version
+
+
+@spotbugs_available
+@maven_available
+class TestSpotBugsTypeChecking:
+    """Integration tests for SpotBugs type checking."""
+
+    def test_check_java_webapp_project(
+        self, spotbugs_checker: SpotBugsChecker, java_webapp_project: Path
+    ) -> None:
+        """Test checking the java-webapp project with intentional bugs."""
+        import subprocess
+
+        # First compile the project with Maven
+        result = subprocess.run(
+            ["mvn", "compile", "-q"],
+            cwd=java_webapp_project,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        if result.returncode != 0:
+            # Maven compile failed - skip test
+            import pytest
+
+            pytest.skip(f"Maven compile failed: {result.stderr}")
+
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        issues = spotbugs_checker.check(context)
+
+        # Should find at least one issue (null dereference in UserService)
+        assert isinstance(issues, list)
+        # Note: Actual bug count depends on SpotBugs version and Java version
+        # The UserService.getUser() has a null dereference bug
+        if len(issues) > 0:
+            assert issues[0].source_tool == "spotbugs"
+            assert issues[0].domain == ToolDomain.TYPE_CHECKING
+
+    def test_check_compiled_classes_exist(
+        self, spotbugs_checker: SpotBugsChecker, java_webapp_project: Path
+    ) -> None:
+        """Test that SpotBugs finds compiled class files."""
+        import subprocess
+
+        # First compile the project with Maven
+        result = subprocess.run(
+            ["mvn", "compile", "-q"],
+            cwd=java_webapp_project,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        if result.returncode != 0:
+            import pytest
+
+            pytest.skip(f"Maven compile failed: {result.stderr}")
+
+        # Check that target/classes exists
+        classes_dir = java_webapp_project / "target" / "classes"
+        assert classes_dir.exists(), "Maven should create target/classes directory"
+
+        # Check that class files were compiled
+        class_files = list(classes_dir.rglob("*.class"))
+        assert len(class_files) > 0, "Maven should compile Java files"
+
+
+@spotbugs_available
+class TestSpotBugsIssueGeneration:
+    """Tests for SpotBugs issue generation."""
+
+    @maven_available
+    def test_issue_has_correct_fields(
+        self, spotbugs_checker: SpotBugsChecker, java_webapp_project: Path
+    ) -> None:
+        """Test that generated issues have all required fields."""
+        import subprocess
+
+        # First compile the project with Maven
+        result = subprocess.run(
+            ["mvn", "compile", "-q"],
+            cwd=java_webapp_project,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        if result.returncode != 0:
+            import pytest
+
+            pytest.skip(f"Maven compile failed: {result.stderr}")
+
+        context = ScanContext(
+            project_root=java_webapp_project,
+            paths=[java_webapp_project],
+            enabled_domains=[],
+        )
+
+        issues = spotbugs_checker.check(context)
+
+        if len(issues) > 0:
+            issue = issues[0]
+
+            # Check required fields
+            assert issue.id is not None
+            assert issue.id.startswith("spotbugs-")
+            assert issue.domain == ToolDomain.TYPE_CHECKING
+            assert issue.source_tool == "spotbugs"
+            assert issue.severity is not None
+            assert issue.title is not None
+            assert issue.description is not None

--- a/tests/unit/core/test_domain_runner.py
+++ b/tests/unit/core/test_domain_runner.py
@@ -1,0 +1,386 @@
+"""Unit tests for domain runner utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Type
+
+
+from lucidshark.core.domain_runner import (
+    EXTENSION_LANGUAGE,
+    PLUGIN_LANGUAGES,
+    check_severity_threshold,
+    detect_language,
+    filter_plugins_by_language,
+    get_domains_for_language,
+)
+from lucidshark.core.models import Severity, ToolDomain, UnifiedIssue
+
+
+class MockPlugin:
+    """Mock plugin for testing."""
+
+    pass
+
+
+class MockPythonPlugin:
+    """Mock Python plugin."""
+
+    pass
+
+
+class MockJsPlugin:
+    """Mock JavaScript plugin."""
+
+    pass
+
+
+class TestFilterPluginsByLanguage:
+    """Tests for filter_plugins_by_language function."""
+
+    def test_returns_all_plugins_when_no_languages(self) -> None:
+        """Test all plugins returned when no languages specified."""
+        plugins: Dict[str, Type[Any]] = {
+            "ruff": MockPythonPlugin,
+            "eslint": MockJsPlugin,
+        }
+
+        result = filter_plugins_by_language(plugins, [])
+
+        assert result == plugins
+
+    def test_filters_plugins_by_language(self) -> None:
+        """Test plugins are filtered by supported language."""
+        plugins: Dict[str, Type[Any]] = {
+            "ruff": MockPythonPlugin,
+            "eslint": MockJsPlugin,
+        }
+
+        result = filter_plugins_by_language(plugins, ["python"])
+
+        assert "ruff" in result
+        assert "eslint" not in result
+
+    def test_includes_plugin_for_any_matching_language(self) -> None:
+        """Test plugin included if any language matches."""
+        plugins: Dict[str, Type[Any]] = {
+            "eslint": MockJsPlugin,
+        }
+
+        # eslint supports both javascript and typescript
+        result = filter_plugins_by_language(plugins, ["typescript"])
+
+        assert "eslint" in result
+
+    def test_case_insensitive_language_matching(self) -> None:
+        """Test language matching is case insensitive."""
+        plugins: Dict[str, Type[Any]] = {
+            "ruff": MockPythonPlugin,
+        }
+
+        result = filter_plugins_by_language(plugins, ["Python"])
+
+        assert "ruff" in result
+
+    def test_includes_plugins_without_language_restrictions(self) -> None:
+        """Test plugins with no language restrictions are included."""
+        plugins: Dict[str, Type[Any]] = {
+            "unknown_plugin": MockPlugin,
+        }
+
+        # Unknown plugins not in PLUGIN_LANGUAGES are included
+        result = filter_plugins_by_language(plugins, ["python"])
+
+        assert "unknown_plugin" in result
+
+    def test_multiple_languages_filter(self) -> None:
+        """Test filtering with multiple languages."""
+        plugins: Dict[str, Type[Any]] = {
+            "ruff": MockPythonPlugin,
+            "mypy": MockPythonPlugin,
+            "eslint": MockJsPlugin,
+            "typescript": MockJsPlugin,
+        }
+
+        result = filter_plugins_by_language(plugins, ["python", "typescript"])
+
+        assert "ruff" in result
+        assert "mypy" in result
+        assert "eslint" in result
+        assert "typescript" in result
+
+
+class TestDetectLanguage:
+    """Tests for detect_language function."""
+
+    def test_detects_python(self) -> None:
+        """Test Python detection from .py extension."""
+        assert detect_language(Path("test.py")) == "python"
+
+    def test_detects_python_stub(self) -> None:
+        """Test Python stub detection from .pyi extension."""
+        assert detect_language(Path("types.pyi")) == "python"
+
+    def test_detects_javascript(self) -> None:
+        """Test JavaScript detection from .js extension."""
+        assert detect_language(Path("index.js")) == "javascript"
+
+    def test_detects_jsx(self) -> None:
+        """Test JSX detection as javascript."""
+        assert detect_language(Path("component.jsx")) == "javascript"
+
+    def test_detects_typescript(self) -> None:
+        """Test TypeScript detection from .ts extension."""
+        assert detect_language(Path("app.ts")) == "typescript"
+
+    def test_detects_tsx(self) -> None:
+        """Test TSX detection as typescript."""
+        assert detect_language(Path("component.tsx")) == "typescript"
+
+    def test_detects_java(self) -> None:
+        """Test Java detection from .java extension."""
+        assert detect_language(Path("Main.java")) == "java"
+
+    def test_detects_go(self) -> None:
+        """Test Go detection from .go extension."""
+        assert detect_language(Path("main.go")) == "go"
+
+    def test_detects_rust(self) -> None:
+        """Test Rust detection from .rs extension."""
+        assert detect_language(Path("lib.rs")) == "rust"
+
+    def test_detects_terraform(self) -> None:
+        """Test Terraform detection from .tf extension."""
+        assert detect_language(Path("main.tf")) == "terraform"
+
+    def test_detects_yaml(self) -> None:
+        """Test YAML detection from .yaml and .yml extensions."""
+        assert detect_language(Path("config.yaml")) == "yaml"
+        assert detect_language(Path("config.yml")) == "yaml"
+
+    def test_detects_json(self) -> None:
+        """Test JSON detection from .json extension."""
+        assert detect_language(Path("package.json")) == "json"
+
+    def test_returns_unknown_for_unrecognized(self) -> None:
+        """Test unknown returned for unrecognized extensions."""
+        assert detect_language(Path("readme.md")) == "unknown"
+        assert detect_language(Path("Makefile")) == "unknown"
+        assert detect_language(Path("script.sh")) == "unknown"
+
+    def test_case_insensitive_extension(self) -> None:
+        """Test extension matching is case insensitive."""
+        assert detect_language(Path("Test.PY")) == "python"
+        assert detect_language(Path("App.TS")) == "typescript"
+
+
+class TestGetDomainsForLanguage:
+    """Tests for get_domains_for_language function."""
+
+    def test_python_domains(self) -> None:
+        """Test Python gets all standard domains."""
+        domains = get_domains_for_language("python")
+
+        assert "linting" in domains
+        assert "type_checking" in domains
+        assert "testing" in domains
+        assert "coverage" in domains
+        assert "sast" in domains
+        assert "sca" in domains
+
+    def test_javascript_domains(self) -> None:
+        """Test JavaScript gets all standard domains."""
+        domains = get_domains_for_language("javascript")
+
+        assert "linting" in domains
+        assert "type_checking" in domains
+        assert "testing" in domains
+        assert "coverage" in domains
+
+    def test_typescript_domains(self) -> None:
+        """Test TypeScript gets all standard domains."""
+        domains = get_domains_for_language("typescript")
+
+        assert "linting" in domains
+        assert "type_checking" in domains
+        assert "testing" in domains
+        assert "coverage" in domains
+
+    def test_java_domains(self) -> None:
+        """Test Java gets all standard domains."""
+        domains = get_domains_for_language("java")
+
+        assert "linting" in domains
+        assert "type_checking" in domains
+        assert "testing" in domains
+        assert "coverage" in domains
+
+    def test_kotlin_domains(self) -> None:
+        """Test Kotlin gets all standard domains."""
+        domains = get_domains_for_language("kotlin")
+
+        assert "linting" in domains
+        assert "type_checking" in domains
+        assert "testing" in domains
+        assert "coverage" in domains
+
+    def test_terraform_domains(self) -> None:
+        """Test Terraform gets IAC domain only."""
+        domains = get_domains_for_language("terraform")
+
+        assert domains == ["iac"]
+
+    def test_yaml_domains(self) -> None:
+        """Test YAML gets IAC and SAST domains."""
+        domains = get_domains_for_language("yaml")
+
+        assert "iac" in domains
+        assert "sast" in domains
+
+    def test_json_domains(self) -> None:
+        """Test JSON gets IAC and SAST domains."""
+        domains = get_domains_for_language("json")
+
+        assert "iac" in domains
+        assert "sast" in domains
+
+    def test_unknown_language_domains(self) -> None:
+        """Test unknown language gets default domains."""
+        domains = get_domains_for_language("unknown")
+
+        assert "linting" in domains
+        assert "sast" in domains
+        assert "sca" in domains
+
+
+class TestCheckSeverityThreshold:
+    """Tests for check_severity_threshold function."""
+
+    def _create_issue(self, severity: Severity) -> UnifiedIssue:
+        """Helper to create a test issue."""
+        return UnifiedIssue(
+            id="test-001",
+            domain=ToolDomain.LINTING,
+            source_tool="test",
+            severity=severity,
+            rule_id="test-rule",
+            title="Test issue",
+            description="Test description",
+        )
+
+    def test_returns_false_when_no_threshold(self) -> None:
+        """Test returns False when no threshold specified."""
+        issues = [self._create_issue(Severity.CRITICAL)]
+
+        assert check_severity_threshold(issues, None) is False
+
+    def test_returns_false_when_no_issues(self) -> None:
+        """Test returns False when no issues."""
+        assert check_severity_threshold([], "high") is False
+
+    def test_returns_true_when_critical_meets_critical_threshold(self) -> None:
+        """Test critical issue meets critical threshold."""
+        issues = [self._create_issue(Severity.CRITICAL)]
+
+        assert check_severity_threshold(issues, "critical") is True
+
+    def test_returns_true_when_critical_exceeds_high_threshold(self) -> None:
+        """Test critical issue exceeds high threshold."""
+        issues = [self._create_issue(Severity.CRITICAL)]
+
+        assert check_severity_threshold(issues, "high") is True
+
+    def test_returns_false_when_low_below_high_threshold(self) -> None:
+        """Test low issue doesn't meet high threshold."""
+        issues = [self._create_issue(Severity.LOW)]
+
+        assert check_severity_threshold(issues, "high") is False
+
+    def test_returns_true_when_medium_meets_medium_threshold(self) -> None:
+        """Test medium issue meets medium threshold."""
+        issues = [self._create_issue(Severity.MEDIUM)]
+
+        assert check_severity_threshold(issues, "medium") is True
+
+    def test_returns_true_when_any_issue_meets_threshold(self) -> None:
+        """Test returns True if any issue meets threshold."""
+        issues = [
+            self._create_issue(Severity.LOW),
+            self._create_issue(Severity.MEDIUM),
+            self._create_issue(Severity.HIGH),
+        ]
+
+        assert check_severity_threshold(issues, "high") is True
+
+    def test_case_insensitive_threshold(self) -> None:
+        """Test threshold comparison is case insensitive."""
+        issues = [self._create_issue(Severity.HIGH)]
+
+        assert check_severity_threshold(issues, "HIGH") is True
+        assert check_severity_threshold(issues, "High") is True
+
+    def test_unknown_threshold_matches_all_issues(self) -> None:
+        """Test unknown threshold matches all issues (level 99 is very permissive)."""
+        issues = [self._create_issue(Severity.LOW)]
+
+        # Unknown threshold gets level 99, all issue severities (0-3) will be <= 99
+        assert check_severity_threshold(issues, "unknown_level") is True
+
+
+class TestPluginLanguagesMapping:
+    """Tests for PLUGIN_LANGUAGES constant."""
+
+    def test_ruff_supports_python(self) -> None:
+        """Test ruff is mapped to Python."""
+        assert "python" in PLUGIN_LANGUAGES["ruff"]
+
+    def test_eslint_supports_js_and_ts(self) -> None:
+        """Test eslint supports JavaScript and TypeScript."""
+        assert "javascript" in PLUGIN_LANGUAGES["eslint"]
+        assert "typescript" in PLUGIN_LANGUAGES["eslint"]
+
+    def test_mypy_supports_python(self) -> None:
+        """Test mypy is mapped to Python."""
+        assert "python" in PLUGIN_LANGUAGES["mypy"]
+
+    def test_pytest_supports_python(self) -> None:
+        """Test pytest is mapped to Python."""
+        assert "python" in PLUGIN_LANGUAGES["pytest"]
+
+    def test_duplo_supports_multiple_languages(self) -> None:
+        """Test duplo supports many languages."""
+        duplo_langs = PLUGIN_LANGUAGES["duplo"]
+        assert "python" in duplo_langs
+        assert "java" in duplo_langs
+        assert "javascript" in duplo_langs
+        assert "go" in duplo_langs
+
+
+class TestExtensionLanguageMapping:
+    """Tests for EXTENSION_LANGUAGE constant."""
+
+    def test_python_extensions(self) -> None:
+        """Test Python extensions are mapped correctly."""
+        assert EXTENSION_LANGUAGE[".py"] == "python"
+        assert EXTENSION_LANGUAGE[".pyi"] == "python"
+
+    def test_javascript_extensions(self) -> None:
+        """Test JavaScript extensions are mapped correctly."""
+        assert EXTENSION_LANGUAGE[".js"] == "javascript"
+        assert EXTENSION_LANGUAGE[".jsx"] == "javascript"
+
+    def test_typescript_extensions(self) -> None:
+        """Test TypeScript extensions are mapped correctly."""
+        assert EXTENSION_LANGUAGE[".ts"] == "typescript"
+        assert EXTENSION_LANGUAGE[".tsx"] == "typescript"
+
+    def test_java_extension(self) -> None:
+        """Test Java extension is mapped correctly."""
+        assert EXTENSION_LANGUAGE[".java"] == "java"
+
+    def test_infrastructure_extensions(self) -> None:
+        """Test infrastructure file extensions are mapped."""
+        assert EXTENSION_LANGUAGE[".tf"] == "terraform"
+        assert EXTENSION_LANGUAGE[".yaml"] == "yaml"
+        assert EXTENSION_LANGUAGE[".yml"] == "yaml"
+        assert EXTENSION_LANGUAGE[".json"] == "json"

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -1,0 +1,174 @@
+"""Unit tests for path utilities."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lucidshark.core.paths import determine_scan_paths, resolve_node_bin
+
+
+class TestDetermineScanPaths:
+    """Tests for determine_scan_paths function."""
+
+    def test_all_files_true_returns_project_root(self) -> None:
+        """Test that all_files=True returns the project root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            result = determine_scan_paths(project_root, all_files=True)
+
+            assert result == [project_root]
+
+    def test_specific_files_resolved_correctly(self) -> None:
+        """Test that specific files are resolved to absolute paths."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir).resolve()
+            test_file = project_root / "test.py"
+            test_file.touch()
+
+            result = determine_scan_paths(project_root, files=["test.py"])
+
+            assert len(result) == 1
+            assert result[0] == test_file
+
+    def test_nonexistent_file_logs_warning(self) -> None:
+        """Test that nonexistent files are skipped with a warning."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir).resolve()
+            existing_file = project_root / "exists.py"
+            existing_file.touch()
+
+            # Include both existing and nonexistent files
+            result = determine_scan_paths(
+                project_root,
+                files=["exists.py", "nonexistent.py"]
+            )
+
+            # Only the existing file should be returned
+            assert len(result) == 1
+            assert result[0] == existing_file
+
+    def test_all_files_nonexistent_falls_back_to_project_root(self) -> None:
+        """Test fallback to project root when all specified files don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            result = determine_scan_paths(
+                project_root,
+                files=["nonexistent1.py", "nonexistent2.py"]
+            )
+
+            # Should fall back to project root
+            assert result == [project_root]
+
+    def test_no_changed_files_returns_empty_list(self) -> None:
+        """Test that no changed files returns empty list (not project root)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            # Mock get_changed_files to return empty list (git repo with no changes)
+            with patch("lucidshark.core.paths.get_changed_files", return_value=[]):
+                result = determine_scan_paths(project_root)
+
+            assert result == []
+
+    def test_git_unavailable_falls_back_to_project_root(self) -> None:
+        """Test fallback to project root when git is unavailable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            # Mock get_changed_files to return None (git unavailable)
+            with patch("lucidshark.core.paths.get_changed_files", return_value=None):
+                result = determine_scan_paths(project_root)
+
+            assert result == [project_root]
+
+    def test_changed_files_returned_when_present(self) -> None:
+        """Test that changed files are returned when detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            changed_file = project_root / "changed.py"
+            changed_file.touch()
+
+            with patch(
+                "lucidshark.core.paths.get_changed_files",
+                return_value=[changed_file]
+            ):
+                result = determine_scan_paths(project_root)
+
+            assert result == [changed_file]
+
+
+class TestResolveNodeBin:
+    """Tests for resolve_node_bin function."""
+
+    def test_finds_binary_in_node_modules(self) -> None:
+        """Test finding a binary in node_modules/.bin."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            bin_dir = project_root / "node_modules" / ".bin"
+            bin_dir.mkdir(parents=True)
+            eslint_bin = bin_dir / "eslint"
+            eslint_bin.touch()
+
+            result = resolve_node_bin(project_root, "eslint")
+
+            assert result == eslint_bin
+
+    def test_returns_none_when_binary_not_found(self) -> None:
+        """Test that None is returned when binary doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            # Don't create node_modules/.bin
+
+            result = resolve_node_bin(project_root, "eslint")
+
+            assert result is None
+
+    def test_returns_none_when_node_modules_missing(self) -> None:
+        """Test that None is returned when node_modules doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            result = resolve_node_bin(project_root, "eslint")
+
+            assert result is None
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
+    def test_prefers_cmd_on_windows(self) -> None:
+        """Test that .cmd files are preferred on Windows."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            bin_dir = project_root / "node_modules" / ".bin"
+            bin_dir.mkdir(parents=True)
+
+            # Create both plain and .cmd versions
+            plain_bin = bin_dir / "eslint"
+            cmd_bin = bin_dir / "eslint.cmd"
+            plain_bin.touch()
+            cmd_bin.touch()
+
+            result = resolve_node_bin(project_root, "eslint")
+
+            # On Windows, should prefer .cmd
+            assert result == cmd_bin
+
+    def test_windows_cmd_resolution_mocked(self) -> None:
+        """Test Windows .cmd resolution with platform mocking."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            bin_dir = project_root / "node_modules" / ".bin"
+            bin_dir.mkdir(parents=True)
+            cmd_bin = bin_dir / "eslint.cmd"
+            cmd_bin.touch()
+
+            # Mock sys.platform to simulate Windows
+            with patch.object(sys, "platform", "win32"):
+                result = resolve_node_bin(project_root, "eslint")
+
+            assert result == cmd_bin

--- a/tests/unit/core/test_streaming.py
+++ b/tests/unit/core/test_streaming.py
@@ -1,0 +1,342 @@
+"""Unit tests for stream handler module."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from typing import List, Tuple
+
+import pytest
+
+from lucidshark.core.streaming import (
+    CallbackStreamHandler,
+    CLIStreamHandler,
+    MCPStreamHandler,
+    NullStreamHandler,
+    StreamEvent,
+    StreamType,
+)
+
+
+class TestStreamType:
+    """Tests for StreamType enum."""
+
+    def test_stdout_value(self) -> None:
+        """Test STDOUT enum value."""
+        assert StreamType.STDOUT.value == "stdout"
+
+    def test_stderr_value(self) -> None:
+        """Test STDERR enum value."""
+        assert StreamType.STDERR.value == "stderr"
+
+    def test_status_value(self) -> None:
+        """Test STATUS enum value."""
+        assert StreamType.STATUS.value == "status"
+
+    def test_is_string_enum(self) -> None:
+        """Test StreamType is a string enum."""
+        assert isinstance(StreamType.STDOUT, str)
+        assert StreamType.STDOUT == "stdout"
+
+
+class TestStreamEvent:
+    """Tests for StreamEvent dataclass."""
+
+    def test_basic_event(self) -> None:
+        """Test creating a basic stream event."""
+        event = StreamEvent(
+            tool_name="pytest",
+            stream_type=StreamType.STDOUT,
+            content="test output",
+        )
+        assert event.tool_name == "pytest"
+        assert event.stream_type == StreamType.STDOUT
+        assert event.content == "test output"
+        assert event.line_number is None
+
+    def test_event_with_line_number(self) -> None:
+        """Test creating event with line number."""
+        event = StreamEvent(
+            tool_name="ruff",
+            stream_type=StreamType.STDERR,
+            content="error on line 42",
+            line_number=42,
+        )
+        assert event.line_number == 42
+
+
+class TestNullStreamHandler:
+    """Tests for NullStreamHandler."""
+
+    def test_emit_is_noop(self) -> None:
+        """Test emit does nothing."""
+        handler = NullStreamHandler()
+        event = StreamEvent(
+            tool_name="test",
+            stream_type=StreamType.STDOUT,
+            content="content",
+        )
+        # Should not raise
+        handler.emit(event)
+
+    def test_start_tool_is_noop(self) -> None:
+        """Test start_tool does nothing."""
+        handler = NullStreamHandler()
+        # Should not raise
+        handler.start_tool("test_tool")
+
+    def test_end_tool_is_noop(self) -> None:
+        """Test end_tool does nothing."""
+        handler = NullStreamHandler()
+        # Should not raise
+        handler.end_tool("test_tool", success=True)
+        handler.end_tool("test_tool", success=False)
+
+
+class TestCLIStreamHandler:
+    """Tests for CLIStreamHandler."""
+
+    def test_emit_with_show_output_false(self) -> None:
+        """Test emit does nothing when show_output is False."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=False)
+        event = StreamEvent(
+            tool_name="test",
+            stream_type=StreamType.STDOUT,
+            content="content",
+        )
+        handler.emit(event)
+        assert output.getvalue() == ""
+
+    def test_emit_status_event(self) -> None:
+        """Test emit outputs status events."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=True)
+        event = StreamEvent(
+            tool_name="pytest",
+            stream_type=StreamType.STATUS,
+            content="Running tests...",
+        )
+        handler.emit(event)
+        assert "[pytest] Running tests..." in output.getvalue()
+
+    def test_emit_stdout_event(self) -> None:
+        """Test emit outputs stdout events with prefix."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=True)
+        event = StreamEvent(
+            tool_name="ruff",
+            stream_type=StreamType.STDOUT,
+            content="checking files...",
+        )
+        handler.emit(event)
+        output_str = output.getvalue()
+        assert "ruff:" in output_str
+        assert "checking files..." in output_str
+
+    def test_start_tool_outputs_starting_message(self) -> None:
+        """Test start_tool outputs starting message."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=True)
+        handler.start_tool("mypy")
+        assert "[mypy] Starting..." in output.getvalue()
+
+    def test_end_tool_success_outputs_done(self) -> None:
+        """Test end_tool with success outputs Done."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=True)
+        handler.end_tool("pytest", success=True)
+        assert "[pytest] Done" in output.getvalue()
+
+    def test_end_tool_failure_outputs_failed(self) -> None:
+        """Test end_tool with failure outputs Failed."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=True)
+        handler.end_tool("pytest", success=False)
+        assert "[pytest] Failed" in output.getvalue()
+
+    def test_emit_stderr_event(self) -> None:
+        """Test emit outputs stderr events with prefix."""
+        output = io.StringIO()
+        handler = CLIStreamHandler(output=output, show_output=True)
+        event = StreamEvent(
+            tool_name="mypy",
+            stream_type=StreamType.STDERR,
+            content="error found",
+        )
+        handler.emit(event)
+        output_str = output.getvalue()
+        assert "mypy:" in output_str
+        assert "error found" in output_str
+
+
+class TestCallbackStreamHandler:
+    """Tests for CallbackStreamHandler."""
+
+    def test_emit_calls_on_event_callback(self) -> None:
+        """Test emit invokes on_event callback."""
+        events: List[StreamEvent] = []
+
+        def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        handler = CallbackStreamHandler(on_event=on_event)
+        event = StreamEvent(
+            tool_name="test",
+            stream_type=StreamType.STDOUT,
+            content="content",
+        )
+        handler.emit(event)
+
+        assert len(events) == 1
+        assert events[0] == event
+
+    def test_emit_without_callback_is_noop(self) -> None:
+        """Test emit does nothing without callback."""
+        handler = CallbackStreamHandler()
+        event = StreamEvent(
+            tool_name="test",
+            stream_type=StreamType.STDOUT,
+            content="content",
+        )
+        # Should not raise
+        handler.emit(event)
+
+    def test_start_tool_calls_on_start_callback(self) -> None:
+        """Test start_tool invokes on_start callback."""
+        started_tools: List[str] = []
+
+        def on_start(tool_name: str) -> None:
+            started_tools.append(tool_name)
+
+        handler = CallbackStreamHandler(on_start=on_start)
+        handler.start_tool("pytest")
+
+        assert started_tools == ["pytest"]
+
+    def test_start_tool_also_emits_event(self) -> None:
+        """Test start_tool also emits a status event."""
+        events: List[StreamEvent] = []
+
+        def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        handler = CallbackStreamHandler(on_event=on_event)
+        handler.start_tool("ruff")
+
+        assert len(events) == 1
+        assert events[0].tool_name == "ruff"
+        assert events[0].stream_type == StreamType.STATUS
+        assert events[0].content == "started"
+
+    def test_end_tool_calls_on_end_callback(self) -> None:
+        """Test end_tool invokes on_end callback."""
+        ended_tools: List[Tuple[str, bool]] = []
+
+        def on_end(tool_name: str, success: bool) -> None:
+            ended_tools.append((tool_name, success))
+
+        handler = CallbackStreamHandler(on_end=on_end)
+        handler.end_tool("pytest", success=True)
+        handler.end_tool("mypy", success=False)
+
+        assert ended_tools == [("pytest", True), ("mypy", False)]
+
+    def test_end_tool_also_emits_event(self) -> None:
+        """Test end_tool also emits a status event."""
+        events: List[StreamEvent] = []
+
+        def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        handler = CallbackStreamHandler(on_event=on_event)
+        handler.end_tool("ruff", success=True)
+        handler.end_tool("mypy", success=False)
+
+        assert len(events) == 2
+        assert events[0].content == "completed"
+        assert events[1].content == "failed"
+
+
+class TestMCPStreamHandler:
+    """Tests for MCPStreamHandler."""
+
+    @pytest.mark.asyncio
+    async def test_emit_schedules_async_callback(self) -> None:
+        """Test emit schedules async callback."""
+        events: List[StreamEvent] = []
+
+        async def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        loop = asyncio.get_running_loop()
+        handler = MCPStreamHandler(on_event=on_event, loop=loop)
+
+        event = StreamEvent(
+            tool_name="test",
+            stream_type=StreamType.STDOUT,
+            content="content",
+        )
+        handler.emit(event)
+
+        # Allow time for callback to execute
+        await asyncio.sleep(0.01)
+
+        assert len(events) == 1
+        assert events[0] == event
+
+    @pytest.mark.asyncio
+    async def test_start_tool_emits_started_event(self) -> None:
+        """Test start_tool emits started status event."""
+        events: List[StreamEvent] = []
+
+        async def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        loop = asyncio.get_running_loop()
+        handler = MCPStreamHandler(on_event=on_event, loop=loop)
+
+        handler.start_tool("pytest")
+
+        await asyncio.sleep(0.01)
+
+        assert len(events) == 1
+        assert events[0].tool_name == "pytest"
+        assert events[0].stream_type == StreamType.STATUS
+        assert events[0].content == "started"
+
+    @pytest.mark.asyncio
+    async def test_end_tool_emits_completed_event(self) -> None:
+        """Test end_tool emits completed status event on success."""
+        events: List[StreamEvent] = []
+
+        async def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        loop = asyncio.get_running_loop()
+        handler = MCPStreamHandler(on_event=on_event, loop=loop)
+
+        handler.end_tool("pytest", success=True)
+
+        await asyncio.sleep(0.01)
+
+        assert len(events) == 1
+        assert events[0].content == "completed"
+
+    @pytest.mark.asyncio
+    async def test_end_tool_emits_failed_event(self) -> None:
+        """Test end_tool emits failed status event on failure."""
+        events: List[StreamEvent] = []
+
+        async def on_event(event: StreamEvent) -> None:
+            events.append(event)
+
+        loop = asyncio.get_running_loop()
+        handler = MCPStreamHandler(on_event=on_event, loop=loop)
+
+        handler.end_tool("pytest", success=False)
+
+        await asyncio.sleep(0.01)
+
+        assert len(events) == 1
+        assert events[0].content == "failed"

--- a/tests/unit/detection/test_detector.py
+++ b/tests/unit/detection/test_detector.py
@@ -1,0 +1,179 @@
+"""Unit tests for codebase detector."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from lucidshark.detection.detector import CodebaseDetector, ProjectContext
+from lucidshark.detection.languages import LanguageInfo
+
+
+class TestProjectContext:
+    """Tests for ProjectContext dataclass."""
+
+    def test_primary_language_returns_none_when_empty(self) -> None:
+        """Test primary_language returns None when no languages detected."""
+        context = ProjectContext(root=Path("/tmp"))
+
+        assert context.primary_language is None
+
+    def test_primary_language_returns_highest_file_count(self) -> None:
+        """Test primary_language returns language with most files."""
+        context = ProjectContext(
+            root=Path("/tmp"),
+            languages=[
+                LanguageInfo(name="python", file_count=100),
+                LanguageInfo(name="javascript", file_count=50),
+            ],
+        )
+
+        assert context.primary_language == "python"
+
+    def test_has_go_property(self) -> None:
+        """Test has_go property."""
+        context_with_go = ProjectContext(
+            root=Path("/tmp"),
+            languages=[LanguageInfo(name="go", file_count=10)],
+        )
+        context_without_go = ProjectContext(
+            root=Path("/tmp"),
+            languages=[LanguageInfo(name="python", file_count=10)],
+        )
+
+        assert context_with_go.has_go is True
+        assert context_without_go.has_go is False
+
+    def test_has_java_property(self) -> None:
+        """Test has_java property."""
+        context = ProjectContext(
+            root=Path("/tmp"),
+            languages=[LanguageInfo(name="java", file_count=10)],
+        )
+
+        assert context.has_java is True
+
+    def test_has_kotlin_property(self) -> None:
+        """Test has_kotlin property."""
+        context = ProjectContext(
+            root=Path("/tmp"),
+            languages=[LanguageInfo(name="kotlin", file_count=10)],
+        )
+
+        assert context.has_kotlin is True
+
+
+class TestCodebaseDetector:
+    """Tests for CodebaseDetector class."""
+
+    def test_detect_pipenv_project(self) -> None:
+        """Test detection of Pipenv package manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "Pipfile").touch()
+            (project_root / "app.py").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "pipenv" in context.package_managers
+
+    def test_detect_poetry_project(self) -> None:
+        """Test detection of Poetry package manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "poetry.lock").touch()
+            (project_root / "app.py").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "poetry" in context.package_managers
+
+    def test_detect_yarn_project(self) -> None:
+        """Test detection of Yarn package manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "yarn.lock").touch()
+            (project_root / "index.js").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "yarn" in context.package_managers
+
+    def test_detect_pnpm_project(self) -> None:
+        """Test detection of pnpm package manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "pnpm-lock.yaml").touch()
+            (project_root / "index.js").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "pnpm" in context.package_managers
+
+    def test_detect_go_modules(self) -> None:
+        """Test detection of Go modules."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "go.mod").write_text("module example.com/test")
+            (project_root / "main.go").write_text("package main")
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "go" in context.package_managers
+
+    def test_detect_cargo_project(self) -> None:
+        """Test detection of Cargo (Rust) package manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "Cargo.toml").write_text('[package]\nname = "test"')
+            (project_root / "src").mkdir()
+            (project_root / "src" / "main.rs").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "cargo" in context.package_managers
+
+    def test_detect_maven_project(self) -> None:
+        """Test detection of Maven (Java) build tool."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "pom.xml").write_text("<project></project>")
+            (project_root / "src" / "main" / "java").mkdir(parents=True)
+            (project_root / "src" / "main" / "java" / "App.java").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "maven" in context.package_managers
+
+    def test_detect_gradle_project(self) -> None:
+        """Test detection of Gradle (Java/Kotlin) build tool."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "build.gradle").write_text("apply plugin: 'java'")
+            (project_root / "src" / "main" / "java").mkdir(parents=True)
+            (project_root / "src" / "main" / "java" / "App.java").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "gradle" in context.package_managers
+
+    def test_detect_gradle_kotlin_dsl(self) -> None:
+        """Test detection of Gradle with Kotlin DSL."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "build.gradle.kts").write_text("plugins { }")
+            (project_root / "src" / "main" / "kotlin").mkdir(parents=True)
+            (project_root / "src" / "main" / "kotlin" / "App.kt").touch()
+
+            detector = CodebaseDetector()
+            context = detector.detect(project_root)
+
+            assert "gradle" in context.package_managers

--- a/tests/unit/plugins/coverage/test_coverage_py.py
+++ b/tests/unit/plugins/coverage/test_coverage_py.py
@@ -212,33 +212,3 @@ class TestCoveragePyCoverageIssueCreation:
         assert metadata["covered_lines"] == 150
         assert metadata["missing_lines"] == 50
         assert metadata["gap_percentage"] == 5.0
-
-
-class TestCoveragePyIssueIdGeneration:
-    """Tests for deterministic issue ID generation."""
-
-    def test_same_input_same_id(self) -> None:
-        """Test same input produces same ID."""
-        plugin = CoveragePyPlugin()
-
-        id1 = plugin._generate_issue_id(75.0, 80.0)
-        id2 = plugin._generate_issue_id(75.0, 80.0)
-
-        assert id1 == id2
-
-    def test_different_input_different_id(self) -> None:
-        """Test different input produces different ID."""
-        plugin = CoveragePyPlugin()
-
-        id1 = plugin._generate_issue_id(75.0, 80.0)
-        id2 = plugin._generate_issue_id(60.0, 80.0)
-
-        assert id1 != id2
-
-    def test_id_format(self) -> None:
-        """Test ID format starts with coverage-."""
-        plugin = CoveragePyPlugin()
-
-        issue_id = plugin._generate_issue_id(75.0, 80.0)
-
-        assert issue_id.startswith("coverage-")

--- a/tests/unit/plugins/coverage/test_jacoco.py
+++ b/tests/unit/plugins/coverage/test_jacoco.py
@@ -263,36 +263,6 @@ class TestJaCoCoSourcePathResolution:
             assert resolved == test_dir / "ServiceTest.java"
 
 
-class TestJaCoCoIssueIdGeneration:
-    """Tests for deterministic issue ID generation."""
-
-    def test_same_input_same_id(self) -> None:
-        """Test same input produces same ID."""
-        plugin = JaCoCoPlugin()
-
-        id1 = plugin._generate_issue_id(75.0, 80.0)
-        id2 = plugin._generate_issue_id(75.0, 80.0)
-
-        assert id1 == id2
-
-    def test_different_input_different_id(self) -> None:
-        """Test different input produces different ID."""
-        plugin = JaCoCoPlugin()
-
-        id1 = plugin._generate_issue_id(75.0, 80.0)
-        id2 = plugin._generate_issue_id(60.0, 80.0)
-
-        assert id1 != id2
-
-    def test_id_format(self) -> None:
-        """Test ID format starts with jacoco-."""
-        plugin = JaCoCoPlugin()
-
-        issue_id = plugin._generate_issue_id(75.0, 80.0)
-
-        assert issue_id.startswith("jacoco-")
-
-
 class TestJaCoCoTestStatsParsing:
     """Tests for parsing test statistics from build output."""
 

--- a/tests/unit/plugins/coverage/test_jacoco.py
+++ b/tests/unit/plugins/coverage/test_jacoco.py
@@ -1,0 +1,330 @@
+"""Unit tests for JaCoCo coverage plugin."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lucidshark.core.models import Severity, ToolDomain
+from lucidshark.plugins.coverage.jacoco import JaCoCoPlugin
+
+
+class TestJaCoCoPlugin:
+    """Tests for JaCoCoPlugin class."""
+
+    def test_name(self) -> None:
+        """Test plugin name."""
+        plugin = JaCoCoPlugin()
+        assert plugin.name == "jacoco"
+
+    def test_languages(self) -> None:
+        """Test supported languages."""
+        plugin = JaCoCoPlugin()
+        assert "java" in plugin.languages
+        assert "kotlin" in plugin.languages
+
+    def test_domain(self) -> None:
+        """Test domain is COVERAGE."""
+        plugin = JaCoCoPlugin()
+        assert plugin.domain == ToolDomain.COVERAGE
+
+
+class TestJaCoCoBuildSystemDetection:
+    """Tests for build system detection logic."""
+
+    def test_detect_maven_wrapper(self) -> None:
+        """Test detecting Maven wrapper (mvnw)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            mvnw = project_root / "mvnw"
+            mvnw.touch()
+
+            plugin = JaCoCoPlugin(project_root=project_root)
+            binary, build_system = plugin._detect_build_system()
+
+            assert binary == mvnw
+            assert build_system == "maven"
+
+    def test_detect_gradle_wrapper(self) -> None:
+        """Test detecting Gradle wrapper (gradlew)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            gradlew = project_root / "gradlew"
+            gradlew.touch()
+
+            plugin = JaCoCoPlugin(project_root=project_root)
+            binary, build_system = plugin._detect_build_system()
+
+            assert binary == gradlew
+            assert build_system == "gradle"
+
+    def test_no_build_system_raises_error(self) -> None:
+        """Test FileNotFoundError when no build system found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            with patch("shutil.which") as mock_which:
+                mock_which.return_value = None
+                plugin = JaCoCoPlugin(project_root=project_root)
+
+                with pytest.raises(FileNotFoundError) as exc:
+                    plugin._detect_build_system()
+
+                assert "No build system found" in str(exc.value)
+
+
+class TestJaCoCoXmlParsing:
+    """Tests for JaCoCo XML report parsing."""
+
+    def test_parse_xml_report(self) -> None:
+        """Test parsing JaCoCo XML report."""
+        plugin = JaCoCoPlugin()
+
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="user-service">
+    <counter type="INSTRUCTION" missed="100" covered="400"/>
+    <counter type="BRANCH" missed="10" covered="30"/>
+    <counter type="LINE" missed="50" covered="200"/>
+    <counter type="COMPLEXITY" missed="20" covered="80"/>
+    <counter type="METHOD" missed="5" covered="45"/>
+    <counter type="CLASS" missed="1" covered="9"/>
+    <package name="com/example/service">
+        <sourcefile name="UserService.java">
+            <line nr="10" mi="0" ci="5" mb="0" cb="2"/>
+            <line nr="15" mi="2" ci="0" mb="1" cb="0"/>
+            <counter type="LINE" missed="5" covered="25"/>
+        </sourcefile>
+    </package>
+</report>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            report_file = project_root / "jacoco.xml"
+            report_file.write_text(xml_content)
+
+            result = plugin._parse_xml_report(report_file, project_root, threshold=80.0)
+
+            assert result.total_lines == 250  # 50 + 200
+            assert result.covered_lines == 200
+            assert result.missing_lines == 50
+            assert result.threshold == 80.0
+
+            # 200/250 = 80%, should pass at 80% threshold
+            assert result.percentage == 80.0
+            assert result.passed is True
+            assert len(result.issues) == 0
+
+    def test_parse_xml_report_below_threshold(self) -> None:
+        """Test parsing report with coverage below threshold."""
+        plugin = JaCoCoPlugin()
+
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<report name="test">
+    <counter type="LINE" missed="60" covered="40"/>
+</report>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            report_file = project_root / "jacoco.xml"
+            report_file.write_text(xml_content)
+
+            result = plugin._parse_xml_report(report_file, project_root, threshold=80.0)
+
+            assert result.total_lines == 100
+            assert result.covered_lines == 40
+            assert result.percentage == 40.0
+            assert result.passed is False
+            assert len(result.issues) == 1
+
+            issue = result.issues[0]
+            assert issue.domain == ToolDomain.COVERAGE
+            assert issue.source_tool == "jacoco"
+            assert issue.rule_id == "coverage_below_threshold"
+            assert "40.0%" in issue.title
+            assert "80.0%" in issue.title
+
+    def test_parse_xml_report_per_file_coverage(self) -> None:
+        """Test parsing per-file coverage data."""
+        plugin = JaCoCoPlugin()
+
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<report name="test">
+    <counter type="LINE" missed="20" covered="80"/>
+    <package name="com/example">
+        <sourcefile name="Service.java">
+            <line nr="10" mi="2" ci="0"/>
+            <line nr="20" mi="0" ci="5"/>
+            <counter type="LINE" missed="10" covered="40"/>
+        </sourcefile>
+    </package>
+</report>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            report_file = project_root / "jacoco.xml"
+            report_file.write_text(xml_content)
+
+            # Create source file
+            src_dir = project_root / "src" / "main" / "java" / "com" / "example"
+            src_dir.mkdir(parents=True)
+            (src_dir / "Service.java").touch()
+
+            result = plugin._parse_xml_report(report_file, project_root, threshold=80.0)
+
+            assert len(result.files) == 1
+
+
+class TestJaCoCoCoverageIssue:
+    """Tests for coverage issue creation."""
+
+    def test_create_coverage_issue_below_50(self) -> None:
+        """Test HIGH severity when coverage below 50%."""
+        plugin = JaCoCoPlugin()
+
+        issue = plugin._create_coverage_issue(
+            percentage=30.0,
+            threshold=80.0,
+            total_lines=100,
+            covered_lines=30,
+            missing_lines=70,
+        )
+
+        assert issue.severity == Severity.HIGH
+        assert "30.0%" in issue.title
+        assert "80.0%" in issue.title
+
+    def test_create_coverage_issue_moderately_below(self) -> None:
+        """Test MEDIUM severity when coverage moderately below threshold."""
+        plugin = JaCoCoPlugin()
+
+        issue = plugin._create_coverage_issue(
+            percentage=60.0,
+            threshold=80.0,
+            total_lines=100,
+            covered_lines=60,
+            missing_lines=40,
+        )
+
+        assert issue.severity == Severity.MEDIUM
+
+    def test_create_coverage_issue_slightly_below(self) -> None:
+        """Test LOW severity when coverage slightly below threshold."""
+        plugin = JaCoCoPlugin()
+
+        issue = plugin._create_coverage_issue(
+            percentage=75.0,
+            threshold=80.0,
+            total_lines=100,
+            covered_lines=75,
+            missing_lines=25,
+        )
+
+        assert issue.severity == Severity.LOW
+
+
+class TestJaCoCoSourcePathResolution:
+    """Tests for source file path resolution."""
+
+    def test_resolve_source_path_standard(self) -> None:
+        """Test resolving standard Maven/Gradle source path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_dir = project_root / "src" / "main" / "java" / "com" / "example"
+            src_dir.mkdir(parents=True)
+            (src_dir / "Service.java").touch()
+
+            plugin = JaCoCoPlugin()
+            resolved = plugin._resolve_source_path(
+                project_root, "com/example", "Service.java"
+            )
+
+            assert resolved == src_dir / "Service.java"
+
+    def test_resolve_source_path_test_directory(self) -> None:
+        """Test resolving test source path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            test_dir = project_root / "src" / "test" / "java" / "com" / "example"
+            test_dir.mkdir(parents=True)
+            (test_dir / "ServiceTest.java").touch()
+
+            plugin = JaCoCoPlugin()
+            resolved = plugin._resolve_source_path(
+                project_root, "com/example", "ServiceTest.java"
+            )
+
+            assert resolved == test_dir / "ServiceTest.java"
+
+
+class TestJaCoCoIssueIdGeneration:
+    """Tests for deterministic issue ID generation."""
+
+    def test_same_input_same_id(self) -> None:
+        """Test same input produces same ID."""
+        plugin = JaCoCoPlugin()
+
+        id1 = plugin._generate_issue_id(75.0, 80.0)
+        id2 = plugin._generate_issue_id(75.0, 80.0)
+
+        assert id1 == id2
+
+    def test_different_input_different_id(self) -> None:
+        """Test different input produces different ID."""
+        plugin = JaCoCoPlugin()
+
+        id1 = plugin._generate_issue_id(75.0, 80.0)
+        id2 = plugin._generate_issue_id(60.0, 80.0)
+
+        assert id1 != id2
+
+    def test_id_format(self) -> None:
+        """Test ID format starts with jacoco-."""
+        plugin = JaCoCoPlugin()
+
+        issue_id = plugin._generate_issue_id(75.0, 80.0)
+
+        assert issue_id.startswith("jacoco-")
+
+
+class TestJaCoCoTestStatsParsing:
+    """Tests for parsing test statistics from build output."""
+
+    def test_parse_maven_test_output(self) -> None:
+        """Test parsing Maven test output."""
+        plugin = JaCoCoPlugin()
+
+        # The pattern sums all matches, so use unique output
+        output = """
+[INFO] --- maven-surefire-plugin:3.0.0:test (default-test) @ user-service ---
+[INFO] Tests run: 10, Failures: 1, Errors: 0, Skipped: 2
+        """
+
+        stats = plugin._parse_maven_test_output(output)
+
+        assert stats.total == 10
+        assert stats.failed == 1
+        assert stats.errors == 0
+        assert stats.skipped == 2
+        assert stats.passed == 7
+
+    def test_parse_gradle_test_output(self) -> None:
+        """Test parsing Gradle test output."""
+        plugin = JaCoCoPlugin()
+
+        output = """
+> Task :test
+10 tests completed, 2 failed, 1 skipped
+        """
+
+        stats = plugin._parse_gradle_test_output(output)
+
+        assert stats.total == 10
+        assert stats.failed == 2
+        assert stats.skipped == 1

--- a/tests/unit/plugins/test_runners/test_maven.py
+++ b/tests/unit/plugins/test_runners/test_maven.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/plugins/test_runners/test_maven.py
+++ b/tests/unit/plugins/test_runners/test_maven.py
@@ -1,0 +1,288 @@
+"""Unit tests for Maven/Gradle test runner plugin."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lucidshark.core.models import Severity, ToolDomain
+from lucidshark.plugins.test_runners.maven import MavenTestRunner
+
+
+class TestMavenTestRunner:
+    """Tests for MavenTestRunner class."""
+
+    def test_name(self) -> None:
+        """Test plugin name."""
+        runner = MavenTestRunner()
+        assert runner.name == "maven"
+
+    def test_languages(self) -> None:
+        """Test supported languages."""
+        runner = MavenTestRunner()
+        assert "java" in runner.languages
+        assert "kotlin" in runner.languages
+
+    def test_domain(self) -> None:
+        """Test domain is TESTING."""
+        runner = MavenTestRunner()
+        assert runner.domain == ToolDomain.TESTING
+
+
+class TestMavenBuildSystemDetection:
+    """Tests for build system detection logic."""
+
+    def test_detect_maven_wrapper(self) -> None:
+        """Test detecting Maven wrapper (mvnw)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            mvnw = project_root / "mvnw"
+            mvnw.touch()
+
+            runner = MavenTestRunner(project_root=project_root)
+            binary, build_system = runner._detect_build_system()
+
+            assert binary == mvnw
+            assert build_system == "maven"
+
+    def test_detect_gradle_wrapper(self) -> None:
+        """Test detecting Gradle wrapper (gradlew)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            gradlew = project_root / "gradlew"
+            gradlew.touch()
+
+            runner = MavenTestRunner(project_root=project_root)
+            binary, build_system = runner._detect_build_system()
+
+            assert binary == gradlew
+            assert build_system == "gradle"
+
+    def test_detect_pom_xml_with_mvn(self) -> None:
+        """Test detecting Maven via pom.xml and mvn in PATH."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            pom_xml = project_root / "pom.xml"
+            pom_xml.write_text("<project></project>")
+
+            with patch("shutil.which") as mock_which:
+                mock_which.return_value = "/usr/bin/mvn"
+                runner = MavenTestRunner(project_root=project_root)
+                binary, build_system = runner._detect_build_system()
+
+                assert binary == Path("/usr/bin/mvn")
+                assert build_system == "maven"
+
+    def test_detect_build_gradle_with_gradle(self) -> None:
+        """Test detecting Gradle via build.gradle and gradle in PATH."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            build_gradle = project_root / "build.gradle"
+            build_gradle.write_text("// Gradle build")
+
+            with patch("shutil.which") as mock_which:
+                mock_which.return_value = "/usr/bin/gradle"
+                runner = MavenTestRunner(project_root=project_root)
+                binary, build_system = runner._detect_build_system()
+
+                assert binary == Path("/usr/bin/gradle")
+                assert build_system == "gradle"
+
+    def test_no_build_system_raises_error(self) -> None:
+        """Test FileNotFoundError when no build system found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            with patch("shutil.which") as mock_which:
+                mock_which.return_value = None
+                runner = MavenTestRunner(project_root=project_root)
+
+                with pytest.raises(FileNotFoundError) as exc:
+                    runner._detect_build_system()
+
+                assert "No build system found" in str(exc.value)
+
+
+class TestMavenJunitXmlParsing:
+    """Tests for JUnit XML parsing."""
+
+    def test_parse_junit_xml_with_failures(self) -> None:
+        """Test parsing JUnit XML with test failures."""
+        runner = MavenTestRunner()
+
+        junit_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="com.example.MyTest" tests="3" failures="1" errors="0" skipped="0" time="1.5">
+            <testcase classname="com.example.MyTest" name="testSuccess" time="0.1"/>
+            <testcase classname="com.example.MyTest" name="testFailure" time="0.05">
+                <failure type="java.lang.AssertionError" message="expected: true but was: false">
+java.lang.AssertionError: expected: true but was: false
+    at com.example.MyTest.testFailure(MyTest.java:25)
+                </failure>
+            </testcase>
+            <testcase classname="com.example.MyTest" name="testAnother" time="0.02"/>
+        </testsuite>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            report_file = project_root / "junit.xml"
+            report_file.write_text(junit_xml)
+
+            result = runner._parse_junit_xml(report_file, project_root)
+
+            assert result.passed == 2
+            assert result.failed == 1
+            assert result.errors == 0
+            assert result.duration_ms == 1500
+            assert len(result.issues) == 1
+
+            issue = result.issues[0]
+            assert "testFailure" in issue.title
+            assert issue.severity == Severity.HIGH
+            assert issue.domain == ToolDomain.TESTING
+            assert issue.source_tool == "maven"
+
+    def test_parse_junit_xml_all_passed(self) -> None:
+        """Test parsing JUnit XML with all tests passed."""
+        runner = MavenTestRunner()
+
+        junit_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="com.example.MyTest" tests="5" failures="0" errors="0" skipped="0" time="2.0">
+            <testcase classname="com.example.MyTest" name="test1" time="0.1"/>
+            <testcase classname="com.example.MyTest" name="test2" time="0.1"/>
+            <testcase classname="com.example.MyTest" name="test3" time="0.1"/>
+            <testcase classname="com.example.MyTest" name="test4" time="0.1"/>
+            <testcase classname="com.example.MyTest" name="test5" time="0.1"/>
+        </testsuite>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            report_file = project_root / "junit.xml"
+            report_file.write_text(junit_xml)
+
+            result = runner._parse_junit_xml(report_file, project_root)
+
+            assert result.passed == 5
+            assert result.failed == 0
+            assert result.success is True
+            assert len(result.issues) == 0
+
+    def test_parse_junit_xml_with_errors(self) -> None:
+        """Test parsing JUnit XML with test errors."""
+        runner = MavenTestRunner()
+
+        junit_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="com.example.MyTest" tests="2" failures="0" errors="1" skipped="0" time="0.5">
+            <testcase classname="com.example.MyTest" name="testSuccess" time="0.1"/>
+            <testcase classname="com.example.MyTest" name="testError" time="0.05">
+                <error type="java.lang.NullPointerException" message="NPE">
+java.lang.NullPointerException
+    at com.example.MyTest.testError(MyTest.java:30)
+                </error>
+            </testcase>
+        </testsuite>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            report_file = project_root / "junit.xml"
+            report_file.write_text(junit_xml)
+
+            result = runner._parse_junit_xml(report_file, project_root)
+
+            assert result.passed == 1
+            assert result.errors == 1
+            assert len(result.issues) == 1
+
+            issue = result.issues[0]
+            assert "testError" in issue.title
+            assert issue.severity == Severity.MEDIUM
+
+
+class TestMavenLineExtraction:
+    """Tests for line number extraction from stacktrace."""
+
+    def test_extract_line_from_stacktrace(self) -> None:
+        """Test extracting line number from Java stacktrace."""
+        runner = MavenTestRunner()
+
+        stacktrace = """java.lang.AssertionError: expected: true but was: false
+    at org.junit.Assert.fail(Assert.java:88)
+    at com.example.service.UserServiceTest.testLogin(UserServiceTest.java:42)
+    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+        """
+
+        line = runner._extract_line_from_stacktrace(
+            stacktrace, "com.example.service.UserServiceTest"
+        )
+
+        assert line == 42
+
+    def test_extract_line_no_match(self) -> None:
+        """Test no line number when class not in stacktrace."""
+        runner = MavenTestRunner()
+
+        stacktrace = """java.lang.NullPointerException
+    at java.util.HashMap.get(HashMap.java:100)
+        """
+
+        line = runner._extract_line_from_stacktrace(
+            stacktrace, "com.example.MyTest"
+        )
+
+        assert line is None
+
+
+class TestMavenIssueIdGeneration:
+    """Tests for deterministic issue ID generation."""
+
+    def test_same_input_same_id(self) -> None:
+        """Test same input produces same ID."""
+        runner = MavenTestRunner()
+
+        id1 = runner._generate_issue_id("com.example.Test#testFoo", "expected true")
+        id2 = runner._generate_issue_id("com.example.Test#testFoo", "expected true")
+
+        assert id1 == id2
+
+    def test_different_input_different_id(self) -> None:
+        """Test different input produces different ID."""
+        runner = MavenTestRunner()
+
+        id1 = runner._generate_issue_id("com.example.Test#testFoo", "expected true")
+        id2 = runner._generate_issue_id("com.example.Test#testBar", "expected true")
+
+        assert id1 != id2
+
+    def test_id_format(self) -> None:
+        """Test ID format starts with maven-test-."""
+        runner = MavenTestRunner()
+
+        issue_id = runner._generate_issue_id("com.example.Test#testFoo", "msg")
+
+        assert issue_id.startswith("maven-test-")
+
+
+class TestMavenResultMerging:
+    """Tests for merging multiple TestResults."""
+
+    def test_merge_results(self) -> None:
+        """Test merging two TestResults."""
+        from lucidshark.plugins.test_runners.base import TestResult
+
+        runner = MavenTestRunner()
+
+        result1 = TestResult(passed=5, failed=1, skipped=0, errors=0, duration_ms=1000)
+        result2 = TestResult(passed=3, failed=2, skipped=1, errors=1, duration_ms=500)
+
+        merged = runner._merge_results(result1, result2)
+
+        assert merged.passed == 8
+        assert merged.failed == 3
+        assert merged.skipped == 1
+        assert merged.errors == 1
+        assert merged.duration_ms == 1500

--- a/tests/unit/plugins/test_utils.py
+++ b/tests/unit/plugins/test_utils.py
@@ -1,0 +1,170 @@
+"""Unit tests for shared plugin utilities."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+from lucidshark.plugins.utils import (
+    get_cli_version,
+    resolve_src_paths,
+)
+
+
+class TestGetCliVersion:
+    """Tests for get_cli_version function."""
+
+    def test_returns_version_on_success(self) -> None:
+        """Test successful version retrieval."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "1.2.3"
+
+        with patch("subprocess.run", return_value=mock_result):
+            version = get_cli_version(Path("/usr/bin/tool"))
+
+        assert version == "1.2.3"
+
+    def test_returns_unknown_on_empty_output(self) -> None:
+        """Test returns 'unknown' when output is empty."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            version = get_cli_version(Path("/usr/bin/tool"))
+
+        assert version == "unknown"
+
+    def test_returns_unknown_on_whitespace_output(self) -> None:
+        """Test returns 'unknown' when output is only whitespace."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "   \n\t  "
+
+        with patch("subprocess.run", return_value=mock_result):
+            version = get_cli_version(Path("/usr/bin/tool"))
+
+        assert version == "unknown"
+
+    def test_returns_unknown_on_exception(self) -> None:
+        """Test returns 'unknown' when subprocess raises exception."""
+        with patch("subprocess.run", side_effect=OSError("Command not found")):
+            version = get_cli_version(Path("/usr/bin/nonexistent"))
+
+        assert version == "unknown"
+
+    def test_returns_unknown_on_timeout(self) -> None:
+        """Test returns 'unknown' when subprocess times out."""
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 30)):
+            version = get_cli_version(Path("/usr/bin/slow"))
+
+        assert version == "unknown"
+
+    def test_returns_unknown_on_nonzero_exit(self) -> None:
+        """Test returns 'unknown' when command exits with error."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            version = get_cli_version(Path("/usr/bin/failing"))
+
+        assert version == "unknown"
+
+    def test_uses_custom_parser(self) -> None:
+        """Test custom parser function is used."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Version 2.0.0"
+
+        def extract_version(s: str) -> str:
+            return s.split()[1]
+
+        with patch("subprocess.run", return_value=mock_result):
+            version = get_cli_version(Path("/usr/bin/tool"), parser=extract_version)
+
+        assert version == "2.0.0"
+
+    def test_returns_unknown_when_parser_returns_empty(self) -> None:
+        """Test returns 'unknown' when parser returns empty string."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "invalid output"
+
+        def bad_parser(s: str) -> str:
+            return ""  # Always returns empty
+
+        with patch("subprocess.run", return_value=mock_result):
+            version = get_cli_version(Path("/usr/bin/tool"), parser=bad_parser)
+
+        assert version == "unknown"
+
+
+class TestResolveSrcPaths:
+    """Tests for resolve_src_paths function."""
+
+    def test_returns_context_paths_when_provided(self) -> None:
+        """Test that explicit context paths are returned as-is."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            context_paths = [
+                project_root / "file1.py",
+                project_root / "file2.py",
+            ]
+
+            result = resolve_src_paths(context_paths, project_root)
+
+            assert len(result) == 2
+            assert result[0].endswith("file1.py")
+            assert result[1].endswith("file2.py")
+
+    def test_returns_src_dir_when_exists(self) -> None:
+        """Test fallback to src directory when it exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_dir = project_root / "src"
+            src_dir.mkdir()
+
+            result = resolve_src_paths(None, project_root)
+
+            assert len(result) == 1
+            assert result[0].endswith("src")
+
+    def test_returns_dot_when_src_not_exists(self) -> None:
+        """Test fallback to '.' when src directory doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            # Don't create src directory
+
+            result = resolve_src_paths(None, project_root)
+
+            assert result == ["."]
+
+    def test_uses_custom_default_subdir(self) -> None:
+        """Test custom default subdirectory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            lib_dir = project_root / "lib"
+            lib_dir.mkdir()
+
+            result = resolve_src_paths(None, project_root, default_subdir="lib")
+
+            assert len(result) == 1
+            assert result[0].endswith("lib")
+
+    def test_empty_context_paths_treated_as_none(self) -> None:
+        """Test that empty context paths list falls back to default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_dir = project_root / "src"
+            src_dir.mkdir()
+
+            # Empty list should fall back to src directory
+            result = resolve_src_paths([], project_root)
+
+            # Empty list is falsy, so should fall back
+            assert result == ["."] or result[0].endswith("src")

--- a/tests/unit/plugins/type_checkers/test_spotbugs.py
+++ b/tests/unit/plugins/type_checkers/test_spotbugs.py
@@ -1,0 +1,302 @@
+"""Unit tests for SpotBugs type checker plugin."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lucidshark.core.models import Severity, ToolDomain
+from lucidshark.plugins.type_checkers.spotbugs import SpotBugsChecker
+
+
+class TestSpotBugsChecker:
+    """Tests for SpotBugsChecker class."""
+
+    def test_name(self) -> None:
+        """Test plugin name."""
+        checker = SpotBugsChecker()
+        assert checker.name == "spotbugs"
+
+    def test_languages(self) -> None:
+        """Test supported languages."""
+        checker = SpotBugsChecker()
+        assert checker.languages == ["java"]
+
+    def test_domain(self) -> None:
+        """Test domain is TYPE_CHECKING."""
+        checker = SpotBugsChecker()
+        assert checker.domain == ToolDomain.TYPE_CHECKING
+
+    def test_supports_strict_mode(self) -> None:
+        """Test strict mode support."""
+        checker = SpotBugsChecker()
+        assert checker.supports_strict_mode is True
+
+
+class TestSpotBugsJavaDetection:
+    """Tests for Java detection logic."""
+
+    @patch("shutil.which")
+    def test_check_java_available(self, mock_which) -> None:
+        """Test Java detection when available."""
+        mock_which.return_value = "/usr/bin/java"
+        checker = SpotBugsChecker()
+        java_path = checker._check_java_available()
+        assert java_path == Path("/usr/bin/java")
+
+    @patch("shutil.which")
+    def test_check_java_not_available(self, mock_which) -> None:
+        """Test Java detection when not available."""
+        mock_which.return_value = None
+        checker = SpotBugsChecker()
+        java_path = checker._check_java_available()
+        assert java_path is None
+
+    @patch("shutil.which")
+    def test_ensure_binary_no_java_raises(self, mock_which) -> None:
+        """Test ensure_binary raises when Java not available."""
+        mock_which.return_value = None
+        checker = SpotBugsChecker()
+
+        with pytest.raises(FileNotFoundError) as exc:
+            checker.ensure_binary()
+
+        assert "Java is not installed" in str(exc.value)
+
+
+class TestSpotBugsClassDirectoryFinding:
+    """Tests for finding compiled class directories."""
+
+    def test_find_maven_class_directories(self) -> None:
+        """Test finding Maven target/classes directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            target_classes = project_root / "target" / "classes"
+            target_classes.mkdir(parents=True)
+
+            checker = SpotBugsChecker()
+            class_dirs = checker._find_class_directories(project_root)
+
+            assert target_classes in class_dirs
+
+    def test_find_gradle_class_directories(self) -> None:
+        """Test finding Gradle build/classes directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            build_classes = project_root / "build" / "classes" / "java" / "main"
+            build_classes.mkdir(parents=True)
+
+            checker = SpotBugsChecker()
+            class_dirs = checker._find_class_directories(project_root)
+
+            assert build_classes in class_dirs
+
+    def test_find_multi_module_class_directories(self) -> None:
+        """Test finding class directories in multi-module project."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            module_classes = project_root / "module-a" / "target" / "classes"
+            module_classes.mkdir(parents=True)
+
+            checker = SpotBugsChecker()
+            class_dirs = checker._find_class_directories(project_root)
+
+            assert module_classes in class_dirs
+
+    def test_no_class_directories(self) -> None:
+        """Test empty list when no class directories found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            checker = SpotBugsChecker()
+            class_dirs = checker._find_class_directories(project_root)
+
+            assert class_dirs == []
+
+
+class TestSpotBugsSourceDirectoryFinding:
+    """Tests for finding source directories."""
+
+    def test_find_standard_source_directory(self) -> None:
+        """Test finding src/main/java directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_main_java = project_root / "src" / "main" / "java"
+            src_main_java.mkdir(parents=True)
+
+            checker = SpotBugsChecker()
+            source_dirs = checker._find_source_directories(project_root)
+
+            assert src_main_java in source_dirs
+
+
+class TestSpotBugsXmlParsing:
+    """Tests for SpotBugs XML output parsing."""
+
+    def test_parse_xml_with_bugs(self) -> None:
+        """Test parsing SpotBugs XML output with bugs."""
+        checker = SpotBugsChecker()
+
+        xml_output = """<?xml version="1.0" encoding="UTF-8"?>
+<BugCollection version="4.8.6" timestamp="1704067200000">
+    <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" rank="5" category="CORRECTNESS">
+        <ShortMessage>Possible null pointer dereference</ShortMessage>
+        <LongMessage>Possible null pointer dereference of user in method processUser</LongMessage>
+        <SourceLine classname="com.example.UserService" start="42" end="42"
+                    sourcepath="com/example/UserService.java"/>
+    </BugInstance>
+    <BugInstance type="DM_STRING_VOID_CTOR" priority="2" rank="15" category="PERFORMANCE">
+        <ShortMessage>String constructor creates unnecessary object</ShortMessage>
+        <LongMessage>Method creates unnecessary String object</LongMessage>
+        <SourceLine classname="com.example.Utils" start="15" end="15"
+                    sourcepath="com/example/Utils.java"/>
+    </BugInstance>
+</BugCollection>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_main_java = project_root / "src" / "main" / "java"
+            src_main_java.mkdir(parents=True)
+
+            issues = checker._parse_output(xml_output, project_root, [src_main_java])
+
+            assert len(issues) == 2
+
+            # First issue (high priority, low rank = HIGH severity)
+            issue1 = issues[0]
+            assert issue1.rule_id == "NP_NULL_ON_SOME_PATH"
+            assert issue1.severity == Severity.HIGH
+            assert issue1.domain == ToolDomain.TYPE_CHECKING
+            assert issue1.source_tool == "spotbugs"
+            assert issue1.line_start == 42
+
+            # Second issue (medium priority, high rank = MEDIUM severity)
+            issue2 = issues[1]
+            assert issue2.rule_id == "DM_STRING_VOID_CTOR"
+            assert issue2.severity == Severity.MEDIUM
+
+    def test_parse_xml_no_bugs(self) -> None:
+        """Test parsing SpotBugs XML output with no bugs."""
+        checker = SpotBugsChecker()
+
+        xml_output = """<?xml version="1.0" encoding="UTF-8"?>
+<BugCollection version="4.8.6" timestamp="1704067200000">
+</BugCollection>
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            issues = checker._parse_output(xml_output, project_root, [])
+
+            assert len(issues) == 0
+
+    def test_parse_empty_output(self) -> None:
+        """Test parsing empty output."""
+        checker = SpotBugsChecker()
+        issues = checker._parse_output("", Path("/tmp"), [])
+        assert len(issues) == 0
+
+    def test_parse_no_xml_in_output(self) -> None:
+        """Test parsing output without XML."""
+        checker = SpotBugsChecker()
+        issues = checker._parse_output("Some text without XML", Path("/tmp"), [])
+        assert len(issues) == 0
+
+
+class TestSpotBugsSeverityMapping:
+    """Tests for priority/rank to severity mapping."""
+
+    def test_priority_1_high_severity(self) -> None:
+        """Test priority 1 maps to HIGH severity."""
+        checker = SpotBugsChecker()
+
+        xml_output = """<?xml version="1.0" encoding="UTF-8"?>
+<BugCollection>
+    <BugInstance type="TEST" priority="1" rank="10" category="CORRECTNESS">
+        <LongMessage>Test message</LongMessage>
+    </BugInstance>
+</BugCollection>
+        """
+
+        issues = checker._parse_output(xml_output, Path("/tmp"), [])
+        assert issues[0].severity == Severity.HIGH
+
+    def test_priority_2_medium_severity(self) -> None:
+        """Test priority 2 maps to MEDIUM severity."""
+        checker = SpotBugsChecker()
+
+        xml_output = """<?xml version="1.0" encoding="UTF-8"?>
+<BugCollection>
+    <BugInstance type="TEST" priority="2" rank="15" category="PERFORMANCE">
+        <LongMessage>Test message</LongMessage>
+    </BugInstance>
+</BugCollection>
+        """
+
+        issues = checker._parse_output(xml_output, Path("/tmp"), [])
+        assert issues[0].severity == Severity.MEDIUM
+
+    def test_priority_3_low_severity(self) -> None:
+        """Test priority 3 maps to LOW severity."""
+        checker = SpotBugsChecker()
+
+        xml_output = """<?xml version="1.0" encoding="UTF-8"?>
+<BugCollection>
+    <BugInstance type="TEST" priority="3" rank="18" category="STYLE">
+        <LongMessage>Test message</LongMessage>
+    </BugInstance>
+</BugCollection>
+        """
+
+        issues = checker._parse_output(xml_output, Path("/tmp"), [])
+        assert issues[0].severity == Severity.LOW
+
+    def test_low_rank_upgrades_severity(self) -> None:
+        """Test low rank (scary) upgrades severity to HIGH."""
+        checker = SpotBugsChecker()
+
+        # Priority 3 (LOW) but rank 3 (very scary) should upgrade to HIGH
+        xml_output = """<?xml version="1.0" encoding="UTF-8"?>
+<BugCollection>
+    <BugInstance type="TEST" priority="3" rank="3" category="SECURITY">
+        <LongMessage>Test message</LongMessage>
+    </BugInstance>
+</BugCollection>
+        """
+
+        issues = checker._parse_output(xml_output, Path("/tmp"), [])
+        assert issues[0].severity == Severity.HIGH
+
+
+class TestSpotBugsIssueIdGeneration:
+    """Tests for deterministic issue ID generation."""
+
+    def test_same_input_same_id(self) -> None:
+        """Test same input produces same ID."""
+        checker = SpotBugsChecker()
+
+        id1 = checker._generate_issue_id("NP_NULL", "file.java", 42, "message")
+        id2 = checker._generate_issue_id("NP_NULL", "file.java", 42, "message")
+
+        assert id1 == id2
+
+    def test_different_input_different_id(self) -> None:
+        """Test different input produces different ID."""
+        checker = SpotBugsChecker()
+
+        id1 = checker._generate_issue_id("NP_NULL", "file.java", 42, "message")
+        id2 = checker._generate_issue_id("NP_NULL", "other.java", 42, "message")
+
+        assert id1 != id2
+
+    def test_id_format(self) -> None:
+        """Test ID format starts with spotbugs-."""
+        checker = SpotBugsChecker()
+
+        issue_id = checker._generate_issue_id("NP_NULL", "file.java", 42, "msg")
+
+        assert issue_id.startswith("spotbugs-NP_NULL-")


### PR DESCRIPTION
- Add JaCoCo coverage plugin with multi-strategy Maven execution
- Add Maven test runner plugin for JUnit/TestNG tests
- Add SpotBugs static analysis plugin
- Add extra_args config option for coverage (Java-specific Maven args)
- Add language auto-detection to filter plugins by project language
- Update documentation with Java coverage examples and extra_args usage
- Add unit and integration tests for all Java plugins
- Add java-webapp test project fixture