### PR TITLE
docs: comprehensive documentation review and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ lucidshark scan --preset typescript-minimal
 
 | Preset | Best For | Includes |
 |--------|----------|----------|
-| `python-strict` | Production Python | Ruff, mypy (strict), pytest, 80% coverage, security, duplication |
+| `python-strict` | Production Python | Ruff, mypy (strict), pytest, 80% coverage, security, duplication (5%) |
 | `python-minimal` | Quick Python setup | Ruff, mypy, security |
-| `typescript-strict` | Production TS/React | ESLint, TypeScript, Jest, security |
+| `typescript-strict` | Production TS/React | ESLint, TypeScript, Jest, 80% coverage, security |
 | `typescript-minimal` | Quick TS setup | ESLint, TypeScript, security |
 | `minimal` | Any project | Security only (Trivy + OpenGrep) |
 
@@ -248,9 +248,12 @@ ignore:
 lucidshark init --claude-code             # Configure Claude Code
 lucidshark init --cursor                  # Configure Cursor
 lucidshark init --all                     # Configure all AI tools
+lucidshark init --remove --claude-code    # Remove LucidShark from Claude Code
+lucidshark init --dry-run --all           # Preview changes without applying
+lucidshark init --force --all             # Overwrite existing configuration
 
 # Auto-configure project (detect languages, generate lucidshark.yml)
-lucidshark autoconfigure [--ci github|gitlab|bitbucket] [--non-interactive]
+lucidshark autoconfigure [--non-interactive] [--force] [path]
 
 # Run quality pipeline
 lucidshark scan [--linting] [--type-checking] [--sca] [--sast] [--iac] [--container] [--testing] [--coverage] [--duplication] [--all]
@@ -258,6 +261,16 @@ lucidshark scan [--fix] [--stream] [--format table|json|sarif|summary]
 lucidshark scan [--fail-on critical|high|medium|low]
 lucidshark scan [--preset python-strict|python-minimal|typescript-strict|typescript-minimal|minimal]
 lucidshark scan [--dry-run]               # Preview what would be scanned
+lucidshark scan [--files FILE ...]        # Scan specific files
+lucidshark scan [--all-files]             # Scan entire project (not just changed files)
+lucidshark scan [--image IMAGE]           # Scan container image (with --container)
+lucidshark scan [--config PATH]           # Use specific config file
+lucidshark scan [--sequential]            # Disable parallel execution (debugging)
+lucidshark scan [--coverage-threshold N]  # Override coverage threshold
+lucidshark scan [--duplication-threshold N] # Override duplication threshold
+
+# Validate configuration
+lucidshark validate [--config PATH]       # Validate lucidshark.yml
 
 # Server mode
 lucidshark serve --mcp                    # Run MCP server
@@ -265,7 +278,13 @@ lucidshark serve --watch                  # Watch mode with auto-checking
 
 # Diagnostics
 lucidshark doctor                         # Check setup and environment health
-lucidshark status [--tools]               # Show configuration and tool status
+lucidshark status [--tools] [--config]    # Show configuration and tool status
+
+# Help
+lucidshark help                           # Show LLM-friendly documentation
+lucidshark --version                      # Show version
+lucidshark --debug                        # Enable debug logging
+lucidshark --verbose                      # Enable verbose logging
 ```
 
 ## Exit Codes

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,26 +9,27 @@ LucidShark unifies code quality tools (linting, type checking, security, testing
 ## Roadmap Overview
 
 ```
-    v0.1-v0.5         v0.5.x            v0.6-v0.8           v0.9              v1.0
+    v0.1-v0.5         v0.5.25           v0.6-v0.8           v0.9              v1.0
         |               |                  |                 |                 |
    ─────●───────────────●──────────────────●─────────────────●─────────────────●─────
         |               |                  |                 |                 |
     COMPLETE        COMPLETE           Language           CI/CD           Production
                    Partial+Java        Expansion        Integration           Ready
+                   DX+Presets
 
   ┌─────────────┐ ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
   │ Core        │ │ Git-aware   │  │ 5 Languages │  │ GitHub      │  │ Docs        │
   │ Security    │ │ Partial     │  │ Go, C#      │  │ Actions     │  │ Performance │
-  │ MCP Server  │ │ SpotBugs    │  │ More tools  │  │ GitLab CI   │  │ Stability   │
-  │ AI Tools    │ │ Maven+JaCoCo│  │             │  │             │  │             │
+  │ MCP Server  │ │ Java tools  │  │ More tools  │  │ GitLab CI   │  │ Stability   │
+  │ AI Tools    │ │ DX tooling  │  │             │  │             │  │             │
   └─────────────┘ └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘
 ```
 
 ---
 
-## Completed (v0.1 - v0.5.x)
+## Completed (v0.1 - v0.5.25)
 
-All foundational work is complete. LucidShark is a fully functional code quality platform with AI integration, partial scanning, and full Java support.
+All foundational work is complete. LucidShark is a fully functional code quality platform with AI integration, partial scanning, full Java support, binary distribution, and developer experience tooling.
 
 ### What's Built
 
@@ -41,9 +42,13 @@ All foundational work is complete. LucidShark is a fully functional code quality
 | **Testing** | pytest (Python), Jest (JS/TS), Karma (Angular), Playwright (E2E), Maven/Gradle (Java) |
 | **Coverage** | coverage.py (Python), Istanbul (JS/TS), JaCoCo (Java) |
 | **Duplication** | Duplo (multi-language code clone detection) |
-| **AI Integration** | MCP server, file watcher, structured AI instructions |
+| **AI Integration** | MCP server, file watcher, Claude Code skill, structured AI instructions |
 | **Output** | JSON, Table, SARIF, Summary reporters |
 | **Partial Scanning** | Git-aware scanning (changed files only by default) |
+| **Presets** | python-strict, python-minimal, typescript-strict, typescript-minimal, minimal |
+| **DX Tooling** | Dry-run mode, doctor command, validate command, streaming output |
+| **Distribution** | PyPI package, standalone binary (macOS, Linux), install scripts with shell integration |
+| **Tool Bootstrap** | Automatic download and management of tool binaries (Trivy, OpenGrep, Ruff, Biome, etc.) |
 
 ### Current Language Support
 
@@ -63,15 +68,20 @@ lucidshark scan --all                 # Run complete pipeline
 lucidshark scan --linting --fix       # Lint with auto-fix
 lucidshark scan --type-checking       # Type checking
 lucidshark scan --testing --coverage  # Tests with coverage
+lucidshark scan --preset python-strict  # Scan with a preset
+lucidshark scan --dry-run --all       # Preview what would run
 lucidshark serve --mcp                # MCP server for AI tools
 lucidshark status                     # Show tool status
+lucidshark doctor                     # Check setup health
+lucidshark validate                   # Validate lucidshark.yml
+lucidshark help                       # Show LLM-friendly docs
 ```
 
 ---
 
-## Completed - Partial Scans (Git-Aware Scanning) ✅
+## Completed - Partial Scans (Git-Aware Scanning)
 
-**Status**: IMPLEMENTED in v0.5.x
+**Status**: IMPLEMENTED in v0.5.x (current: v0.5.25)
 
 LucidShark now defaults to scanning only changed files (uncommitted changes).
 
@@ -136,7 +146,7 @@ scan(domains=["linting"], files=["src/foo.py"])
 |----------|---------|---------------|---------|----------|
 | **Python** | Ruff, Flake8 | mypy, pyright | pytest, unittest | coverage.py |
 | **JS/TS** | ESLint, Biome | TypeScript (tsc) | Jest, Vitest | Istanbul, c8 |
-| **Java** | Checkstyle, SpotBugs | (compiler) | JUnit, TestNG | JaCoCo, Cobertura |
+| **Java** | Checkstyle | SpotBugs | JUnit (Maven/Gradle), TestNG | JaCoCo, Cobertura |
 | **Go** | golangci-lint, staticcheck | (compiler) | go test, testify | go cover |
 | **C#** | StyleCop, Roslyn | (compiler) | xUnit, NUnit | Coverlet, dotCover |
 
@@ -155,9 +165,6 @@ scan(domains=["linting"], files=["src/foo.py"])
 
 | Task | Status |
 |------|--------|
-| SpotBugs type checker plugin | ✅ Complete |
-| Maven/Gradle test runner plugin | ✅ Complete |
-| JaCoCo coverage plugin | ✅ Complete |
 | Go language detection | Planned |
 | golangci-lint plugin | Planned |
 | staticcheck plugin | Planned |
@@ -165,6 +172,8 @@ scan(domains=["linting"], files=["src/foo.py"])
 | go cover integration | Planned |
 | TestNG test runner plugin | Planned |
 | Cobertura coverage plugin | Planned |
+
+> **Note**: SpotBugs, Maven/Gradle test runner, and JaCoCo plugins were originally planned for v0.7 but shipped early in v0.5.x.
 
 #### v0.8 - Add C#
 
@@ -249,7 +258,7 @@ jobs:
 | **Documentation** | Complete user guide, API reference, plugin development guide |
 | **Performance** | Incremental checking, result caching, parallel execution |
 | **Stability** | Error handling, graceful degradation, clear error messages |
-| **Distribution** | PyPI, Docker image, Homebrew formula |
+| **Distribution** | Docker image, Homebrew formula (PyPI and standalone binary already available) |
 
 ### Success Criteria
 
@@ -266,7 +275,7 @@ Beyond v1.0, potential directions include:
 
 | Direction | Description |
 |-----------|-------------|
-| **More languages** | Rust, PHP, Kotlin, Swift |
+| **More languages** | Rust, PHP, Swift (Kotlin partially supported via Java tooling) |
 | **VS Code extension** | Native IDE integration beyond MCP |
 | **Team features** | Shared configs, policy enforcement, dashboards |
 | **Custom rules** | User-defined linting and security rules |
@@ -281,7 +290,11 @@ These are not committed - they depend on user feedback and adoption.
 | Version | Status | Highlights |
 |---------|--------|------------|
 | v0.1-v0.5 | ✅ Complete | Core framework, security scanning, linting, type checking, testing, coverage, MCP server, AI integration |
-| v0.5.x | ✅ Complete | Partial scans (git-aware), full Java support (SpotBugs, Maven/Gradle, JaCoCo), duplication detection |
+| v0.5.12-v0.5.13 | ✅ Complete | Centralized tool version management, streaming support, duplication detection (Duplo) |
+| v0.5.19 | ✅ Complete | Binary distribution (standalone macOS/Linux builds), Checkov standalone binary, Windows compatibility |
+| v0.5.22 | ✅ Complete | DX improvements: dry-run mode, doctor command, presets, Claude Code skill auto-generation |
+| v0.5.25 | ✅ Complete | SSL certificate fixes for macOS binary, install scripts with shell integration, local binary detection for MCP |
+| v0.5.x | ✅ Complete | Partial scans (git-aware), full Java support (SpotBugs, Maven/Gradle, JaCoCo), config validation |
 | v0.6 | Planned | Complete Python (Flake8, unittest) and JS/TS (Vitest, c8) tool coverage |
 | v0.7 | Planned | Add Go support (golangci-lint, staticcheck, go test, go cover) |
 | v0.8 | Planned | Add C# support (StyleCop, Roslyn, xUnit, NUnit, Coverlet, dotCover) |


### PR DESCRIPTION
## Summary

Two-phase documentation and DX improvement effort:

1. **Phase 1 — Documentation Review**: 5 agents reviewed all doc files against the actual codebase (v0.5.25), fixing inaccuracies and adding missing content
2. **Phase 2 — DX Audit**: A DX expert audited the entire project, identifying 9 improvements implemented by 4 specialized agents

**Total: 1,927 lines added, 371 removed across 17 files (5 docs, 2 new guides, 4 source files, 2 test files)**

---

## Phase 1: Documentation Review (792 insertions, 183 deletions)

### README.md
- Added missing CLI commands (`validate`, `help`) and global options
- Fixed scan command flags, removed phantom `--ci` flag
- Updated preset descriptions

### docs/help.md
- Added `lucidshark doctor` command (was entirely missing)
- Fixed AI Tool Setup paths (skill file, executable detection)
- Added Global Options section

### docs/main.md
- Rewrote Plugin Interface to document all 7 actual ABCs
- Updated MCP Server from stale 4-tool to actual 8-tool API
- Added Presets and Module Structure sections

### docs/roadmap.md
- Fixed SpotBugs classification (type checker, not linter)
- Expanded changelog with v0.5.12-v0.5.25 entries

### docs/ignore-patterns.md
- Added 7 undocumented tools (Biome, Checkstyle, Pyright, SpotBugs, Playwright, Karma, Maven)
- Fixed Ruff flag from `--exclude` to `--extend-exclude`

---

## Phase 2: DX Improvements (1,135 insertions, 188 deletions)

### Bug Fixes
- **Fix doctor/init MCP path mismatch**: `init --claude-code` writes `.mcp.json` but `doctor` only checked `.claude/mcp_servers.json` — now checks both
- **Better scan error messages**: When no config found, suggests `autoconfigure` and presets instead of cryptic "no domains selected"

### Code Improvements
- **Domain-aware table reporter**: Uses `FILE:LINE | RULE` for linting, `DEPENDENCY` only for SCA — no more empty columns
- **Better summary reporter**: "All checks passed. No issues found." instead of "No summary available"

### Documentation
- **Sample output in README**: Shows what scan results look like before installing
- **Shorter README**: 348 → 242 lines — condensed CLI ref, linked to help.md
- **6 config examples in help.md**: Copy-paste-ready configs for Python, TypeScript, Java, security-only
- **Getting Started guides**: New `docs/guide-python.md` (310 lines) and `docs/guide-typescript.md` (360 lines)
- **Unified tagline**: "Unified code quality pipeline" across CLI and docs

## Test plan

- [x] All 1,098 unit tests pass
- [x] Linting: 0 issues
- [x] Type checking: 0 issues
- [ ] Verify CLI `--help` output matches docs
- [ ] Verify `lucidshark doctor` detects `.mcp.json`
- [ ] Spot-check getting started guides for accuracy
- [ ] Review rendered markdown for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)