### PR TITLE
Remove Cursor IDE support, focus exclusively on Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ htmlcov/
 # IDE
 .idea/
 .vscode/
-.cursor/
 *.swp
 *.swo
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AI writes code → LucidShark checks → AI fixes → repeat
 
 - **Configuration-as-code** - `lucidshark.yml` lives in your repo. Same rules for everyone, changes go through code review.
 
-- **AI-native** - MCP integration with Claude Code and Cursor. Structured feedback that AI agents can act on directly.
+- **AI-native** - MCP integration with Claude Code. Structured feedback that AI agents can act on directly.
 
 - **Unified pipeline** - Linting, type checking, security (SAST/SCA/IaC), tests, coverage, and duplication detection in one tool. Stop configuring 5+ separate tools.
 
@@ -42,8 +42,8 @@ curl -fsSL https://raw.githubusercontent.com/lucidshark-code/lucidshark/main/ins
 # Windows (PowerShell):
 irm https://raw.githubusercontent.com/lucidshark-code/lucidshark/main/install.ps1 | iex
 
-# 2. Set up your AI tools (Claude Code and/or Cursor)
-lucidshark init --all
+# 2. Set up Claude Code
+lucidshark init --claude-code
 
 # 3. Restart your AI tool, then ask it:
 #    "Autoconfigure LucidShark for this project"
@@ -126,14 +126,12 @@ This checks:
 - Tool availability (security scanners, linters, type checkers)
 - Python environment compatibility
 - Git repository status
-- MCP integrations (Claude Code, Cursor)
+- MCP integration (Claude Code)
 
 ### AI Tool Setup
 
 ```bash
 lucidshark init --claude-code    # Configure Claude Code (.mcp.json + CLAUDE.md)
-lucidshark init --cursor         # Configure Cursor (mcp.json + rules)
-lucidshark init --all            # Configure all AI tools
 ```
 
 Restart your AI tool after running `init` to activate.
@@ -214,7 +212,7 @@ See [docs/help.md](docs/help.md) for the full configuration reference.
 |---------|-------------|
 | `lucidshark scan --all` | Run all quality checks |
 | `lucidshark scan --linting --fix` | Lint and auto-fix |
-| `lucidshark init --all` | Configure AI tools (Claude Code, Cursor) |
+| `lucidshark init --claude-code` | Configure Claude Code integration |
 | `lucidshark autoconfigure` | Auto-detect project and generate config |
 | `lucidshark doctor` | Check setup and environment health |
 | `lucidshark validate` | Validate `lucidshark.yml` |

--- a/docs/guide-python.md
+++ b/docs/guide-python.md
@@ -211,27 +211,13 @@ This modifies files in place. Only linting issues are auto-fixable -- type error
 
 ## Set Up AI Integration
 
-LucidShark integrates with Claude Code and Cursor via MCP (Model Context Protocol). Your AI assistant can run scans, read results, and fix issues directly.
-
-### Claude Code
+LucidShark integrates with Claude Code via MCP (Model Context Protocol). Your AI assistant can run scans, read results, and fix issues directly.
 
 ```bash
 lucidshark init --claude-code
 ```
 
 Restart Claude Code, then ask it: "Autoconfigure LucidShark for this project" or "Run a LucidShark scan."
-
-### Cursor
-
-```bash
-lucidshark init --cursor
-```
-
-### Both
-
-```bash
-lucidshark init --all
-```
 
 ## Common Python Tips
 

--- a/docs/guide-typescript.md
+++ b/docs/guide-typescript.md
@@ -228,27 +228,13 @@ This modifies files in place. Only linting issues are auto-fixable -- type error
 
 ## Set Up AI Integration
 
-LucidShark integrates with Claude Code and Cursor via MCP (Model Context Protocol). Your AI assistant can run scans, read results, and fix issues directly.
-
-### Claude Code
+LucidShark integrates with Claude Code via MCP (Model Context Protocol). Your AI assistant can run scans, read results, and fix issues directly.
 
 ```bash
 lucidshark init --claude-code
 ```
 
 Restart Claude Code, then ask it: "Autoconfigure LucidShark for this project" or "Run a LucidShark scan."
-
-### Cursor
-
-```bash
-lucidshark init --cursor
-```
-
-### Both
-
-```bash
-lucidshark init --all
-```
 
 ## Common TypeScript Tips
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -13,10 +13,10 @@ pip install lucidshark
 ### Recommended Setup (AI-Assisted)
 
 ```bash
-# 1. Set up your AI tools
-lucidshark init --all
+# 1. Set up Claude Code
+lucidshark init --claude-code
 
-# 2. Restart Claude Code or Cursor, then ask:
+# 2. Restart Claude Code, then ask:
 #    "Autoconfigure LucidShark for this project"
 ```
 
@@ -68,13 +68,11 @@ These options are available for all commands:
 
 ### `lucidshark init`
 
-Configure AI tools (Claude Code, Cursor) to use LucidShark via MCP.
+Configure Claude Code to use LucidShark via MCP.
 
 | Option | Description |
 |--------|-------------|
 | `--claude-code` | Configure Claude Code MCP settings |
-| `--cursor` | Configure Cursor MCP settings |
-| `--all` | Configure all supported AI tools |
 | `--dry-run` | Show changes without applying |
 | `--force` | Overwrite existing configuration |
 | `--remove` | Remove LucidShark from tool configuration |
@@ -82,8 +80,6 @@ Configure AI tools (Claude Code, Cursor) to use LucidShark via MCP.
 **Examples:**
 ```bash
 lucidshark init --claude-code
-lucidshark init --cursor
-lucidshark init --all
 lucidshark init --claude-code --remove
 ```
 
@@ -206,7 +202,7 @@ Run LucidShark as a server for AI tool integration.
 
 | Option | Description |
 |--------|-------------|
-| `--mcp` | Run as MCP server (for Claude Code, Cursor) |
+| `--mcp` | Run as MCP server (for Claude Code) |
 | `--watch` | Watch files and run incremental checks |
 | `--port PORT` | HTTP port for status endpoint (default: 7432) |
 | `--debounce MS` | File watcher debounce delay (default: 1000) |
@@ -238,7 +234,7 @@ Run health checks on the LucidShark setup and environment. Checks configuration,
 - Common linters/type checkers available (ruff, mypy, pyright)
 - Python version (requires 3.10+)
 - Git repository detected
-- Claude Code and Cursor MCP integrations configured
+- Claude Code MCP integration configured
 
 **Examples:**
 ```bash
@@ -984,28 +980,6 @@ Or manually create `.mcp.json`:
 ```
 
 **Note:** The `command` path is auto-detected. For venv installs, it will use the relative path (e.g., `.venv/bin/lucidshark`). For standalone installs, it uses `./lucidshark`.
-
-### Cursor
-
-```bash
-lucidshark init --cursor
-```
-
-This creates:
-- `~/.cursor/mcp.json` - MCP server configuration
-- `.cursor/rules/lucidshark.mdc` - Cursor rules
-
-Or manually add to `~/.cursor/mcp.json`:
-```json
-{
-  "mcpServers": {
-    "lucidshark": {
-      "command": "lucidshark",
-      "args": ["serve", "--mcp"]
-    }
-  }
-}
-```
 
 ---
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -2,7 +2,7 @@
 
 ## 1. Problem Statement
 
-AI coding assistants have fundamentally changed software development. Tools like Claude Code, Cursor, GitHub Copilot, and Windsurf can generate hundreds of lines of code in seconds. But this speed creates a new problem: **developers cannot trust AI-generated code**.
+AI coding assistants have fundamentally changed software development. Tools like Claude Code, GitHub Copilot, and Windsurf can generate hundreds of lines of code in seconds. But this speed creates a new problem: **developers cannot trust AI-generated code**.
 
 The trust gap manifests in several ways:
 
@@ -36,8 +36,8 @@ This trust layer doesn't replace existing tools - it orchestrates them and bridg
 LucidShark is the **trust layer for AI-assisted development**. It provides:
 
 ```
-lucidshark init --all
-→ Configures AI tools (Claude Code, Cursor)
+lucidshark init --claude-code
+→ Configures Claude Code
 
 "Autoconfigure LucidShark" (via AI)
 → AI analyzes your codebase
@@ -66,8 +66,8 @@ LucidShark is a **unified code quality pipeline** with native AI agent integrati
 ### 2.1 Zero-Config Initialization
 
 ```bash
-# 1. Set up AI tools
-lucidshark init --all
+# 1. Set up Claude Code
+lucidshark init --claude-code
 
 # 2. Ask your AI: "Autoconfigure LucidShark for this project"
 ```
@@ -103,12 +103,10 @@ All results normalized to a common schema. One exit code for automation.
 LucidShark bridges deterministic tools and AI agents via MCP (Model Context Protocol):
 
 ```bash
-# Configure AI tools (creates MCP config and instructions)
-lucidshark init --claude-code  # Configure Claude Code
-lucidshark init --cursor       # Configure Cursor
-lucidshark init --all          # Configure all AI tools
+# Configure Claude Code (creates MCP config and instructions)
+lucidshark init --claude-code
 
-# Then restart your AI tool for changes to take effect
+# Then restart Claude Code for changes to take effect
 ```
 
 When configured:
@@ -157,7 +155,7 @@ LucidShark uses AI to **explain and fix** issues, not to decide what matters.
 ### 4.1 Primary: Developers Using AI Coding Tools
 
 Developers who:
-- Use Claude Code, Cursor, Copilot, or similar AI assistants
+- Use Claude Code, Copilot, or similar AI assistants
 - Want confidence that AI-generated code is production-ready
 - Need fast feedback loops without manual tool orchestration
 - Work in teams with shared quality standards
@@ -531,7 +529,7 @@ output:
   format: json | table | sarif | summary
 ```
 
-> **Note**: AI tool integration is configured via `lucidshark init --claude-code` or `lucidshark init --cursor`, not through lucidshark.yml.
+> **Note**: AI tool integration is configured via `lucidshark init --claude-code`, not through lucidshark.yml.
 
 #### 5.4.2 Exclude File
 
@@ -631,7 +629,7 @@ Binaries are cached in `{project_root}/.lucidshark/` by default. The `LUCIDSHARK
 │                        LucidShark CLI                            │
 ├─────────────────────────────────────────────────────────────────┤
 │  Commands                                                       │
-│  ├── init           → Configure AI tools (Claude Code, Cursor)  │
+│  ├── init           → Configure Claude Code integration           │
 │  ├── autoconfigure  → Detect project, generate lucidshark.yml   │
 │  ├── scan           → Pipeline execution                        │
 │  ├── serve          → MCP server / file watcher                 │
@@ -1031,18 +1029,6 @@ lucidshark serve --mcp
 }
 ```
 
-**For Cursor** (MCP configuration):
-```json
-{
-  "mcpServers": {
-    "lucidshark": {
-      "command": "lucidshark",
-      "args": ["serve", "--mcp"]
-    }
-  }
-}
-```
-
 #### 7.1.2 Hooks Mode
 
 LucidShark can run via editor hooks:
@@ -1138,7 +1124,6 @@ The AI integration creates an automated feedback loop with partial scanning for 
 
 The feedback loop is driven by instructions provided to the AI tool via `lucidshark init`, which creates:
 - `.claude/CLAUDE.md` for Claude Code with scan workflow instructions
-- `.cursor/rules/lucidshark.mdc` for Cursor with auto-scan rules
 
 These instruct the AI to:
 - Run **default scans** (changed files only) after code changes for fast feedback
@@ -1197,20 +1182,16 @@ Global Options:
 ```
 lucidshark init [OPTIONS]
 
-Configure AI tools (Claude Code, Cursor) to use LucidShark.
+Configure Claude Code to use LucidShark.
 
 Options:
   --claude-code        Configure Claude Code MCP settings
-  --cursor             Configure Cursor MCP settings
-  --all                Configure all supported AI tools
   --dry-run            Show changes without applying
   --force              Overwrite existing configuration
   --remove             Remove LucidShark from tool configuration
 
 Examples:
   lucidshark init --claude-code      # Configure Claude Code
-  lucidshark init --cursor           # Configure Cursor
-  lucidshark init --all              # Configure all AI tools
 ```
 
 #### 8.2.2 `autoconfigure`
@@ -1290,14 +1271,14 @@ lucidshark serve [OPTIONS] [PATH]
 Run LucidShark as a server for AI integration.
 
 Options:
-  --mcp                Run as MCP server (for Claude Code, Cursor)
+  --mcp                Run as MCP server (for Claude Code)
   --watch              Watch files and run incremental checks on changes
   --port PORT          HTTP port for status endpoint (default: 7432)
   --debounce MS        Debounce delay for file watcher (default: 1000ms)
   PATH                 Project directory to serve (default: current directory)
 
 Examples:
-  lucidshark serve --mcp             # MCP server for Claude Code/Cursor
+  lucidshark serve --mcp             # MCP server for Claude Code
   lucidshark serve --watch           # File watcher mode
 ```
 
@@ -1343,7 +1324,7 @@ Checks:
   - Configuration: lucidshark.yml presence and validity
   - Tools: Scanner plugin availability and versions
   - Environment: Python version, platform, git repository
-  - Integrations: Claude Code and Cursor MCP configuration
+  - Integrations: Claude Code MCP configuration
 
 Examples:
   lucidshark doctor                  # Run all health checks
@@ -1494,7 +1475,6 @@ pipeline:
 - [x] AI instruction formatter
 - [x] File watcher mode
 - [x] Claude Code integration (`lucidshark init --claude-code`)
-- [x] Cursor integration (`lucidshark init --cursor`)
 - [x] Feedback loop configuration
 - [x] MCP autoconfigure tool (AI-driven project setup)
 - [x] MCP validate_config tool

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 > **Vision**: Unified code quality pipeline for AI-assisted development
 
-LucidShark unifies code quality tools (linting, type checking, security, testing, coverage, duplication detection) into a single pipeline that auto-configures for any project and integrates with AI coding tools like Claude Code and Cursor.
+LucidShark unifies code quality tools (linting, type checking, security, testing, coverage, duplication detection) into a single pipeline that auto-configures for any project and integrates with Claude Code.
 
 ---
 
@@ -62,7 +62,6 @@ All foundational work is complete. LucidShark is a fully functional code quality
 
 ```bash
 lucidshark init --claude-code         # Configure Claude Code
-lucidshark init --cursor              # Configure Cursor
 lucidshark autoconfigure              # Generate lucidshark.yml
 lucidshark scan --all                 # Run complete pipeline
 lucidshark scan --linting --fix       # Lint with auto-fix

--- a/install.sh
+++ b/install.sh
@@ -278,8 +278,6 @@ main() {
     echo "Then configure your AI tool:"
     echo ""
     success "  lucidshark init --claude-code    # For Claude Code"
-    echo "  lucidshark init --cursor         # For Cursor"
-    echo "  lucidshark init --all            # For both"
     echo ""
     info "This sets up MCP integration so AI tools can scan automatically."
     echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ keywords = [
   "mcp",
   "ai",
   "claude",
-  "cursor",
   "linting",
   "type-checking",
   "testing",

--- a/src/lucidshark/cli/arguments.py
+++ b/src/lucidshark/cli/arguments.py
@@ -1,7 +1,7 @@
 """Argument parser construction for lucidshark CLI.
 
 This module builds the argument parser with subcommands:
-- lucidshark init          - Configure AI tools (Claude Code, Cursor)
+- lucidshark init          - Configure AI tools (Claude Code)
 - lucidshark autoconfigure - Auto-configure project (generate lucidshark.yml)
 - lucidshark scan          - Run security/quality scans
 - lucidshark status        - Show configuration and tool status
@@ -41,13 +41,13 @@ def _add_global_options(parser: argparse.ArgumentParser) -> None:
 def _build_init_parser(subparsers: argparse._SubParsersAction) -> None:
     """Build the 'init' subcommand parser.
 
-    This command configures AI tools (Claude Code, Cursor) to use LucidShark.
+    This command configures AI tools (Claude Code) to use LucidShark.
     """
     init_parser = subparsers.add_parser(
         "init",
         help="Configure AI tools to use LucidShark.",
         description=(
-            "Configure Claude Code, Cursor, or other MCP-compatible AI tools "
+            "Configure Claude Code or other MCP-compatible AI tools "
             "to use LucidShark for code quality checks."
         ),
     )
@@ -58,11 +58,6 @@ def _build_init_parser(subparsers: argparse._SubParsersAction) -> None:
         "--claude-code",
         action="store_true",
         help="Configure Claude Code MCP settings.",
-    )
-    tool_group.add_argument(
-        "--cursor",
-        action="store_true",
-        help="Configure Cursor MCP settings.",
     )
     tool_group.add_argument(
         "--all",
@@ -316,7 +311,7 @@ def _build_serve_parser(subparsers: argparse._SubParsersAction) -> None:
         "serve",
         help="Run LucidShark as a server for AI integration.",
         description=(
-            "Run LucidShark as an MCP server for Claude Code, Cursor, "
+            "Run LucidShark as an MCP server for Claude Code "
             "or as a file watcher for real-time checking."
         ),
     )
@@ -326,7 +321,7 @@ def _build_serve_parser(subparsers: argparse._SubParsersAction) -> None:
     mode_group.add_argument(
         "--mcp",
         action="store_true",
-        help="Run as MCP server (for Claude Code, Cursor).",
+        help="Run as MCP server (for Claude Code).",
     )
     mode_group.add_argument(
         "--watch",
@@ -417,7 +412,6 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  lucidshark init --claude-code       # Configure Claude Code\n"
-            "  lucidshark init --cursor            # Configure Cursor\n"
             "  lucidshark autoconfigure            # Auto-configure project\n"
             "  lucidshark scan --sca               # Scan dependencies\n"
             "  lucidshark scan --all               # Run all scans\n"

--- a/src/lucidshark/cli/commands/doctor.py
+++ b/src/lucidshark/cli/commands/doctor.py
@@ -281,18 +281,6 @@ class DoctorCommand(Command):
         if claude_result is not None:
             results.append(claude_result)
 
-        # Check Cursor MCP config (global and project-level)
-        cursor_result = self._check_mcp_config(
-            name="cursor_mcp",
-            display_name="Cursor",
-            global_config=Path.home() / ".cursor" / "mcp.json",
-            project_config=project_root / ".cursor" / "mcp.json",
-            init_command="lucidshark init --cursor",
-            report_if_missing=False,  # Don't report Cursor as missing if not installed
-        )
-        if cursor_result is not None:
-            results.append(cursor_result)
-
         return results
 
     def _check_mcp_config(
@@ -387,7 +375,7 @@ class DoctorCommand(Command):
             "Configuration": ["config_file", "config_valid"],
             "Tools": [r.name for r in results if r.name.startswith("tool_")],
             "Environment": ["python_version", "platform", "git_repo"],
-            "Integrations": ["claude_code_mcp", "cursor_mcp"],
+            "Integrations": ["claude_code_mcp"],
         }
 
         for category, keys in categories.items():

--- a/src/lucidshark/mcp/__init__.py
+++ b/src/lucidshark/mcp/__init__.py
@@ -1,7 +1,7 @@
 """MCP (Model Context Protocol) integration for LucidShark.
 
 This package provides MCP server functionality for AI agent integration,
-enabling tools like Claude Code and Cursor to invoke LucidShark checks.
+enabling tools like Claude Code to invoke LucidShark checks.
 """
 
 from __future__ import annotations

--- a/src/lucidshark/mcp/server.py
+++ b/src/lucidshark/mcp/server.py
@@ -216,7 +216,7 @@ class LucidSharkMCPServer:
                 """Send progress event via MCP progress notification.
 
                 Uses the standard MCP progress notification mechanism which
-                clients (Claude/Cursor) display prominently during tool execution.
+                clients (Claude Code) display prominently during tool execution.
                 Falls back to MCP logging if progress tokens are not supported.
                 """
                 tool_name = event.get("tool", "lucidshark")

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -568,9 +568,9 @@ class MCPToolExecutor:
                     "guidance": (
                         "After generating the config, tell the user: "
                         "1) Which tools need to be installed (security tools are auto-downloaded), "
-                        "2) Run 'lucidshark init --claude-code' or '--cursor' for AI integration, "
+                        "2) Run 'lucidshark init --claude-code' for AI integration, "
                         "3) Run 'lucidshark scan --all' to verify the configuration works, "
-                        "4) IMPORTANT: Restart Claude Code or Cursor for the configuration to take effect."
+                        "4) IMPORTANT: Restart Claude Code for the configuration to take effect."
                     ),
                 },
             ],
@@ -844,11 +844,11 @@ ignore:
 """,
             },
             "post_config_steps": [
-                "Run 'lucidshark init --claude-code' or 'lucidshark init --cursor' to set up AI tool integration",
+                "Run 'lucidshark init --claude-code' to set up AI tool integration",
                 "Install required linting/testing tools via package manager (security tools auto-download)",
                 "Run 'lucidshark scan --all' to test the configuration and see initial results",
                 "If many issues appear, consider starting with relaxed thresholds (see gradual_adoption example)",
-                "IMPORTANT: Restart Claude Code or Cursor for the new configuration to take effect",
+                "IMPORTANT: Restart Claude Code for the new configuration to take effect",
             ],
         }
 


### PR DESCRIPTION
## Summary

- Removed all Cursor IDE support (CLI `--cursor` flag, MCP config, health checks, rules generation)
- Updated all documentation (README, help, guides, roadmap) to reflect Claude Code as sole integration
- Cleaned up tests, config files (`pyproject.toml`, `.gitignore`), and install script
- 16 files changed, +53/-377 lines — zero Cursor references remain

## Test plan

- [x] All 2081 unit/integration tests pass
- [x] LucidShark scan: 0 issues across all domains (linting, type checking, SAST, SCA, testing, coverage, duplication)
- [x] Verified zero "cursor" references remain via case-insensitive grep across entire codebase
- [ ] Manual: run `lucidshark init --claude-code` and verify it works
- [ ] Manual: run `lucidshark doctor` and verify no Cursor health checks appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)