### PR TITLE
Fix install scripts: unbound variable bug and local install path

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@
     Install globally to %LOCALAPPDATA%\Programs\lucidshark
 
 .PARAMETER Local
-    Install locally to .lucidshark\bin in current directory
+    Install locally to current directory
 
 .PARAMETER Version
     Specific version to install (e.g., v0.5.17)
@@ -102,9 +102,9 @@ function Main {
         Write-Host "      - Available system-wide"
         Write-Host "      - Added to user PATH"
         Write-Host ""
-        Write-Host "  [2] This project (.lucidshark\bin)"
+        Write-Host "  [2] This project (current directory)"
         Write-Host "      - Project-specific installation"
-        Write-Host "      - Auto-detected by LucidShark"
+        Write-Host "      - Binary placed in project root"
         Write-Host ""
 
         $choice = Read-Host "Choice [1/2]"
@@ -121,7 +121,7 @@ function Main {
         $installDir = Join-Path $env:LOCALAPPDATA "Programs\lucidshark"
     }
     else {
-        $installDir = Join-Path (Get-Location) ".lucidshark\bin"
+        $installDir = Get-Location
     }
 
     # Create install directory
@@ -180,10 +180,7 @@ function Main {
         Write-Host "Run: lucidshark --help"
     }
     else {
-        Write-Host "Run: .lucidshark\bin\lucidshark.exe --help"
-        Write-Host ""
-        Write-Host "Or set LUCIDSHARK_HOME for global access:"
-        Write-Host "  `$env:LUCIDSHARK_HOME = `"$(Get-Location)\.lucidshark`""
+        Write-Host "Run: .\lucidshark.exe --help"
     }
     Write-Host ""
 }

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # Configuration
 REPO="lucidshark-code/lucidshark"
 BINARY_NAME="lucidshark"
+TMP_FILE=""
 
 # Colors for output
 RED='\033[0;31m'
@@ -104,7 +105,7 @@ main() {
                 echo ""
                 echo "Options:"
                 echo "  --global, -g     Install globally to ~/.local/bin"
-                echo "  --local, -l      Install locally to .lucidshark/bin"
+                echo "  --local, -l      Install locally to current directory"
                 echo "  --version, -v    Install specific version (e.g., v0.5.17)"
                 echo "  --help, -h       Show this help message"
                 exit 0
@@ -150,9 +151,9 @@ main() {
         echo "      - Available system-wide"
         echo "      - May require adding to PATH"
         echo ""
-        echo "  [2] This project (.lucidshark/bin)"
+        echo "  [2] This project (current directory)"
         echo "      - Project-specific installation"
-        echo "      - Auto-detected by LucidShark"
+        echo "      - Binary placed in project root"
         echo ""
 
         local choice
@@ -169,7 +170,7 @@ main() {
     if [[ "$install_mode" == "global" ]]; then
         install_dir="${HOME}/.local/bin"
     else
-        install_dir=".lucidshark/bin"
+        install_dir="."
     fi
 
     # Create install directory
@@ -183,17 +184,16 @@ main() {
     info "Downloading ${binary_name}..."
 
     # Create temp file for download
-    local tmp_file
-    tmp_file="$(mktemp)"
-    trap 'rm -f "$tmp_file"' EXIT
+    TMP_FILE="$(mktemp)"
+    trap 'rm -f "$TMP_FILE"' EXIT
 
-    if ! download "$download_url" "$tmp_file"; then
+    if ! download "$download_url" "$TMP_FILE"; then
         error "Failed to download binary from: $download_url"
     fi
 
     # Install binary
     info "Installing to ${install_path}..."
-    mv "$tmp_file" "$install_path"
+    mv "$TMP_FILE" "$install_path"
     chmod +x "$install_path"
 
     echo ""
@@ -225,10 +225,7 @@ main() {
         fi
         echo "Run: lucidshark --help"
     else
-        echo "Run: .lucidshark/bin/lucidshark --help"
-        echo ""
-        echo "Or set LUCIDSHARK_HOME for global access:"
-        echo "  export LUCIDSHARK_HOME=\"$(pwd)/.lucidshark\""
+        echo "Run: ./lucidshark --help"
     fi
     echo ""
 }


### PR DESCRIPTION
- Fix unbound variable error in install.sh by making TMP_FILE a global variable instead of local (trap runs after main() exits)
- Change local install to place binary in project root instead of .lucidshark/bin for both Unix and Windows installers