### PR TITLE
feat: add per-domain exclude patterns to all pipeline domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ fail_on:
   linting: error
   security: high
   testing: any
-ignore: ["**/node_modules/**", "**/.venv/**"]
+exclude: ["**/node_modules/**", "**/.venv/**"]
 ```
 
 See [docs/help.md](docs/help.md) for the full configuration reference.
@@ -235,7 +235,7 @@ pytest tests/
 - [Getting Started: Python](docs/guide-python.md) - Step-by-step guide for Python projects
 - [Getting Started: TypeScript](docs/guide-typescript.md) - Step-by-step guide for TypeScript projects
 - [LLM Reference Documentation](docs/help.md) - For AI agents and detailed reference
-- [Ignore Patterns](docs/ignore-patterns.md) - Guide for excluding files and findings
+- [Exclude Patterns](docs/exclude-patterns.md) - Guide for exclude patterns and per-domain exclusions
 - [Full Specification](docs/main.md)
 - [Roadmap](docs/roadmap.md)
 

--- a/docs/guide-python.md
+++ b/docs/guide-python.md
@@ -118,7 +118,7 @@ fail_on:
   coverage: below_threshold
   duplication: above_threshold
 
-ignore:
+exclude:
   - "**/__pycache__/**"
   - "**/.venv/**"
   - "**/.pytest_cache/**"
@@ -128,7 +128,7 @@ ignore:
 Key sections:
 - **pipeline** -- Which tools to run. Each domain (linting, type checking, etc.) can be toggled independently.
 - **fail_on** -- When LucidShark should return a non-zero exit code. `error` means any linting error fails the scan; `high` means only high/critical security findings cause failure.
-- **ignore** -- Glob patterns for files to skip (gitignore-style syntax).
+- **exclude** -- Glob patterns for files to exclude (gitignore-style syntax).
 
 You can also skip the config file and use a preset instead:
 
@@ -278,7 +278,7 @@ def test_buggy():
 password = os.getenv("DB_PASS")  # nosemgrep: hardcoded-password
 ```
 
-See [Ignore Patterns](ignore-patterns.md) for the full reference.
+See [Exclude Patterns](exclude-patterns.md) for the full reference.
 
 ## Adding to CI
 
@@ -306,5 +306,5 @@ LucidShark exits with code `1` when issues exceed thresholds, which fails the CI
 ## Next Steps
 
 - [LLM Reference](help.md) -- Full CLI and configuration reference
-- [Ignore Patterns](ignore-patterns.md) -- Detailed guide for excluding files and findings
+- [Exclude Patterns](exclude-patterns.md) -- Detailed guide for exclude patterns and per-domain exclusions
 - [Full Specification](main.md) -- Architecture and design documentation

--- a/docs/guide-typescript.md
+++ b/docs/guide-typescript.md
@@ -132,7 +132,7 @@ fail_on:
   testing: any
   coverage: below_threshold
 
-ignore:
+exclude:
   - "**/node_modules/**"
   - "**/dist/**"
   - "**/build/**"
@@ -142,7 +142,7 @@ ignore:
 Key sections:
 - **pipeline** -- Which tools to run. Each domain can be toggled independently.
 - **fail_on** -- When LucidShark returns a non-zero exit code.
-- **ignore** -- Glob patterns for files to skip (gitignore-style syntax).
+- **exclude** -- Glob patterns for files to exclude (gitignore-style syntax).
 
 You can skip the config file entirely and use a preset:
 
@@ -324,7 +324,7 @@ For code security patterns (OpenGrep SAST):
 const secret = process.env.API_KEY; // nosemgrep: hardcoded-secret
 ```
 
-See [Ignore Patterns](ignore-patterns.md) for the full reference.
+See [Exclude Patterns](exclude-patterns.md) for the full reference.
 
 ## Adding to CI
 
@@ -356,5 +356,5 @@ LucidShark exits with code `1` when issues exceed thresholds, which fails the CI
 ## Next Steps
 
 - [LLM Reference](help.md) -- Full CLI and configuration reference
-- [Ignore Patterns](ignore-patterns.md) -- Detailed guide for excluding files and findings
+- [Exclude Patterns](exclude-patterns.md) -- Detailed guide for exclude patterns and per-domain exclusions
 - [Full Specification](main.md) -- Architecture and design documentation

--- a/docs/main.md
+++ b/docs/main.md
@@ -270,6 +270,8 @@ pipeline:
     enabled: true
     threshold: 10.0  # Max allowed duplication percentage
     min_lines: 4     # Minimum lines for a duplicate block
+    exclude:         # Patterns to exclude from duplication scan
+      - "htmlcov/**"
     tools:
       - name: duplo
 
@@ -281,7 +283,7 @@ fail_on:
   coverage: below_threshold  # Fail if coverage below pipeline.coverage.threshold
   duplication: above_threshold  # Fail if duplication exceeds pipeline.duplication.threshold
 
-ignore:
+exclude:
   - "**/__pycache__/**"
   - "**/node_modules/**"
   - "**/.venv/**"
@@ -467,6 +469,7 @@ project:
 pipeline:
   linting:
     enabled: boolean
+    exclude: [string]  # Patterns to exclude from linting
     tools:
       - name: string
         config: string  # Path to tool config
@@ -474,6 +477,7 @@ pipeline:
 
   type_checking:
     enabled: boolean
+    exclude: [string]  # Patterns to exclude from type checking
     tools:
       - name: string
         strict: boolean
@@ -481,6 +485,7 @@ pipeline:
 
   security:
     enabled: boolean
+    exclude: [string]  # Patterns to exclude from security scanning
     tools:
       - name: string
         domains: [sca, sast, iac, container]
@@ -488,6 +493,7 @@ pipeline:
 
   testing:
     enabled: boolean
+    exclude: [string]  # Patterns to exclude from testing
     tools:
       - name: string
         args: [string]
@@ -495,6 +501,7 @@ pipeline:
 
   coverage:
     enabled: boolean
+    exclude: [string]  # Patterns to exclude from coverage analysis
     threshold: number  # Default: 80
     tools:
       - name: string  # coverage_py for Python, istanbul for JS/TS, jacoco for Java
@@ -502,10 +509,10 @@ pipeline:
 
   duplication:
     enabled: boolean
+    exclude: [string]  # Patterns to exclude from duplication scan
     threshold: number  # Default: 10.0 (max allowed duplication %)
     min_lines: number  # Default: 4 (minimum lines for duplicate block)
     min_chars: number  # Default: 3 (minimum characters per line)
-    exclude: [string]  # Patterns to exclude from duplication scan
     tools:
       - name: string  # duplo
 
@@ -517,8 +524,8 @@ fail_on:
   coverage: below_threshold | any | none
   duplication: above_threshold | any | none | percentage (e.g., "5%")
 
-ignore:
-  - string  # Glob patterns
+exclude:
+  - string  # Global glob patterns (applies to all domains)
 
 output:
   format: json | table | sarif | summary
@@ -526,9 +533,9 @@ output:
 
 > **Note**: AI tool integration is configured via `lucidshark init --claude-code` or `lucidshark init --cursor`, not through lucidshark.yml.
 
-#### 5.4.2 Ignore File
+#### 5.4.2 Exclude File
 
-`.lucidsharkignore` supports gitignore syntax:
+`.lucidsharkignore` supports gitignore syntax and contributes to the global exclude patterns:
 
 ```
 # Dependencies
@@ -1435,7 +1442,7 @@ pipeline:
 |------|-----------|----------------|--------------|
 | Duplo | Python, Rust, Java, JavaScript, TypeScript, C, C++, C#, Go, Ruby, Erlang, VB, HTML, CSS | binary | ❌ No |
 
-**Note:** Duplication detection always scans the entire project to find cross-file duplicates. Use the `pipeline.duplication.exclude` configuration to skip generated or vendor files (e.g., `htmlcov/**`, `generated/**`).
+**Note:** Duplication detection always scans the entire project to find cross-file duplicates. Use the `pipeline.duplication.exclude` configuration or the global `exclude` list to skip generated or vendor files (e.g., `htmlcov/**`, `generated/**`).
 
 ---
 
@@ -1516,7 +1523,7 @@ pipeline:
 
 **Goal**: Production readiness
 
-- [x] Comprehensive documentation (README, spec, LLM help, ignore patterns, roadmap)
+- [x] Comprehensive documentation (README, spec, LLM help, exclude patterns, roadmap)
 - [ ] Plugin SDK for third-party tools
 - [ ] Performance optimization (caching, incremental checks)
 - [ ] Telemetry (opt-in, anonymized)

--- a/lucidshark.yml
+++ b/lucidshark.yml
@@ -48,7 +48,7 @@ fail_on:
   coverage: below_threshold
   duplication: above_threshold
 
-ignore:
+exclude:
   - "**/.venv/**"
   - "**/__pycache__/**"
   - "**/dist/**"

--- a/src/lucidshark/config/loader.py
+++ b/src/lucidshark/config/loader.py
@@ -350,7 +350,8 @@ def _parse_domain_pipeline_config(
             # Simple string format: just the tool name
             tools.append(ToolConfig(name=tool_data))
 
-    return DomainPipelineConfig(enabled=enabled, tools=tools)
+    exclude = domain_data.get("exclude", [])
+    return DomainPipelineConfig(enabled=enabled, tools=tools, exclude=exclude)
 
 
 def _parse_coverage_pipeline_config(
@@ -382,6 +383,7 @@ def _parse_coverage_pipeline_config(
         threshold=coverage_data.get("threshold", 80),
         tools=tools,
         extra_args=coverage_data.get("extra_args", []),
+        exclude=coverage_data.get("exclude", []),
     )
 
 
@@ -499,7 +501,7 @@ def dict_to_config(data: Dict[str, Any]) -> LucidSharkConfig:
     return LucidSharkConfig(
         project=project,
         fail_on=fail_on,
-        ignore=data.get("ignore", []),
+        ignore=data.get("exclude", data.get("ignore", [])),
         output=output,
         scanners=scanners,
         enrichers=enrichers,

--- a/src/lucidshark/config/models.py
+++ b/src/lucidshark/config/models.py
@@ -80,6 +80,7 @@ class DomainPipelineConfig:
 
     enabled: bool = True
     tools: List[ToolConfig] = field(default_factory=list)
+    exclude: List[str] = field(default_factory=list)  # Patterns to exclude from this domain
 
 
 @dataclass
@@ -92,6 +93,7 @@ class CoveragePipelineConfig:
     # Extra arguments to pass to Maven/Gradle when running coverage tests
     # e.g., ["-DskipITs", "-Ddocker.skip=true"]
     extra_args: List[str] = field(default_factory=list)
+    exclude: List[str] = field(default_factory=list)  # Patterns to exclude from coverage
 
 
 @dataclass

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -949,9 +949,13 @@ ignore:
             List of linting issues.
         """
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self._runner.run_linting, context, fix
+        linting_exclude = None
+        if self.config.pipeline.linting and self.config.pipeline.linting.exclude:
+            linting_exclude = self.config.pipeline.linting.exclude
+        run_fn = functools.partial(
+            self._runner.run_linting, context, fix, exclude_patterns=linting_exclude
         )
+        return await loop.run_in_executor(None, run_fn)
 
     async def _run_type_checking(self, context: ScanContext) -> List[UnifiedIssue]:
         """Run type checking asynchronously.
@@ -963,9 +967,13 @@ ignore:
             List of type checking issues.
         """
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self._runner.run_type_checking, context
+        tc_exclude = None
+        if self.config.pipeline.type_checking and self.config.pipeline.type_checking.exclude:
+            tc_exclude = self.config.pipeline.type_checking.exclude
+        run_fn = functools.partial(
+            self._runner.run_type_checking, context, exclude_patterns=tc_exclude
         )
+        return await loop.run_in_executor(None, run_fn)
 
     async def _run_testing(
         self, context: ScanContext, with_coverage: bool = False
@@ -980,9 +988,13 @@ ignore:
             List of test failure issues.
         """
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self._runner.run_tests, context, with_coverage
+        testing_exclude = None
+        if self.config.pipeline.testing and self.config.pipeline.testing.exclude:
+            testing_exclude = self.config.pipeline.testing.exclude
+        run_fn = functools.partial(
+            self._runner.run_tests, context, with_coverage, exclude_patterns=testing_exclude
         )
+        return await loop.run_in_executor(None, run_fn)
 
     async def _run_coverage(
         self,
@@ -999,11 +1011,14 @@ ignore:
             List of coverage issues.
         """
         loop = asyncio.get_event_loop()
-        # Use functools.partial to pass run_tests parameter
+        coverage_exclude = None
+        if self.config.pipeline.coverage and self.config.pipeline.coverage.exclude:
+            coverage_exclude = self.config.pipeline.coverage.exclude
         run_coverage_fn = functools.partial(
             self._runner.run_coverage,
             context,
             run_tests=run_tests,
+            exclude_patterns=coverage_exclude,
         )
         issues = await loop.run_in_executor(None, run_coverage_fn)
         # Coverage result is stored in context.coverage_result by DomainRunner
@@ -1024,9 +1039,13 @@ ignore:
             List of security issues.
         """
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self._runner.run_security, context, domain
+        security_exclude = None
+        if self.config.pipeline.security and self.config.pipeline.security.exclude:
+            security_exclude = self.config.pipeline.security.exclude
+        run_fn = functools.partial(
+            self._runner.run_security, context, domain, exclude_patterns=security_exclude
         )
+        return await loop.run_in_executor(None, run_fn)
 
     async def _run_duplication(self, context: ScanContext) -> List[UnifiedIssue]:
         """Run duplication detection asynchronously.

--- a/tests/unit/cli/commands/test_scan.py
+++ b/tests/unit/cli/commands/test_scan.py
@@ -414,7 +414,7 @@ class TestScanCommandRunScan:
         result = cmd._run_scan(args, config)
 
         assert result.issues == []
-        mock_runner.run_tests.assert_called_once_with(mock_ctx, with_coverage=False)
+        mock_runner.run_tests.assert_called_once_with(mock_ctx, with_coverage=False, exclude_patterns=None)
 
     @patch("lucidshark.cli.commands.scan.PipelineExecutor")
     @patch("lucidshark.cli.commands.scan.DomainRunner")
@@ -454,7 +454,7 @@ class TestScanCommandRunScan:
 
         result = cmd._run_scan(args, config)
 
-        mock_runner.run_tests.assert_called_once_with(mock_ctx, with_coverage=True)
+        mock_runner.run_tests.assert_called_once_with(mock_ctx, with_coverage=True, exclude_patterns=None)
         mock_runner.run_coverage.assert_called_once()
         assert result.coverage_summary is not None
         assert result.coverage_summary.coverage_percentage == 85.0

--- a/tests/unit/config/test_domain_excludes.py
+++ b/tests/unit/config/test_domain_excludes.py
@@ -1,0 +1,909 @@
+"""Tests for per-domain exclude pattern configuration.
+
+Tests that exclude patterns can be configured per-domain and are properly
+loaded, validated, and combined with global exclude patterns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from lucidshark.config.ignore import IgnorePatterns
+from lucidshark.config.loader import (
+    dict_to_config,
+    _parse_coverage_pipeline_config,
+    _parse_domain_pipeline_config,
+)
+from lucidshark.config.models import (
+    CoveragePipelineConfig,
+    DomainPipelineConfig,
+    DuplicationPipelineConfig,
+    LucidSharkConfig,
+)
+from lucidshark.config.validation import validate_config
+from lucidshark.core.models import ScanContext, ToolDomain
+
+
+class TestDomainPipelineConfigExclude:
+    """Tests for DomainPipelineConfig.exclude field."""
+
+    def test_default_exclude_is_empty(self) -> None:
+        """Test that exclude defaults to empty list."""
+        config = DomainPipelineConfig()
+        assert config.exclude == []
+
+    def test_exclude_stores_patterns(self) -> None:
+        """Test that exclude stores provided patterns."""
+        config = DomainPipelineConfig(
+            exclude=["scripts/**", "migrations/**"]
+        )
+        assert config.exclude == ["scripts/**", "migrations/**"]
+
+    def test_exclude_preserves_order(self) -> None:
+        """Test that pattern order is preserved."""
+        patterns = ["z/**", "a/**", "m/**"]
+        config = DomainPipelineConfig(exclude=patterns)
+        assert config.exclude == ["z/**", "a/**", "m/**"]
+
+    def test_exclude_allows_empty_list(self) -> None:
+        """Test that explicitly passing empty list works."""
+        config = DomainPipelineConfig(exclude=[])
+        assert config.exclude == []
+
+    def test_exclude_independent_of_enabled(self) -> None:
+        """Test that exclude works regardless of enabled state."""
+        config = DomainPipelineConfig(enabled=False, exclude=["scripts/**"])
+        assert config.exclude == ["scripts/**"]
+
+
+class TestCoveragePipelineConfigExclude:
+    """Tests for CoveragePipelineConfig.exclude field."""
+
+    def test_default_exclude_is_empty(self) -> None:
+        """Test that exclude defaults to empty list."""
+        config = CoveragePipelineConfig()
+        assert config.exclude == []
+
+    def test_exclude_stores_patterns(self) -> None:
+        """Test that exclude stores provided patterns."""
+        config = CoveragePipelineConfig(
+            exclude=["tests/**", "scripts/**"]
+        )
+        assert config.exclude == ["tests/**", "scripts/**"]
+
+    def test_exclude_coexists_with_threshold(self) -> None:
+        """Test that exclude works alongside threshold configuration."""
+        config = CoveragePipelineConfig(
+            threshold=90,
+            exclude=["tests/**"],
+        )
+        assert config.threshold == 90
+        assert config.exclude == ["tests/**"]
+
+    def test_exclude_coexists_with_extra_args(self) -> None:
+        """Test that exclude works alongside extra_args."""
+        config = CoveragePipelineConfig(
+            extra_args=["-DskipITs"],
+            exclude=["integration/**"],
+        )
+        assert config.extra_args == ["-DskipITs"]
+        assert config.exclude == ["integration/**"]
+
+
+class TestDuplicationPipelineConfigExclude:
+    """Tests for DuplicationPipelineConfig.exclude field (pre-existing)."""
+
+    def test_default_exclude_is_empty(self) -> None:
+        """Test that exclude defaults to empty list."""
+        config = DuplicationPipelineConfig()
+        assert config.exclude == []
+
+    def test_exclude_stores_patterns(self) -> None:
+        """Test that exclude stores provided patterns."""
+        config = DuplicationPipelineConfig(
+            exclude=["generated/**", "vendor/**"]
+        )
+        assert config.exclude == ["generated/**", "vendor/**"]
+
+
+class TestConfigLoaderDomainExcludes:
+    """Tests for loading domain-specific exclude patterns from config dict."""
+
+    def test_parse_domain_config_with_exclude(self) -> None:
+        """Test that _parse_domain_pipeline_config parses exclude field."""
+        data: Dict[str, Any] = {
+            "enabled": True,
+            "tools": [{"name": "ruff"}],
+            "exclude": ["scripts/**", "generated/**"],
+        }
+        result = _parse_domain_pipeline_config(data)
+        assert result is not None
+        assert result.exclude == ["scripts/**", "generated/**"]
+
+    def test_parse_domain_config_without_exclude(self) -> None:
+        """Test that exclude defaults to empty when not specified."""
+        data: Dict[str, Any] = {
+            "enabled": True,
+            "tools": [{"name": "ruff"}],
+        }
+        result = _parse_domain_pipeline_config(data)
+        assert result is not None
+        assert result.exclude == []
+
+    def test_parse_domain_config_with_empty_exclude(self) -> None:
+        """Test that explicit empty exclude list is preserved."""
+        data: Dict[str, Any] = {
+            "enabled": True,
+            "tools": [{"name": "ruff"}],
+            "exclude": [],
+        }
+        result = _parse_domain_pipeline_config(data)
+        assert result is not None
+        assert result.exclude == []
+
+    def test_parse_domain_config_none_returns_none(self) -> None:
+        """Test that None input returns None."""
+        result = _parse_domain_pipeline_config(None)
+        assert result is None
+
+    def test_parse_coverage_config_with_exclude(self) -> None:
+        """Test that _parse_coverage_pipeline_config parses exclude field."""
+        data: Dict[str, Any] = {
+            "enabled": True,
+            "tools": [{"name": "coverage_py"}],
+            "threshold": 80,
+            "exclude": ["tests/**"],
+        }
+        result = _parse_coverage_pipeline_config(data)
+        assert result is not None
+        assert result.exclude == ["tests/**"]
+
+    def test_parse_coverage_config_without_exclude(self) -> None:
+        """Test that exclude defaults to empty when not specified."""
+        data: Dict[str, Any] = {
+            "enabled": True,
+            "tools": [{"name": "coverage_py"}],
+        }
+        result = _parse_coverage_pipeline_config(data)
+        assert result is not None
+        assert result.exclude == []
+
+    def test_parse_coverage_config_none_returns_none(self) -> None:
+        """Test that None input returns None."""
+        result = _parse_coverage_pipeline_config(None)
+        assert result is None
+
+    def test_parse_coverage_config_preserves_other_fields(self) -> None:
+        """Test that exclude doesn't interfere with threshold and extra_args."""
+        data: Dict[str, Any] = {
+            "enabled": True,
+            "tools": [{"name": "coverage_py"}],
+            "threshold": 90,
+            "extra_args": ["-DskipITs"],
+            "exclude": ["vendor/**"],
+        }
+        result = _parse_coverage_pipeline_config(data)
+        assert result is not None
+        assert result.threshold == 90
+        assert result.extra_args == ["-DskipITs"]
+        assert result.exclude == ["vendor/**"]
+
+    def test_dict_to_config_all_domains_have_exclude(self) -> None:
+        """Test that all domain configs parse exclude from full config dict."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                    "exclude": ["lint_exclude/**"],
+                },
+                "type_checking": {
+                    "enabled": True,
+                    "tools": [{"name": "mypy"}],
+                    "exclude": ["tc_exclude/**"],
+                },
+                "security": {
+                    "enabled": True,
+                    "tools": [{"name": "trivy", "domains": ["sca"]}],
+                    "exclude": ["sec_exclude/**"],
+                },
+                "testing": {
+                    "enabled": True,
+                    "tools": [{"name": "pytest"}],
+                    "exclude": ["test_exclude/**"],
+                },
+                "coverage": {
+                    "enabled": True,
+                    "tools": [{"name": "coverage_py"}],
+                    "exclude": ["cov_exclude/**"],
+                },
+                "duplication": {
+                    "enabled": True,
+                    "tools": [{"name": "duplo"}],
+                    "exclude": ["dup_exclude/**"],
+                },
+            }
+        }
+        config = dict_to_config(data)
+        assert config.pipeline.linting is not None
+        assert config.pipeline.linting.exclude == ["lint_exclude/**"]
+        assert config.pipeline.type_checking is not None
+        assert config.pipeline.type_checking.exclude == ["tc_exclude/**"]
+        assert config.pipeline.security is not None
+        assert config.pipeline.security.exclude == ["sec_exclude/**"]
+        assert config.pipeline.testing is not None
+        assert config.pipeline.testing.exclude == ["test_exclude/**"]
+        assert config.pipeline.coverage is not None
+        assert config.pipeline.coverage.exclude == ["cov_exclude/**"]
+        assert config.pipeline.duplication is not None
+        assert config.pipeline.duplication.exclude == ["dup_exclude/**"]
+
+    def test_dict_to_config_domains_without_exclude(self) -> None:
+        """Test that domains without exclude get empty lists."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                },
+                "type_checking": {
+                    "enabled": True,
+                    "tools": [{"name": "mypy"}],
+                },
+            }
+        }
+        config = dict_to_config(data)
+        assert config.pipeline.linting is not None
+        assert config.pipeline.linting.exclude == []
+        assert config.pipeline.type_checking is not None
+        assert config.pipeline.type_checking.exclude == []
+
+    def test_dict_to_config_unconfigured_domains_are_none(self) -> None:
+        """Test that domains not in the config dict remain None."""
+        data: Dict[str, Any] = {}
+        config = dict_to_config(data)
+        assert config.pipeline.linting is None
+        assert config.pipeline.type_checking is None
+        assert config.pipeline.security is None
+        assert config.pipeline.testing is None
+        assert config.pipeline.coverage is None
+        assert config.pipeline.duplication is None
+
+
+class TestTopLevelExcludeKey:
+    """Tests for the top-level 'exclude' key (alias for 'ignore')."""
+
+    def test_exclude_key_maps_to_ignore(self) -> None:
+        """Test that top-level 'exclude' key populates config.ignore."""
+        data: Dict[str, Any] = {
+            "exclude": ["**/.venv/**", "**/dist/**"],
+        }
+        config = dict_to_config(data)
+        assert config.ignore == ["**/.venv/**", "**/dist/**"]
+
+    def test_ignore_key_still_works(self) -> None:
+        """Test backward compatibility: 'ignore' key still works."""
+        data: Dict[str, Any] = {
+            "ignore": ["**/.venv/**"],
+        }
+        config = dict_to_config(data)
+        assert config.ignore == ["**/.venv/**"]
+
+    def test_exclude_takes_precedence_over_ignore(self) -> None:
+        """Test that 'exclude' takes precedence when both are specified."""
+        data: Dict[str, Any] = {
+            "ignore": ["old_pattern/**"],
+            "exclude": ["new_pattern/**"],
+        }
+        config = dict_to_config(data)
+        # dict_to_config uses: data.get("exclude", data.get("ignore", []))
+        # When "exclude" is present, it wins.
+        assert config.ignore == ["new_pattern/**"]
+
+    def test_neither_key_defaults_to_empty(self) -> None:
+        """Test that config.ignore is empty when neither key is present."""
+        data: Dict[str, Any] = {}
+        config = dict_to_config(data)
+        assert config.ignore == []
+
+    def test_exclude_key_with_empty_list(self) -> None:
+        """Test that empty exclude list is preserved."""
+        data: Dict[str, Any] = {"exclude": []}
+        config = dict_to_config(data)
+        assert config.ignore == []
+
+    def test_ignore_fallback_when_exclude_absent(self) -> None:
+        """Test that ignore is used as fallback when exclude is absent."""
+        data: Dict[str, Any] = {
+            "ignore": ["fallback_pattern/**"],
+        }
+        config = dict_to_config(data)
+        assert config.ignore == ["fallback_pattern/**"]
+
+
+class TestConfigValidationExcludes:
+    """Tests for validation of exclude patterns in config."""
+
+    def test_top_level_exclude_is_valid(self) -> None:
+        """Test that 'exclude' is recognized as valid top-level key."""
+        data: Dict[str, Any] = {"exclude": ["**/.venv/**"]}
+        warnings = validate_config(data, "test.yml")
+        # Should not have "Unknown top-level key 'exclude'" warning
+        assert not any(
+            "exclude" in w.message and "Unknown" in w.message for w in warnings
+        )
+
+    def test_top_level_exclude_must_be_list(self) -> None:
+        """Test that non-list 'exclude' produces warning."""
+        data: Dict[str, Any] = {"exclude": "not-a-list"}
+        warnings = validate_config(data, "test.yml")
+        assert any("'exclude' must be a list" in w.message for w in warnings)
+
+    def test_top_level_exclude_valid_list(self) -> None:
+        """Test that valid list exclude produces no warnings."""
+        data: Dict[str, Any] = {"exclude": ["**/.venv/**", "**/dist/**"]}
+        warnings = validate_config(data, "test.yml")
+        exclude_warnings = [w for w in warnings if "exclude" in (w.key or "")]
+        assert len(exclude_warnings) == 0
+
+    def test_domain_exclude_is_valid_key_linting(self) -> None:
+        """Test that 'exclude' is valid in pipeline.linting section."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                    "exclude": ["pattern/**"],
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        unknown_key_warnings = [
+            w for w in warnings
+            if "pipeline.linting.exclude" in (w.key or "")
+            and "Unknown" in w.message
+        ]
+        assert not unknown_key_warnings
+
+    def test_domain_exclude_is_valid_key_type_checking(self) -> None:
+        """Test that 'exclude' is valid in pipeline.type_checking section."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "type_checking": {
+                    "enabled": True,
+                    "tools": [{"name": "mypy"}],
+                    "exclude": ["stubs/**"],
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        unknown_key_warnings = [
+            w for w in warnings
+            if "pipeline.type_checking.exclude" in (w.key or "")
+            and "Unknown" in w.message
+        ]
+        assert not unknown_key_warnings
+
+    def test_domain_exclude_is_valid_key_testing(self) -> None:
+        """Test that 'exclude' is valid in pipeline.testing section."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "testing": {
+                    "enabled": True,
+                    "tools": [{"name": "pytest"}],
+                    "exclude": ["integration/**"],
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        unknown_key_warnings = [
+            w for w in warnings
+            if "pipeline.testing.exclude" in (w.key or "")
+            and "Unknown" in w.message
+        ]
+        assert not unknown_key_warnings
+
+    def test_coverage_exclude_is_valid_key(self) -> None:
+        """Test that 'exclude' is valid in coverage section."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "coverage": {
+                    "enabled": True,
+                    "tools": [{"name": "coverage_py"}],
+                    "exclude": ["tests/**"],
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        unknown_key_warnings = [
+            w for w in warnings
+            if "pipeline.coverage.exclude" in (w.key or "")
+            and "Unknown" in w.message
+        ]
+        assert not unknown_key_warnings
+
+    def test_security_exclude_is_valid_key(self) -> None:
+        """Test that 'exclude' is valid in security section."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "security": {
+                    "enabled": True,
+                    "tools": [{"name": "trivy", "domains": ["sca"]}],
+                    "exclude": ["tests/**"],
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        unknown_key_warnings = [
+            w for w in warnings
+            if "pipeline.security.exclude" in (w.key or "")
+            and "Unknown" in w.message
+        ]
+        assert not unknown_key_warnings
+
+    def test_duplication_exclude_is_valid_key(self) -> None:
+        """Test that 'exclude' is valid in duplication section."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "duplication": {
+                    "enabled": True,
+                    "tools": [{"name": "duplo"}],
+                    "exclude": ["generated/**"],
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        unknown_key_warnings = [
+            w for w in warnings
+            if "pipeline.duplication.exclude" in (w.key or "")
+            and "Unknown" in w.message
+        ]
+        assert not unknown_key_warnings
+
+    def test_domain_exclude_must_be_list_linting(self) -> None:
+        """Test that non-list linting exclude produces warning."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                    "exclude": "not-a-list",
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        assert any(
+            "pipeline.linting.exclude" in (w.key or "")
+            and "must be a list" in w.message
+            for w in warnings
+        )
+
+    def test_domain_exclude_must_be_list_type_checking(self) -> None:
+        """Test that non-list type_checking exclude produces warning."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "type_checking": {
+                    "enabled": True,
+                    "tools": [{"name": "mypy"}],
+                    "exclude": "not-a-list",
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        assert any(
+            "pipeline.type_checking.exclude" in (w.key or "")
+            and "must be a list" in w.message
+            for w in warnings
+        )
+
+    def test_domain_exclude_must_be_list_coverage(self) -> None:
+        """Test that non-list coverage exclude produces warning."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "coverage": {
+                    "enabled": True,
+                    "tools": [{"name": "coverage_py"}],
+                    "exclude": "not-a-list",
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        assert any(
+            "pipeline.coverage.exclude" in (w.key or "")
+            and "must be a list" in w.message
+            for w in warnings
+        )
+
+    def test_domain_exclude_must_be_list_security(self) -> None:
+        """Test that non-list security exclude produces warning."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "security": {
+                    "enabled": True,
+                    "tools": [{"name": "trivy", "domains": ["sca"]}],
+                    "exclude": "not-a-list",
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        assert any(
+            "pipeline.security.exclude" in (w.key or "")
+            and "must be a list" in w.message
+            for w in warnings
+        )
+
+    def test_domain_exclude_must_be_list_duplication(self) -> None:
+        """Test that non-list duplication exclude produces warning."""
+        data: Dict[str, Any] = {
+            "pipeline": {
+                "duplication": {
+                    "enabled": True,
+                    "tools": [{"name": "duplo"}],
+                    "exclude": "not-a-list",
+                }
+            }
+        }
+        warnings = validate_config(data, "test.yml")
+        assert any(
+            "pipeline.duplication.exclude" in (w.key or "")
+            and "must be a list" in w.message
+            for w in warnings
+        )
+
+    def test_all_domains_exclude_valid_produces_no_warnings(self) -> None:
+        """Test that valid excludes in all domains produce no exclude-related warnings."""
+        data: Dict[str, Any] = {
+            "exclude": ["global/**"],
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                    "exclude": ["lint/**"],
+                },
+                "type_checking": {
+                    "enabled": True,
+                    "tools": [{"name": "mypy"}],
+                    "exclude": ["tc/**"],
+                },
+                "testing": {
+                    "enabled": True,
+                    "tools": [{"name": "pytest"}],
+                    "exclude": ["test/**"],
+                },
+                "coverage": {
+                    "enabled": True,
+                    "tools": [{"name": "coverage_py"}],
+                    "exclude": ["cov/**"],
+                },
+                "security": {
+                    "enabled": True,
+                    "tools": [{"name": "trivy", "domains": ["sca"]}],
+                    "exclude": ["sec/**"],
+                },
+                "duplication": {
+                    "enabled": True,
+                    "tools": [{"name": "duplo"}],
+                    "exclude": ["dup/**"],
+                },
+            },
+        }
+        warnings = validate_config(data, "test.yml")
+        exclude_warnings = [
+            w for w in warnings
+            if "exclude" in (w.key or "") and "Unknown" in w.message
+        ]
+        assert not exclude_warnings
+
+
+class TestDomainRunnerExcludePatterns:
+    """Tests for DomainRunner domain-specific exclude pattern handling."""
+
+    def test_context_with_domain_excludes_merges_patterns(self) -> None:
+        """Test that _context_with_domain_excludes merges domain patterns with global."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig(ignore=["**/.venv/**"])
+        runner = DomainRunner(Path("/project"), config)
+
+        global_ignore = IgnorePatterns(["**/.venv/**"], source="global")
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=global_ignore,
+        )
+
+        new_context = runner._context_with_domain_excludes(
+            context, ["scripts/**", "migrations/**"]
+        )
+
+        patterns = new_context.get_exclude_patterns()
+        # Should contain both global and domain-specific patterns
+        assert "**/.venv/**" in patterns
+        assert "scripts/**" in patterns
+        assert "migrations/**" in patterns
+
+    def test_context_with_domain_excludes_returns_same_when_none(self) -> None:
+        """Test that None exclude_patterns returns the same context."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+        )
+
+        result = runner._context_with_domain_excludes(context, None)
+        assert result is context  # Should be the exact same object
+
+    def test_context_with_domain_excludes_returns_same_when_empty(self) -> None:
+        """Test that empty exclude_patterns returns the same context."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+        )
+
+        result = runner._context_with_domain_excludes(context, [])
+        assert result is context
+
+    def test_context_with_domain_excludes_preserves_other_fields(self) -> None:
+        """Test that only ignore_patterns changes, other fields are preserved."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        original_paths = [Path("/project/src")]
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=original_paths,
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=IgnorePatterns(["global/**"]),
+        )
+
+        new_context = runner._context_with_domain_excludes(context, ["domain/**"])
+
+        assert new_context.project_root == context.project_root
+        assert new_context.paths == context.paths
+        assert new_context.enabled_domains == context.enabled_domains
+
+    def test_context_with_domain_excludes_handles_no_global_patterns(self) -> None:
+        """Test domain excludes work when there are no global patterns."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=None,
+        )
+
+        new_context = runner._context_with_domain_excludes(context, ["domain/**"])
+        patterns = new_context.get_exclude_patterns()
+        assert "domain/**" in patterns
+
+    def test_context_with_domain_excludes_does_not_mutate_original(self) -> None:
+        """Test that the original context's ignore_patterns is not mutated."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        global_ignore = IgnorePatterns(["global/**"], source="global")
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=global_ignore,
+        )
+
+        original_patterns = context.get_exclude_patterns()
+        runner._context_with_domain_excludes(context, ["domain/**"])
+
+        # Original context should be unchanged
+        assert context.get_exclude_patterns() == original_patterns
+
+    def test_context_with_domain_excludes_new_context_is_different(self) -> None:
+        """Test that a new ScanContext object is returned (not the same reference)."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=IgnorePatterns(["global/**"]),
+        )
+
+        new_context = runner._context_with_domain_excludes(context, ["domain/**"])
+        assert new_context is not context
+
+    def test_context_with_multiple_domain_patterns(self) -> None:
+        """Test merging with multiple domain-specific patterns."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=IgnorePatterns(["global/**"]),
+        )
+
+        domain_patterns = [
+            "scripts/**",
+            "migrations/**",
+            "generated/**",
+            "vendor/**",
+        ]
+        new_context = runner._context_with_domain_excludes(context, domain_patterns)
+        patterns = new_context.get_exclude_patterns()
+
+        assert "global/**" in patterns
+        for dp in domain_patterns:
+            assert dp in patterns
+
+
+class TestCombiningGlobalAndDomainExcludes:
+    """Tests for the full flow of combining global + domain excludes."""
+
+    def test_full_config_with_global_and_domain_excludes(self) -> None:
+        """Test loading a config with both global and per-domain excludes."""
+        data: Dict[str, Any] = {
+            "exclude": ["**/node_modules/**"],
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                    "exclude": ["scripts/**"],
+                },
+                "type_checking": {
+                    "enabled": True,
+                    "tools": [{"name": "mypy"}],
+                    "exclude": ["tests/conftest.py"],
+                },
+            },
+        }
+        config = dict_to_config(data)
+
+        # Global excludes go to config.ignore
+        assert config.ignore == ["**/node_modules/**"]
+
+        # Domain excludes are on their respective configs
+        assert config.pipeline.linting is not None
+        assert config.pipeline.linting.exclude == ["scripts/**"]
+        assert config.pipeline.type_checking is not None
+        assert config.pipeline.type_checking.exclude == ["tests/conftest.py"]
+
+    def test_domain_excludes_do_not_affect_other_domains(self) -> None:
+        """Test that domain-specific excludes don't leak to other domains."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        global_ignore = IgnorePatterns(["**/.venv/**"])
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=global_ignore,
+        )
+
+        # Create linting context with linting-specific excludes
+        linting_ctx = runner._context_with_domain_excludes(context, ["scripts/**"])
+
+        # Original context should be unchanged
+        original_patterns = context.get_exclude_patterns()
+        assert "scripts/**" not in original_patterns
+
+        # Linting context should have both
+        linting_patterns = linting_ctx.get_exclude_patterns()
+        assert "**/.venv/**" in linting_patterns
+        assert "scripts/**" in linting_patterns
+
+    def test_two_domains_get_different_excludes(self) -> None:
+        """Test that two different domains can have independent excludes."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        global_ignore = IgnorePatterns(["**/.venv/**"])
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING, ToolDomain.TYPE_CHECKING],
+            ignore_patterns=global_ignore,
+        )
+
+        linting_ctx = runner._context_with_domain_excludes(context, ["lint_only/**"])
+        tc_ctx = runner._context_with_domain_excludes(context, ["tc_only/**"])
+
+        linting_patterns = linting_ctx.get_exclude_patterns()
+        tc_patterns = tc_ctx.get_exclude_patterns()
+
+        # Both should have global pattern
+        assert "**/.venv/**" in linting_patterns
+        assert "**/.venv/**" in tc_patterns
+
+        # Each should have its own domain pattern
+        assert "lint_only/**" in linting_patterns
+        assert "lint_only/**" not in tc_patterns
+
+        assert "tc_only/**" in tc_patterns
+        assert "tc_only/**" not in linting_patterns
+
+    def test_global_and_domain_excludes_combined_in_runner(self) -> None:
+        """Test end-to-end flow: config loaded, then runner merges patterns."""
+        data: Dict[str, Any] = {
+            "exclude": ["**/node_modules/**", "**/.git/**"],
+            "pipeline": {
+                "linting": {
+                    "enabled": True,
+                    "tools": [{"name": "ruff"}],
+                    "exclude": ["scripts/**", "generated/**"],
+                },
+            },
+        }
+        config = dict_to_config(data)
+
+        from lucidshark.core.domain_runner import DomainRunner
+
+        runner = DomainRunner(Path("/project"), config)
+
+        global_ignore = IgnorePatterns(config.ignore, source="config")
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=global_ignore,
+        )
+
+        linting_exclude = config.pipeline.linting.exclude if config.pipeline.linting else []
+        linting_ctx = runner._context_with_domain_excludes(context, linting_exclude)
+
+        patterns = linting_ctx.get_exclude_patterns()
+        assert "**/node_modules/**" in patterns
+        assert "**/.git/**" in patterns
+        assert "scripts/**" in patterns
+        assert "generated/**" in patterns
+
+    def test_domain_with_no_excludes_gets_only_global(self) -> None:
+        """Test that a domain without excludes only has global patterns."""
+        from lucidshark.core.domain_runner import DomainRunner
+
+        config = LucidSharkConfig()
+        runner = DomainRunner(Path("/project"), config)
+
+        global_ignore = IgnorePatterns(["**/.venv/**", "**/dist/**"])
+        context = ScanContext(
+            project_root=Path("/project"),
+            paths=[],
+            enabled_domains=[ToolDomain.LINTING],
+            ignore_patterns=global_ignore,
+        )
+
+        # Pass empty list -- should return same context
+        result = runner._context_with_domain_excludes(context, [])
+        assert result is context
+        patterns = result.get_exclude_patterns()
+        assert "**/.venv/**" in patterns
+        assert "**/dist/**" in patterns

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 
 from lucidshark.config.models import (
+    CoveragePipelineConfig,
     DEFAULT_PLUGINS,
+    DomainPipelineConfig,
     LucidSharkConfig,
     OutputConfig,
     ScannerDomainConfig,
@@ -167,6 +169,30 @@ class TestLucidSharkConfigGetPluginForDomain:
     def test_returns_empty_string_for_unknown_domain(self) -> None:
         config = LucidSharkConfig()
         assert config.get_plugin_for_domain("unknown") == ""
+
+
+class TestDomainPipelineConfigExclude:
+    """Tests for DomainPipelineConfig exclude field."""
+
+    def test_default_exclude_is_empty_list(self) -> None:
+        config = DomainPipelineConfig()
+        assert config.exclude == []
+
+    def test_custom_exclude_patterns(self) -> None:
+        config = DomainPipelineConfig(exclude=["tests/**", "*.generated.py"])
+        assert config.exclude == ["tests/**", "*.generated.py"]
+
+
+class TestCoveragePipelineConfigExclude:
+    """Tests for CoveragePipelineConfig exclude field."""
+
+    def test_default_exclude_is_empty_list(self) -> None:
+        config = CoveragePipelineConfig()
+        assert config.exclude == []
+
+    def test_custom_exclude_patterns(self) -> None:
+        config = CoveragePipelineConfig(exclude=["vendor/**"])
+        assert config.exclude == ["vendor/**"]
 
 
 class TestLucidSharkConfigGetScannerOptions:


### PR DESCRIPTION
## Summary

- Rename global `ignore` config key to `exclude` (backward compatible -- `ignore` still works)
- Add per-domain `exclude` patterns to **all** pipeline domains: linting, type_checking, security, testing, coverage (duplication already had it)
- Effective excludes for any domain = `.lucidsharkignore` + global `exclude` + domain-specific `exclude`
- Rename `docs/ignore-patterns.md` → `docs/exclude-patterns.md` with comprehensive documentation
- 83 new tests covering config models, validation, loading, and runtime pattern merging

## Changes

**Config layer** (models, validation, loader):
- `DomainPipelineConfig` and `CoveragePipelineConfig` gain `exclude: List[str]`
- `exclude` accepted as valid key in all pipeline domain validation
- Top-level `exclude` key maps to `config.ignore` (precedence over `ignore` if both set)

**Runtime layer** (domain_runner, scan.py, mcp/tools.py):
- `DomainRunner._context_with_domain_excludes()` merges domain patterns with global via `IgnorePatterns.merge()`
- All runner methods accept optional `exclude_patterns` parameter
- CLI and MCP extract domain excludes from config and pass through

**Documentation**:
- All 6 docs updated with per-domain exclude examples and terminology
- New "Per-Domain Exclude Patterns" section in exclude-patterns.md

## Test plan

- [x] 1969 unit tests passing (1 skipped, pre-existing)
- [x] Linting: pass
- [x] Type checking: pass
- [x] Coverage: 85.34% (above 80% threshold)
- [x] Duplication: pass
- [x] SCA/SAST: pass
- [x] 83 new tests for: config models, validation key sets, loader parsing, backward compat, domain runner merging, context isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)