### PR TITLE
feat: unify command/post_command across all pipeline domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -fsSL https://raw.githubusercontent.com/toniantunovi/lucidshark/main/instal
 irm https://raw.githubusercontent.com/toniantunovi/lucidshark/main/install.ps1 | iex
 
 # 2. Set up Claude Code
-lucidshark init --claude-code
+lucidshark init
 
 # 3. Restart your AI tool, then ask it:
 #    "Autoconfigure LucidShark for this project"
@@ -123,7 +123,7 @@ This checks:
 ### AI Tool Setup
 
 ```bash
-lucidshark init --claude-code    # Configure Claude Code (.mcp.json + .claude/CLAUDE.md)
+lucidshark init    # Configure Claude Code (.mcp.json + .claude/CLAUDE.md)
 ```
 
 Restart your AI tool after running `init` to activate.
@@ -189,7 +189,7 @@ See [docs/help.md](docs/help.md) for the full configuration reference.
 |---------|-------------|
 | `lucidshark scan --all` | Run all quality checks |
 | `lucidshark scan --linting --fix` | Lint and auto-fix |
-| `lucidshark init --claude-code` | Configure Claude Code integration |
+| `lucidshark init` | Configure Claude Code integration |
 | `lucidshark doctor` | Check setup and environment health |
 | `lucidshark validate` | Validate `lucidshark.yml` |
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -14,7 +14,7 @@ pip install lucidshark
 
 ```bash
 # 1. Set up Claude Code
-lucidshark init --claude-code
+lucidshark init
 
 # 2. Restart Claude Code, then ask:
 #    "Autoconfigure LucidShark for this project"
@@ -62,15 +62,14 @@ Configure Claude Code to use LucidShark via MCP.
 
 | Option | Description |
 |--------|-------------|
-| `--claude-code` | Configure Claude Code MCP settings |
 | `--dry-run` | Show changes without applying |
 | `--force` | Overwrite existing configuration |
 | `--remove` | Remove LucidShark from tool configuration |
 
 **Examples:**
 ```bash
-lucidshark init --claude-code
-lucidshark init --claude-code --remove
+lucidshark init
+lucidshark init --remove
 ```
 
 ### `lucidshark scan`
@@ -409,7 +408,7 @@ Get this documentation.
 
 ### `autoconfigure`
 
-**This is the primary way to set up LucidShark for a project.** Returns step-by-step instructions for analyzing the codebase and generating `lucidshark.yml`. The AI analyzes the project, asks the user 1-2 questions if needed, generates the configuration, and validates it.
+**This is the primary way to set up LucidShark for a project.** Returns step-by-step instructions for analyzing the codebase, installing required tools, and generating `lucidshark.yml`. The AI analyzes the project, installs missing tools, asks 1-2 questions if needed, generates the configuration, validates it, and runs a verification scan.
 
 **Parameters:** None
 
@@ -423,11 +422,13 @@ autoconfigure()
 1. **Detect languages** -- Check for marker files (`package.json`, `pyproject.toml`, `go.mod`, `pom.xml`, `Cargo.toml`, etc.)
 2. **Detect existing tools** -- Check for configs like `.eslintrc*`, `ruff.toml`, `tsconfig.json`, `mypy.ini`, `biome.json`
 3. **Detect test frameworks** -- Check for `conftest.py`, `jest.config.*`, `karma.conf.*`, `playwright.config.*`
-4. **Ask 1-2 questions** -- Coverage threshold (if tests detected), strict vs gradual mode (for legacy codebases)
-5. **Call `get_help()`** -- Read the Configuration Reference section for the full `lucidshark.yml` format
-6. **Generate `lucidshark.yml`** -- Write the config file based on detected project characteristics
-7. **Call `validate_config()`** -- Verify the configuration is valid, fix any errors
-8. **Inform the user** -- Which tools need installation, suggest running `lucidshark scan --all` to verify
+4. **Identify project-specific exclusions** -- Examine directory structure for generated code, vendored deps, etc.
+5. **Ask 1-2 questions** -- Coverage threshold (if tests detected), strict vs gradual mode (for legacy codebases)
+6. **Call `get_help()`** -- Read the Configuration Reference section for the full `lucidshark.yml` format
+7. **Install required tools** -- Check if tools are installed, install missing ones, AND add them to dev dependencies (pyproject.toml, requirements-dev.txt, package.json, etc.)
+8. **Generate `lucidshark.yml`** -- Write the config file based on detected project characteristics
+9. **Call `validate_config()`** -- Verify the configuration is valid, fix any errors
+10. **Run verification scan** -- Execute `scan(domains=["all"])` to verify everything works
 
 **Tool recommendations by language:**
 
@@ -1058,7 +1059,7 @@ project:
 ### Claude Code
 
 ```bash
-lucidshark init --claude-code
+lucidshark init
 ```
 
 This creates:

--- a/docs/main.md
+++ b/docs/main.md
@@ -36,7 +36,7 @@ This trust layer doesn't replace existing tools - it orchestrates them and bridg
 LucidShark is the **trust layer for AI-assisted development**. It provides:
 
 ```
-lucidshark init --claude-code
+lucidshark init
 → Configures Claude Code
 
 "Autoconfigure LucidShark" (via AI)
@@ -67,7 +67,7 @@ LucidShark is a **unified code quality pipeline** with native AI agent integrati
 
 ```bash
 # 1. Set up Claude Code
-lucidshark init --claude-code
+lucidshark init
 
 # 2. Ask your AI: "Autoconfigure LucidShark for this project"
 ```
@@ -100,7 +100,7 @@ LucidShark bridges deterministic tools and AI agents via MCP (Model Context Prot
 
 ```bash
 # Configure Claude Code (creates MCP config and instructions)
-lucidshark init --claude-code
+lucidshark init
 
 # Then restart Claude Code for changes to take effect
 ```
@@ -553,7 +553,7 @@ output:
   format: json | table | sarif | summary
 ```
 
-> **Note**: AI tool integration is configured via `lucidshark init --claude-code`, not through lucidshark.yml.
+> **Note**: AI tool integration is configured via `lucidshark init`, not through lucidshark.yml.
 
 #### 5.4.2 Exclude File
 
@@ -1209,13 +1209,12 @@ lucidshark init [OPTIONS]
 Configure Claude Code to use LucidShark.
 
 Options:
-  --claude-code        Configure Claude Code MCP settings
   --dry-run            Show changes without applying
   --force              Overwrite existing configuration
   --remove             Remove LucidShark from tool configuration
 
 Examples:
-  lucidshark init --claude-code      # Configure Claude Code
+  lucidshark init                    # Configure Claude Code
 ```
 
 #### 8.2.2 `scan`
@@ -1483,7 +1482,7 @@ pipeline:
 - [x] MCP server implementation (`lucidshark serve --mcp`) with 8 tools
 - [x] AI instruction formatter
 - [x] File watcher mode
-- [x] Claude Code integration (`lucidshark init --claude-code`)
+- [x] Claude Code integration (`lucidshark init`)
 - [x] Feedback loop configuration
 - [x] MCP autoconfigure tool (AI-driven project setup)
 - [x] MCP validate_config tool

--- a/install.ps1
+++ b/install.ps1
@@ -174,7 +174,7 @@ function lucidshark {
     Write-Host ""
     Write-Host "Then configure your AI tool:"
     Write-Host ""
-    Write-Success "  lucidshark init --claude-code    # For Claude Code"
+    Write-Success "  lucidshark init    # For Claude Code"
     Write-Host ""
     Write-Info "This sets up MCP integration so AI tools can scan automatically."
     Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -230,7 +230,7 @@ main() {
     echo ""
     echo "Then configure your AI tool:"
     echo ""
-    success "  lucidshark init --claude-code    # For Claude Code"
+    success "  lucidshark init    # For Claude Code"
     echo ""
     info "This sets up MCP integration so AI tools can scan automatically."
     echo ""

--- a/lucidshark.yml
+++ b/lucidshark.yml
@@ -7,11 +7,13 @@ project:
 pipeline:
   linting:
     enabled: true
-    tools: [ruff]
+    tools:
+      - name: ruff
 
   type_checking:
     enabled: true
-    tools: [mypy]
+    tools:
+      - name: mypy
 
   security:
     enabled: true
@@ -23,20 +25,22 @@ pipeline:
 
   testing:
     enabled: true
-    tools: [pytest]
+    tools:
+      - name: pytest
 
   coverage:
     enabled: true
-    tools: [coverage_py]
+    tools:
+      - name: coverage_py
     threshold: 80
 
   duplication:
     enabled: true
     threshold: 5.0
     min_lines: 7
-    tools: [duplo]
+    tools:
+      - name: duplo
     exclude:
-      - "htmlcov/**"
       - "docs/**"
       - "tests/**"
 
@@ -48,13 +52,30 @@ fail_on:
   coverage: below_threshold
   duplication: above_threshold
 
+# Global excludes - comprehensive list for Python projects
 exclude:
-  - "**/.venv/**"
-  - "**/__pycache__/**"
-  - "**/dist/**"
-  - "**/build/**"
+  # Git and IDE
   - "**/.git/**"
   - "**/.github/**"
   - "**/.lucidshark/**"
-  - "**/lucidshark.egg-info/**"
+  # Python virtual environments
+  - "**/.venv/**"
+  - "**/venv/**"
+  # Python caches
+  - "**/__pycache__/**"
+  - "**/.mypy_cache/**"
+  - "**/.pytest_cache/**"
+  - "**/.ruff_cache/**"
+  # Build artifacts
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/*.egg-info/**"
+  - "**/.eggs/**"
+  # Coverage reports
+  - "**/htmlcov/**"
+  # Test automation
+  - "**/.tox/**"
+  - "**/.nox/**"
+  # Project-specific
   - "tests/integration/projects/**"
+  - ".tasks/**"

--- a/src/lucidshark/cli/arguments.py
+++ b/src/lucidshark/cli/arguments.py
@@ -51,20 +51,6 @@ def _build_init_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
 
-    # Tool selection
-    tool_group = init_parser.add_argument_group("AI tools")
-    tool_group.add_argument(
-        "--claude-code",
-        action="store_true",
-        help="Configure Claude Code MCP settings.",
-    )
-    tool_group.add_argument(
-        "--all",
-        action="store_true",
-        dest="init_all",
-        help="Configure all supported AI tools.",
-    )
-
     # Options
     options_group = init_parser.add_argument_group("options")
     options_group.add_argument(
@@ -374,7 +360,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="LucidShark - Unified code quality pipeline for AI-assisted development.",
         epilog=(
             "Examples:\n"
-            "  lucidshark init --claude-code       # Configure Claude Code\n"
+            "  lucidshark init                     # Configure Claude Code\n"
             "  lucidshark scan --sca               # Scan dependencies\n"
             "  lucidshark scan --all               # Run all scans\n"
             "  lucidshark scan --linting --fix     # Lint and auto-fix\n"

--- a/src/lucidshark/cli/commands/doctor.py
+++ b/src/lucidshark/cli/commands/doctor.py
@@ -275,7 +275,7 @@ class DoctorCommand(Command):
             global_config=Path.home() / ".claude" / "mcp_servers.json",
             project_config=project_root / ".claude" / "mcp_servers.json",
             project_mcp_json=project_root / ".mcp.json",
-            init_command="lucidshark init --claude-code",
+            init_command="lucidshark init",
             report_if_missing=True,
         )
         if claude_result is not None:

--- a/src/lucidshark/cli/commands/init.py
+++ b/src/lucidshark/cli/commands/init.py
@@ -208,17 +208,8 @@ class InitCommand(Command):
         Returns:
             Exit code.
         """
-        # Determine which tools to configure
-        configure_claude = getattr(args, "claude_code", False)
-        configure_all = getattr(args, "init_all", False)
-
-        if configure_all:
-            configure_claude = True
-
-        if not configure_claude:
-            print("No AI tool specified. Use --claude-code or --all.")
-            print("\nRun 'lucidshark init --help' for more options.")
-            return EXIT_INVALID_USAGE
+        # Claude Code is the default (and currently only) target
+        configure_claude = True
 
         dry_run = getattr(args, "dry_run", False)
         force = getattr(args, "force", False)

--- a/tests/unit/cli/test_runner.py
+++ b/tests/unit/cli/test_runner.py
@@ -103,8 +103,8 @@ class TestCLIRunner:
         mock_init_cmd.execute.return_value = EXIT_SUCCESS
         runner._init_cmd = mock_init_cmd  # type: ignore[assignment]
 
-        # init configures AI tools, requires a tool flag
-        result = runner.run(["init", "--claude-code"])
+        # init configures Claude Code by default
+        result = runner.run(["init"])
         assert result == EXIT_SUCCESS
         mock_init_cmd.execute.assert_called_once()
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -26,21 +26,24 @@ class TestInitCommand:
         cmd = InitCommand(version="1.0.0")
         assert cmd.name == "init"
 
-    def test_no_tool_specified_returns_invalid_usage(self, capsys) -> None:
-        """Test that no tool specified returns EXIT_INVALID_USAGE."""
+    def test_default_configures_claude_code(self, tmp_path: Path, capsys) -> None:
+        """Test that init command configures Claude Code by default."""
         cmd = InitCommand(version="1.0.0")
         args = Namespace(
-            claude_code=False,
-            init_all=False,
-            dry_run=False,
+            dry_run=True,
             force=False,
             remove=False,
         )
-        exit_code = cmd.execute(args)
-        assert exit_code == EXIT_INVALID_USAGE
 
+        claude_config = tmp_path / ".mcp.json"
+
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            with patch.object(cmd, "_get_claude_code_config_path", return_value=claude_config):
+                exit_code = cmd.execute(args)
+
+        assert exit_code == EXIT_SUCCESS
         captured = capsys.readouterr()
-        assert "No AI tool specified" in captured.out
+        assert "Claude Code" in captured.out
 
     def test_init_all_configures_claude_code(self, tmp_path: Path, capsys) -> None:
         """Test that --all configures Claude Code."""


### PR DESCRIPTION
## Summary

- Unify `command` and `post_command` configuration across all pipeline domains (linting, type_checking, sast, sca, iac, container, testing, coverage, duplication)
- Reduce code duplication in domain_runner and git modules by extracting common patterns
- Improve cargo test availability check to properly detect when Rust toolchain can't link (e.g., Xcode license issues on macOS)
- Update init command tests to match new default behavior (configures Claude Code by default)
- Bump version to 0.5.38

## Test plan

- [x] All LucidShark scans pass (linting, type_checking, testing, coverage, duplication, sca, sast)
- [x] Unit tests pass for domain_runner, config validation, and init command
- [x] Cargo integration tests properly skip when toolchain can't compile
- [x] Existing functionality preserved