### PR TITLE
chore: bump duplo to v0.1.6 with Linux ARM support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.38"
+version = "0.5.39"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -69,6 +69,9 @@ dependencies = [
 dev = [
   "pytest>=7.0",
   "pytest-asyncio>=0.23.0",
+  "pytest-cov>=7.0",
+  "coverage>=7.0",
+  "ruff>=0.4",
   "mypy>=1.0",
   "pyright>=1.1",
   "types-PyYAML>=6.0",
@@ -146,4 +149,4 @@ trivy = "0.68.2"
 opengrep = "1.15.0"
 checkov = "3.2.499"
 # Duplication detection
-duplo = "0.1.5"
+duplo = "0.1.6"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,8 @@
 pytest>=9.0.2
 pytest-cov>=7.0.0
 pytest-asyncio>=0.23.0
+coverage>=7.0
+ruff>=0.4
+mypy>=1.0
+pyright>=1.1
 lucidshark

--- a/src/lucidshark/bootstrap/versions.py
+++ b/src/lucidshark/bootstrap/versions.py
@@ -35,7 +35,7 @@ _FALLBACK_VERSIONS: Dict[str, str] = {
     "opengrep": "1.16.0",
     "checkov": "3.2.500",
     # Duplication detection
-    "duplo": "0.1.5",
+    "duplo": "0.1.6",
 }
 
 


### PR DESCRIPTION
## Summary
- Bump lucidshark-duplo from v0.1.5 to v0.1.6, which adds a statically-linked Linux ARM (aarch64) binary
- Add missing dev dependencies (pytest-cov, coverage, ruff) to pyproject.toml and requirements-dev.txt
- Bump version to 0.5.39

## Test plan
- [x] Verified duplo v0.1.6 linux-aarch64 binary downloads correctly
- [x] Verified binary is statically linked (no GLIBC dependency)
- [x] Ran duplication scan: 4.73% duplication (98 files, 11,262 lines) — passes 5% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)