### PR TITLE
feat: install scripts auto-configure shell with local-first binary re…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.23"
+version = "0.5.24"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
…solution

Install scripts now add a shell function that:
- Checks for ./lucidshark in current directory first (project-local version)
- Falls back to global installation if no local version exists

This allows users to have different versions per project while still running `lucidshark` without the `./` prefix.

Supports bash, zsh, fish (Linux/macOS) and PowerShell (Windows).