### PR TITLE
feat: add git mode, baseline tracking, and caching to duplo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.33"
+version = "0.5.34"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -152,4 +152,4 @@ checkstyle = "13.2.0"
 pyright = "1.1.408"
 spotbugs = "4.9.8"
 # Duplication detection
-duplo = "0.1.4"
+duplo = "0.1.5"

--- a/src/lucidshark/bootstrap/versions.py
+++ b/src/lucidshark/bootstrap/versions.py
@@ -39,7 +39,7 @@ _FALLBACK_VERSIONS: Dict[str, str] = {
     # Type checkers
     "pyright": "1.1.408",
     # Duplication detection
-    "duplo": "0.1.4",
+    "duplo": "0.1.5",
 }
 
 

--- a/src/lucidshark/cli/commands/scan.py
+++ b/src/lucidshark/cli/commands/scan.py
@@ -264,6 +264,15 @@ class ScanCommand(Command):
             duplication_threshold = duplication_threshold or 10.0
             min_lines = min_lines or 4
 
+            # Get baseline/cache/git flags from config
+            use_baseline = True
+            use_cache = True
+            use_git = True
+            if config.pipeline.duplication:
+                use_baseline = config.pipeline.duplication.baseline
+                use_cache = config.pipeline.duplication.cache
+                use_git = config.pipeline.duplication.use_git
+
             all_issues.extend(
                 runner.run_duplication(
                     context,
@@ -271,6 +280,9 @@ class ScanCommand(Command):
                     min_lines,
                     min_chars,
                     exclude_patterns,
+                    use_baseline=use_baseline,
+                    use_cache=use_cache,
+                    use_git=use_git,
                 )
             )
 

--- a/src/lucidshark/config/loader.py
+++ b/src/lucidshark/config/loader.py
@@ -373,6 +373,9 @@ def _parse_duplication_pipeline_config(
         min_chars=duplication_data.get("min_chars", 3),
         exclude=duplication_data.get("exclude", []),
         tools=tools,
+        baseline=duplication_data.get("baseline", True),
+        cache=duplication_data.get("cache", True),
+        use_git=duplication_data.get("use_git", True),
     )
 
 

--- a/src/lucidshark/config/models.py
+++ b/src/lucidshark/config/models.py
@@ -106,6 +106,9 @@ class DuplicationPipelineConfig:
     min_chars: int = 3  # Minimum characters per line
     exclude: List[str] = field(default_factory=list)  # Patterns to exclude from duplication scan
     tools: List[ToolConfig] = field(default_factory=list)
+    baseline: bool = True  # Only report NEW duplicates after first run
+    cache: bool = True  # Cache processed files for faster re-runs
+    use_git: bool = True  # Use git ls-files for file discovery when available
 
 
 @dataclass

--- a/src/lucidshark/config/validation.py
+++ b/src/lucidshark/config/validation.py
@@ -113,6 +113,9 @@ VALID_PIPELINE_DUPLICATION_KEYS: Set[str] = {
     "min_lines",
     "min_chars",
     "exclude",
+    "baseline",
+    "cache",
+    "use_git",
 }
 
 # Pipeline domains that require tools when enabled

--- a/src/lucidshark/core/domain_runner.py
+++ b/src/lucidshark/core/domain_runner.py
@@ -482,6 +482,9 @@ class DomainRunner:
         min_lines: int = 4,
         min_chars: int = 3,
         exclude_patterns: Optional[List[str]] = None,
+        use_baseline: bool = True,
+        use_cache: bool = True,
+        use_git: bool = True,
     ) -> List[UnifiedIssue]:
         """Run duplication detection.
 
@@ -494,6 +497,9 @@ class DomainRunner:
             min_lines: Minimum lines for a duplicate block.
             min_chars: Minimum characters per line.
             exclude_patterns: Additional patterns to exclude from duplication scan.
+            use_baseline: If True, track known duplicates and only report new ones.
+            use_cache: If True, cache processed files for faster re-runs.
+            use_git: If True, use git ls-files for file discovery when in a git repo.
 
         Returns:
             List of duplication issues.
@@ -519,6 +525,9 @@ class DomainRunner:
                     min_lines=min_lines,
                     min_chars=min_chars,
                     exclude_patterns=exclude_patterns,
+                    use_baseline=use_baseline,
+                    use_cache=use_cache,
+                    use_git=use_git,
                 )
 
                 status = "PASSED" if result.passed else "FAILED"

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -1187,11 +1187,17 @@ ignore:
         min_lines = 7
         min_chars = 3
         exclude_patterns = None
+        use_baseline = True
+        use_cache = True
+        use_git = True
         if self.config.pipeline.duplication:
             threshold = self.config.pipeline.duplication.threshold
             min_lines = self.config.pipeline.duplication.min_lines
             min_chars = self.config.pipeline.duplication.min_chars
             exclude_patterns = self.config.pipeline.duplication.exclude or None
+            use_baseline = self.config.pipeline.duplication.baseline
+            use_cache = self.config.pipeline.duplication.cache
+            use_git = self.config.pipeline.duplication.use_git
 
         run_duplication_fn = functools.partial(
             self._runner.run_duplication,
@@ -1200,6 +1206,9 @@ ignore:
             min_lines=min_lines,
             min_chars=min_chars,
             exclude_patterns=exclude_patterns,
+            use_baseline=use_baseline,
+            use_cache=use_cache,
+            use_git=use_git,
         )
         issues = await loop.run_in_executor(None, run_duplication_fn)
         # Duplication result is stored in context.duplication_result by DomainRunner

--- a/src/lucidshark/plugins/duplication/base.py
+++ b/src/lucidshark/plugins/duplication/base.py
@@ -167,6 +167,9 @@ class DuplicationPlugin(ABC):
         min_lines: int = 4,
         min_chars: int = 3,
         exclude_patterns: Optional[List[str]] = None,
+        use_baseline: bool = True,
+        use_cache: bool = True,
+        use_git: bool = True,
     ) -> DuplicationResult:
         """Run duplication detection on the project.
 
@@ -179,6 +182,9 @@ class DuplicationPlugin(ABC):
             min_lines: Minimum lines for a duplicate block.
             min_chars: Minimum characters per line.
             exclude_patterns: Additional patterns to exclude from duplication scan.
+            use_baseline: If True, track known duplicates and only report new ones.
+            use_cache: If True, cache processed files for faster re-runs.
+            use_git: If True, use git ls-files for file discovery when in a git repo.
 
         Returns:
             DuplicationResult with statistics and detected duplicates.


### PR DESCRIPTION
## Summary
- **Git mode**: Duplo now uses `git ls-files` for file discovery (`--git` flag) when running inside a git repo, replacing manual file collection for faster, more accurate results
- **Baseline tracking**: Tracks known duplicates via a baseline JSON file so subsequent runs only report *new* duplications (`--baseline` / `--save-baseline` flags)
- **File caching**: Caches processed files for faster re-runs (`--cache` / `--cache-dir` flags)
- Adds `baseline`, `cache`, and `use_git` config options to the duplication pipeline config, wired through CLI, MCP, and domain runner layers
- Bumps duplo to 0.1.5 and version to 0.5.34

## Test plan
- [ ] Verify unit tests pass for git mode (flag present/absent based on repo detection)
- [ ] Verify unit tests pass for cache mode (flags and directory creation)
- [ ] Verify unit tests pass for baseline mode (first run vs subsequent runs)
- [ ] Verify existing duplication detection tests still pass with new parameters
- [ ] Run `lucidshark scan --domains duplication` in a git repo and confirm `--git` flag is used
- [ ] Run scan twice and confirm baseline file is created on first run and read on second

🤖 Generated with [Claude Code](https://claude.com/claude-code)