### PR TITLE
feat: add comprehensive common exclusions to autoconfigure

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -620,11 +620,18 @@ fail_on:
 
 # Global file/directory excludes (applies to all domains)
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/node_modules/**"
   - "**/.venv/**"
+  - "**/venv/**"
   - "**/dist/**"
   - "**/build/**"
   - "**/__pycache__/**"
+  - "**/.mypy_cache/**"
+  - "**/.pytest_cache/**"
+  - "**/.ruff_cache/**"
+  - "**/htmlcov/**"
 
 # Output format
 output:
@@ -657,8 +664,17 @@ fail_on:
   linting: error
   type_checking: error
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/__pycache__/**"
   - "**/.venv/**"
+  - "**/venv/**"
+  - "**/.mypy_cache/**"
+  - "**/.ruff_cache/**"
+  - "**/*.egg-info/**"
+  - "**/htmlcov/**"
+  - "**/dist/**"
+  - "**/build/**"
 ```
 
 #### TypeScript Only (Minimal)
@@ -683,8 +699,12 @@ fail_on:
   linting: error
   type_checking: error
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/node_modules/**"
   - "**/dist/**"
+  - "**/build/**"
+  - "**/coverage/**"
 ```
 
 #### Python with Testing and Coverage
@@ -721,9 +741,20 @@ fail_on:
   testing: any
   coverage: below_threshold
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/__pycache__/**"
   - "**/.venv/**"
+  - "**/venv/**"
+  - "**/.mypy_cache/**"
   - "**/.pytest_cache/**"
+  - "**/.ruff_cache/**"
+  - "**/*.egg-info/**"
+  - "**/.eggs/**"
+  - "**/htmlcov/**"
+  - "**/.tox/**"
+  - "**/dist/**"
+  - "**/build/**"
 ```
 
 #### TypeScript Full Stack
@@ -759,10 +790,14 @@ fail_on:
   testing: any
   coverage: below_threshold
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/node_modules/**"
   - "**/dist/**"
   - "**/build/**"
   - "**/coverage/**"
+  - "**/.next/**"
+  - "**/.nuxt/**"
 ```
 
 #### Security Only (Any Language)
@@ -785,9 +820,13 @@ fail_on:
   security: high
 exclude:
   - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/node_modules/**"
   - "**/__pycache__/**"
   - "**/.venv/**"
+  - "**/venv/**"
+  - "**/dist/**"
+  - "**/build/**"
 ```
 
 #### Java Project
@@ -824,8 +863,11 @@ fail_on:
   testing: any
   coverage: below_threshold
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/target/**"
   - "**/.gradle/**"
+  - "**/build/**"
 ```
 
 #### Rust Project
@@ -861,6 +903,8 @@ fail_on:
   testing: any
   coverage: below_threshold
 exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
   - "**/target/**"
 ```
 
@@ -1214,7 +1258,9 @@ pipeline:
 |------|-----------|--------------|
 | Duplo | Python, Rust, Java, JavaScript, TypeScript, C, C++, C#, Go, Ruby, Erlang, VB, HTML, CSS | ❌ No (project-wide) |
 
-**Note:** Duplication detection always scans the entire project to find cross-file duplicates. Use domain-specific `exclude` patterns to skip generated or vendor files. All domains support `exclude` -- the effective excludes are the union of global `exclude`, `.lucidsharkignore`, and the domain's own `exclude` patterns.
+**Note:** Duplication detection always scans the entire project to find cross-file duplicates. This means missing exclusions in either the global `exclude` list or the domain-specific `exclude` will cause it to scan build artifacts, caches, vendored code, and generated files — producing noisy false positives. Always ensure comprehensive exclusions are in place. Examine your project's directory structure and exclude any directories that contain non-source-code files.
+
+All domains support `exclude` — the effective excludes are the union of global `exclude`, `.lucidsharkignore`, and the domain's own `exclude` patterns.
 
 **Configuration example:**
 ```yaml
@@ -1228,4 +1274,22 @@ pipeline:
       - "htmlcov/**"
       - "generated/**"
       - "**/vendor/**"
+      - "**/migrations/**"
+      - "**/*.min.js"
+      - "**/*.min.css"
+      - "**/__snapshots__/**"
+      - "**/fixtures/**"
+      - "**/testdata/**"
+
+# IMPORTANT: Also ensure global excludes are comprehensive
+exclude:
+  - "**/.git/**"
+  - "**/.lucidshark/**"
+  - "**/node_modules/**"
+  - "**/.venv/**"
+  - "**/venv/**"
+  - "**/__pycache__/**"
+  - "**/dist/**"
+  - "**/build/**"
+  # Add language-specific and project-specific excludes here
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.32"
+version = "0.5.33"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Adds a new analysis step (step 4) to the autoconfigure MCP tool instructing the LLM to examine the project directory structure and identify project-specific exclusions (generated code, vendor dirs, fixtures, IDE configs, minified files, migrations, snapshots, etc.)
- Adds a structured `common_exclusions` section with `always_include` patterns (8 universal), `per_language` patterns (Python, JS/TS, Java, Rust, Go), and `project_specific_guidance`
- Strengthens `common_pitfalls` with a CRITICAL warning about global excludes applying to all domains — especially duplication detection which scans the entire project
- Updates all 4 example configs in `tools.py` and all 8 example configs in `docs/help.md` with comprehensive, language-appropriate exclusion lists
- Bumps version to 0.5.33

## Test plan

- [x] All 1950 unit tests pass
- [x] Verified autoconfigure output includes new `common_exclusions` key with correct structure
- [x] Verified analysis steps renumbered correctly (9 steps total, new step 4)
- [x] Verified `common_pitfalls[0]` starts with "CRITICAL"
- [x] Linting, type checking, duplication, coverage, SCA, SAST all pass
- [ ] Manual: run `mcp__lucidshark__autoconfigure` and verify the LLM uses common_exclusions to generate configs with comprehensive excludes

🤖 Generated with [Claude Code](https://claude.com/claude-code)