### PR TITLE
fix: resolve CI pipeline failures across all platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.28"
+version = "0.5.29"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lucidshark/cli/commands/init.py
+++ b/src/lucidshark/cli/commands/init.py
@@ -503,7 +503,7 @@ class InitCommand(Command):
         skill_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            skill_file.write_text(LUCIDSHARK_SKILL_CONTENT.lstrip())
+            skill_file.write_text(LUCIDSHARK_SKILL_CONTENT.lstrip(), encoding="utf-8")
             print(f"  Created lucidshark skill at {skill_file}")
             return True
         except Exception as e:
@@ -553,7 +553,7 @@ class InitCommand(Command):
 
         rules_dir.mkdir(parents=True, exist_ok=True)
         try:
-            rules_file.write_text(LUCIDSHARK_CURSOR_RULES.lstrip())
+            rules_file.write_text(LUCIDSHARK_CURSOR_RULES.lstrip(), encoding="utf-8")
             print(f"  Created {rules_file}")
             return True
         except Exception as e:

--- a/src/lucidshark/plugins/reporters/sarif_reporter.py
+++ b/src/lucidshark/plugins/reporters/sarif_reporter.py
@@ -228,8 +228,8 @@ class SARIFReporter(ReporterPlugin):
         if not issue.file_path:
             return None
 
-        # Use relative path for SARIF (strip leading slash if present)
-        file_uri = str(issue.file_path)
+        # Use forward slashes for SARIF URIs (per SARIF spec)
+        file_uri = issue.file_path.as_posix()
         if file_uri.startswith("/"):
             # Try to make it relative - just use the path as-is for now
             # In practice, the path should already be relative or project-relative

--- a/src/lucidshark/plugins/reporters/table_reporter.py
+++ b/src/lucidshark/plugins/reporters/table_reporter.py
@@ -111,7 +111,7 @@ class TableReporter(ReporterPlugin):
 
         for issue in issues:
             sev = issue.severity.value.upper()
-            location = str(issue.file_path or "")
+            location = issue.file_path.as_posix() if issue.file_path else ""
             if issue.line_start is not None:
                 location = f"{location}:{issue.line_start}"
             location = location[:35]

--- a/src/lucidshark/plugins/type_checkers/spotbugs.py
+++ b/src/lucidshark/plugins/type_checkers/spotbugs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import platform
 import shutil
 import subprocess
 from pathlib import Path
@@ -176,6 +177,9 @@ class SpotBugsChecker(TypeCheckerPlugin):
                     member_path = (install_dir / member.name).resolve()
                     if not str(member_path).startswith(str(install_dir.resolve())):
                         raise ValueError(f"Path traversal attempt: {member.name}")
+                    # Skip symlinks on Windows (unsupported in most environments)
+                    if platform.system() == "Windows" and (member.issym() or member.islnk()):
+                        continue
                     # Extract individual member safely
                     tar.extract(member, path=install_dir)
 

--- a/src/lucidshark/plugins/type_checkers/spotbugs.py
+++ b/src/lucidshark/plugins/type_checkers/spotbugs.py
@@ -7,6 +7,7 @@ https://spotbugs.github.io/
 from __future__ import annotations
 
 import hashlib
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -299,7 +300,7 @@ class SpotBugsChecker(TypeCheckerPlugin):
 
         # Add source path for better reporting
         if source_dirs:
-            cmd.extend(["-sourcepath", ":".join(str(d) for d in source_dirs)])
+            cmd.extend(["-sourcepath", os.pathsep.join(str(d) for d in source_dirs)])
 
         # Add auxiliary classpath if available (for better analysis)
         aux_classpath = self._find_aux_classpath(context.project_root)
@@ -355,7 +356,7 @@ class SpotBugsChecker(TypeCheckerPlugin):
             jars.extend(gradle_cache.glob("*.jar"))
 
         if jars:
-            return ":".join(str(j) for j in jars)
+            return os.pathsep.join(str(j) for j in jars)
         return None
 
     def _parse_output(

--- a/src/lucidshark/plugins/utils.py
+++ b/src/lucidshark/plugins/utils.py
@@ -231,7 +231,7 @@ def detect_source_directory(project_root: Path) -> Optional[str]:
         # Look for a package inside src/
         for child in src_dir.iterdir():
             if child.is_dir() and (child / "__init__.py").exists():
-                return str(child.relative_to(project_root))
+                return child.relative_to(project_root).as_posix()
         # Fallback to src/ itself
         return "src"
 

--- a/src/lucidshark/plugins/utils.py
+++ b/src/lucidshark/plugins/utils.py
@@ -8,11 +8,25 @@ from __future__ import annotations
 import hashlib
 import shutil
 import subprocess
+import sys
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from lucidshark.core.models import Severity, ToolDomain, UnifiedIssue
 from lucidshark.core.paths import resolve_node_bin
+
+# Import tomllib (Python 3.11+) or tomli (Python 3.10)
+try:
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        _tomllib: Any = tomllib
+    else:
+        import tomli  # type: ignore[import-untyped]
+
+        _tomllib = tomli
+except ImportError:
+    _tomllib = None
 
 
 def get_cli_version(
@@ -229,12 +243,10 @@ def detect_source_directory(project_root: Path) -> Optional[str]:
 
     # Check pyproject.toml for package configuration
     pyproject = project_root / "pyproject.toml"
-    if pyproject.exists():
+    if pyproject.exists() and _tomllib is not None:
         try:
-            import tomllib
-
             with open(pyproject, "rb") as f:
-                data = tomllib.load(f)
+                data = _tomllib.load(f)
             # Check [tool.setuptools.packages.find] where = [...]
             packages = (
                 data.get("tool", {}).get("setuptools", {}).get("packages", {})
@@ -271,12 +283,10 @@ def coverage_has_source_config(project_root: Path) -> bool:
     """
     # Check pyproject.toml [tool.coverage.run] source
     pyproject = project_root / "pyproject.toml"
-    if pyproject.exists():
+    if pyproject.exists() and _tomllib is not None:
         try:
-            import tomllib
-
             with open(pyproject, "rb") as f:
-                data = tomllib.load(f)
+                data = _tomllib.load(f)
             source = (
                 data.get("tool", {})
                 .get("coverage", {})

--- a/tests/integration/projects/conftest.py
+++ b/tests/integration/projects/conftest.py
@@ -346,6 +346,7 @@ def _setup_java_project(project_path: Path) -> Path:
         capture_output=True,
         text=True,
         timeout=120,
+        shell=sys.platform == "win32",
     )
 
     if result.returncode != 0:
@@ -376,6 +377,7 @@ def _run_java_tests(project_path: Path) -> Path:
         capture_output=True,
         text=True,
         timeout=180,
+        shell=sys.platform == "win32",
     )
 
     # Tests might fail, but we still want the reports

--- a/tests/integration/type_checkers/test_spotbugs_integration.py
+++ b/tests/integration/type_checkers/test_spotbugs_integration.py
@@ -8,11 +8,15 @@ Run with: pytest tests/integration/type_checkers/test_spotbugs_integration.py -v
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from lucidshark.core.models import ScanContext, ToolDomain
 from lucidshark.plugins.type_checkers.spotbugs import SpotBugsChecker
 from tests.integration.conftest import spotbugs_available, maven_available
+
+# Resolve mvn path for cross-platform subprocess calls (mvn.cmd on Windows)
+_MVN_CMD = shutil.which("mvn") or "mvn"
 
 
 class TestSpotBugsAvailability:
@@ -49,7 +53,7 @@ class TestSpotBugsTypeChecking:
 
         # First compile the project with Maven
         result = subprocess.run(
-            ["mvn", "compile", "-q"],
+            [_MVN_CMD, "compile", "-q"],
             cwd=java_webapp_project,
             capture_output=True,
             text=True,
@@ -86,7 +90,7 @@ class TestSpotBugsTypeChecking:
 
         # First compile the project with Maven
         result = subprocess.run(
-            ["mvn", "compile", "-q"],
+            [_MVN_CMD, "compile", "-q"],
             cwd=java_webapp_project,
             capture_output=True,
             text=True,
@@ -120,7 +124,7 @@ class TestSpotBugsIssueGeneration:
 
         # First compile the project with Maven
         result = subprocess.run(
-            ["mvn", "compile", "-q"],
+            [_MVN_CMD, "compile", "-q"],
             cwd=java_webapp_project,
             capture_output=True,
             text=True,

--- a/tests/integration/type_checkers/test_spotbugs_integration.py
+++ b/tests/integration/type_checkers/test_spotbugs_integration.py
@@ -9,6 +9,7 @@ Run with: pytest tests/integration/type_checkers/test_spotbugs_integration.py -v
 from __future__ import annotations
 
 import shutil
+import sys
 from pathlib import Path
 
 from lucidshark.core.models import ScanContext, ToolDomain
@@ -17,6 +18,8 @@ from tests.integration.conftest import spotbugs_available, maven_available
 
 # Resolve mvn path for cross-platform subprocess calls (mvn.cmd on Windows)
 _MVN_CMD = shutil.which("mvn") or "mvn"
+# On Windows, .cmd/.bat files must be run via cmd.exe (shell=True)
+_IS_WINDOWS = sys.platform == "win32"
 
 
 class TestSpotBugsAvailability:
@@ -58,6 +61,7 @@ class TestSpotBugsTypeChecking:
             capture_output=True,
             text=True,
             timeout=120,
+            shell=_IS_WINDOWS,
         )
 
         if result.returncode != 0:
@@ -95,6 +99,7 @@ class TestSpotBugsTypeChecking:
             capture_output=True,
             text=True,
             timeout=120,
+            shell=_IS_WINDOWS,
         )
 
         if result.returncode != 0:
@@ -129,6 +134,7 @@ class TestSpotBugsIssueGeneration:
             capture_output=True,
             text=True,
             timeout=120,
+            shell=_IS_WINDOWS,
         )
 
         if result.returncode != 0:

--- a/tests/unit/plugins/linters/test_biome.py
+++ b/tests/unit/plugins/linters/test_biome.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import platform
 import subprocess
 import tempfile
 from pathlib import Path
@@ -14,6 +15,8 @@ from lucidshark.plugins.linters.biome import (
     BiomeLinter,
     SEVERITY_MAP,
 )
+
+_BIOME_BINARY = "biome.exe" if platform.system() == "Windows" else "biome"
 
 
 def make_completed_process(returncode: int, stdout: str, stderr: str = "") -> subprocess.CompletedProcess:
@@ -171,7 +174,7 @@ class TestBiomeEnsureBinary:
                     with tempfile.TemporaryDirectory() as tmpdir:
                         bin_dir = Path(tmpdir) / "bin"
                         bin_dir.mkdir()
-                        binary = bin_dir / "biome"
+                        binary = bin_dir / _BIOME_BINARY
                         binary.touch()
                         mock_paths.plugin_bin_dir.return_value = bin_dir
 

--- a/tests/unit/plugins/scanners/test_checkov.py
+++ b/tests/unit/plugins/scanners/test_checkov.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +16,8 @@ from lucidshark.plugins.scanners.checkov import (
     CHECKOV_SEVERITY_MAP,
     _glob_to_regex,
 )
+
+_CHECKOV_BINARY = "checkov.exe" if sys.platform == "win32" else "checkov"
 
 
 def _make_completed_process(
@@ -120,7 +123,7 @@ class TestCheckovEnsureBinary:
     def test_binary_exists(self, scanner: CheckovScanner, tmp_path: Path) -> None:
         binary_dir = scanner._paths.plugin_bin_dir("checkov", "3.2.499")
         binary_dir.mkdir(parents=True, exist_ok=True)
-        binary = binary_dir / "checkov"
+        binary = binary_dir / _CHECKOV_BINARY
         binary.touch()
         result = scanner.ensure_binary()
         assert result == binary
@@ -130,12 +133,12 @@ class TestCheckovEnsureBinary:
             # After download, simulate binary existing
             def create_binary(dest_dir: Path) -> None:
                 dest_dir.mkdir(parents=True, exist_ok=True)
-                (dest_dir / "checkov").touch()
+                (dest_dir / _CHECKOV_BINARY).touch()
 
             mock_dl.side_effect = create_binary
             result = scanner.ensure_binary()
             mock_dl.assert_called_once()
-            assert result.name == "checkov"
+            assert result.name == _CHECKOV_BINARY
 
     def test_raises_when_download_fails(self, scanner: CheckovScanner) -> None:
         with patch.object(scanner, "_download_binary"):

--- a/tests/unit/plugins/test_runners/test_pytest.py
+++ b/tests/unit/plugins/test_runners/test_pytest.py
@@ -266,7 +266,7 @@ class TestBuildBaseCmd:
 
         cmd = runner._build_base_cmd(binary)
 
-        assert cmd == ["/usr/bin/pytest"]
+        assert cmd == [str(binary)]
 
     def test_with_coverage_wraps_with_coverage_run(self) -> None:
         """With coverage_binary, _build_base_cmd wraps pytest with 'coverage run -m pytest'."""
@@ -276,7 +276,7 @@ class TestBuildBaseCmd:
 
         cmd = runner._build_base_cmd(binary, coverage_binary)
 
-        assert cmd[0] == "/usr/bin/coverage"
+        assert cmd[0] == str(coverage_binary)
         assert "run" in cmd
         assert "-m" in cmd
         assert "pytest" in cmd
@@ -316,7 +316,7 @@ class TestBuildBaseCmd:
             )
 
             assert cmd == [
-                "/usr/bin/coverage",
+                str(cov),
                 "run",
                 "--source",
                 "src/mypackage",
@@ -347,7 +347,7 @@ class TestBuildBaseCmd:
 
             # Should NOT include --source since user already configured it
             assert "--source" not in cmd
-            assert cmd == ["/usr/bin/coverage", "run", "-m", "pytest"]
+            assert cmd == [str(cov), "run", "-m", "pytest"]
 
     def test_with_coverage_no_project_root_skips_source(self) -> None:
         """Test that --source is skipped when project_root is None."""
@@ -358,7 +358,7 @@ class TestBuildBaseCmd:
         cmd = runner._build_base_cmd(binary, coverage_binary=cov)
 
         assert "--source" not in cmd
-        assert cmd == ["/usr/bin/coverage", "run", "-m", "pytest"]
+        assert cmd == [str(cov), "run", "-m", "pytest"]
 
     def test_with_coverage_no_source_detected(self) -> None:
         """Test that --source is omitted when source dir cannot be detected."""
@@ -375,4 +375,4 @@ class TestBuildBaseCmd:
             )
 
             assert "--source" not in cmd
-            assert cmd == ["/usr/bin/coverage", "run", "-m", "pytest"]
+            assert cmd == [str(cov), "run", "-m", "pytest"]

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -345,7 +345,7 @@ class TestConfigureClaudeSkill:
 
         assert success
         assert skill_path.exists()
-        content = skill_path.read_text()
+        content = skill_path.read_text(encoding="utf-8")
         assert "LucidShark" in content
 
     def test_skips_if_already_configured(self, tmp_path: Path, capsys) -> None:
@@ -353,7 +353,7 @@ class TestConfigureClaudeSkill:
         cmd = InitCommand(version="1.0.0")
         skill_path = tmp_path / ".claude" / "skills" / "lucidshark" / "SKILL.md"
         skill_path.parent.mkdir(parents=True)
-        skill_path.write_text(LUCIDSHARK_SKILL_CONTENT)
+        skill_path.write_text(LUCIDSHARK_SKILL_CONTENT, encoding="utf-8")
 
         with patch.object(Path, "cwd", return_value=tmp_path):
             success = cmd._configure_claude_skill(dry_run=False, force=False, remove=False)
@@ -373,7 +373,7 @@ class TestConfigureClaudeSkill:
             success = cmd._configure_claude_skill(dry_run=False, force=True, remove=False)
 
         assert success
-        content = skill_path.read_text()
+        content = skill_path.read_text(encoding="utf-8")
         assert "Old skill content" not in content
         assert "LucidShark" in content
 
@@ -395,7 +395,7 @@ class TestConfigureClaudeSkill:
         cmd = InitCommand(version="1.0.0")
         skill_path = tmp_path / ".claude" / "skills" / "lucidshark" / "SKILL.md"
         skill_path.parent.mkdir(parents=True)
-        skill_path.write_text(LUCIDSHARK_SKILL_CONTENT)
+        skill_path.write_text(LUCIDSHARK_SKILL_CONTENT, encoding="utf-8")
 
         with patch.object(Path, "cwd", return_value=tmp_path):
             success = cmd._configure_claude_skill(dry_run=False, force=False, remove=True)

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -318,9 +318,10 @@ class TestSetupCursor:
             remove=False,
         )
 
-        with patch.object(cmd, "_get_cursor_config_path", return_value=config_path):
-            with patch.object(cmd, "_find_lucidshark_path", return_value="/usr/local/bin/lucidshark"):
-                exit_code = cmd.execute(args)
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            with patch.object(cmd, "_get_cursor_config_path", return_value=config_path):
+                with patch.object(cmd, "_find_lucidshark_path", return_value="/usr/local/bin/lucidshark"):
+                    exit_code = cmd.execute(args)
 
         assert exit_code == EXIT_SUCCESS
         assert config_path.exists()


### PR DESCRIPTION
## Summary

- **Python 3.10 compatibility fix**: `detect_source_directory()` and `coverage_has_source_config()` in `utils.py` used `import tomllib` (Python 3.11+ only) with no fallback to `tomli` backport. On Python 3.10, the import silently failed inside `try/except`, causing pyproject.toml parsing to be skipped entirely. This broke 6 tests across all platforms.

- **Windows path handling fixes**: 
  - SpotBugs plugin used hardcoded `":"` as Java classpath separator instead of `os.pathsep` (`;` on Windows), causing malformed paths
  - SARIF and table reporters used `str(Path)` for URI generation, producing backslashes on Windows instead of forward slashes (now uses `.as_posix()`)
  - Updated 7 test files to use platform-agnostic path assertions instead of hardcoded Unix paths

- **Version bump** to 0.5.29

## Test plan

- [x] All 1875 unit tests pass locally (0 failures, 1 skipped)
- [ ] CI pipeline passes on all platforms (Linux, macOS, Windows)
- [ ] CI pipeline passes on Python 3.10 and 3.11+
- [ ] Release pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)