### PR TITLE
feat: add ignore_issues config for acknowledged issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ fail_on:
   linting: error
   security: high
   testing: any
+ignore_issues:
+  - rule_id: CVE-2021-3807
+    reason: "Not exploitable in our context"
+    expires: 2026-06-01
 exclude: ["**/node_modules/**", "**/.venv/**"]
 ```
 
@@ -208,7 +212,7 @@ pytest tests/
 
 - [Supported Languages](docs/languages/README.md) - Per-language tool coverage, detection, and configuration
 - [LLM Reference Documentation](docs/help.md) - For AI agents and detailed reference
-- [Exclude Patterns](docs/exclude-patterns.md) - Guide for exclude patterns and per-domain exclusions
+- [Exclude Patterns & Issue Ignoring](docs/exclude-patterns.md) - File exclusions, per-domain excludes, and ignoring specific issues
 - [Full Specification](docs/main.md)
 
 ## License

--- a/docs/exclude-patterns.md
+++ b/docs/exclude-patterns.md
@@ -518,6 +518,44 @@ fn test_integration() {
 }
 ```
 
+## Ignoring Specific Issues (`ignore_issues`)
+
+While file-level excludes and inline ignores target **where** issues are found, `ignore_issues` targets **which** issues are reported, by rule ID. Ignored issues are acknowledged -- they still appear in output (tagged as ignored) but are excluded from `fail_on` threshold checks and do not affect the exit code.
+
+```yaml
+ignore_issues:
+  # Simple form: just the rule ID
+  - E501
+  - CVE-2021-3807
+
+  # Structured form: with reason and/or expiry
+  - rule_id: CKV_AWS_18
+    reason: "Access logging not required for internal dev buckets"
+  - rule_id: CVE-2024-1234
+    reason: "Not exploitable -- we don't use the affected API"
+    expires: 2026-06-01
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `rule_id` | yes | Native scanner rule ID (e.g., `E501`, `CVE-2021-3807`, `CKV_AWS_1`, `py/sql-injection`) |
+| `reason` | no | Why this issue is being ignored |
+| `expires` | no | ISO date (`YYYY-MM-DD`). After this date, the ignore stops working and a warning is emitted |
+
+**Key behaviors:**
+- Expired ignores stop suppressing -- the issue is reported normally and a warning is emitted
+- Unmatched rule IDs produce a warning (catches typos and stale entries)
+- Works across all domains (linting, type checking, security, testing, coverage, duplication)
+
+### Choosing the Right Exclusion Mechanism
+
+| Mechanism | Scope | Effect | Use When |
+|-----------|-------|--------|----------|
+| `exclude` / `.lucidsharkignore` | Files/directories | Entire files skipped by scanners | Generated code, build output, vendored dependencies |
+| Per-domain `exclude` | Files within a domain | Files skipped for that domain only | Test fixtures excluded from security, migrations excluded from linting |
+| Inline ignores (`# noqa`, `# nosemgrep`) | Single code location | Tool-native, per-line suppression | One-off exceptions at a specific line |
+| `ignore_issues` | All occurrences of a rule | Acknowledged in output, excluded from fail thresholds | Known CVEs, accepted risks, false positives, project-wide rule exceptions |
+
 ## Domain-Specific Configuration
 
 ### Disable Entire Domains

--- a/docs/help.md
+++ b/docs/help.md
@@ -623,6 +623,15 @@ fail_on:
 # Alternative: single threshold for all security
 # fail_on: high
 
+# Ignore specific issues by rule ID (acknowledged but excluded from fail thresholds)
+ignore_issues:
+  - E501                                    # Simple form: just the rule ID
+  - rule_id: CVE-2021-3807                  # Structured form with reason
+    reason: "Not exploitable in our context"
+  - rule_id: CKV_AWS_18                     # Structured form with reason and expiry
+    reason: "Access logging not required for dev buckets"
+    expires: 2026-06-01
+
 # Global file/directory excludes (applies to all domains)
 exclude:
   - "**/.git/**"
@@ -1047,6 +1056,38 @@ exclude:
 ```
 
 Per-domain `exclude` patterns can be set in each pipeline section for domain-specific exclusions. The effective excludes for any domain are the union of global `exclude`, `.lucidsharkignore`, and the domain's own `exclude` patterns. See [Exclude Patterns](exclude-patterns.md) for the full reference.
+
+#### `ignore_issues`
+
+Ignore specific issues by rule ID. Ignored issues are **acknowledged** -- they still appear in output (tagged as ignored) but are excluded from `fail_on` threshold checks and do not affect the exit code.
+
+Supports both simple strings and structured objects:
+
+```yaml
+ignore_issues:
+  # Simple: just the rule ID
+  - E501
+  - CVE-2021-3807
+
+  # Structured: with optional reason and expiry
+  - rule_id: CKV_AWS_18
+    reason: "Access logging not required for dev buckets"
+    expires: 2026-06-01
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `rule_id` | yes | string | Native scanner rule ID (e.g., `E501`, `CVE-2021-3807`, `CKV_AWS_1`) |
+| `reason` | no | string | Why this issue is being ignored |
+| `expires` | no | date | ISO date (`YYYY-MM-DD`). After this date, the ignore stops working and a warning is emitted |
+
+**Behavior:**
+- Matched issues are tagged `ignored: true` in all output formats
+- Ignored issues do not count toward `fail_on` thresholds
+- Expired ignores stop working and produce a warning
+- Unmatched rule IDs (typos, stale entries) produce a warning
+
+Works across all domains -- linting, type checking, security, testing, coverage, and duplication.
 
 ### Config File Locations
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -561,6 +561,13 @@ fail_on:
   coverage: below_threshold | any | none  # Note: test failures always fail coverage regardless of this setting
   duplication: above_threshold | any | none | percentage (e.g., "5%")
 
+# Ignore specific issues by rule ID
+ignore_issues:
+  - string                          # Simple form: just the rule ID
+  - rule_id: string                 # Structured form
+    reason: string                  # Optional: why this is ignored
+    expires: date                   # Optional: ISO date (YYYY-MM-DD) when this ignore expires
+
 exclude:
   - string  # Global glob patterns (applies to all domains)
 
@@ -596,6 +603,57 @@ Support tool-native inline ignores:
 - ESLint: `// eslint-disable-next-line`
 - OpenGrep: `# nosemgrep`
 - Checkov: `# checkov:skip=CKV_AWS_1`
+
+#### 5.4.4 Issue Ignoring (`ignore_issues`)
+
+Ignore specific issues by rule ID across all domains. Ignored issues are **acknowledged** -- they still appear in scan output (tagged as ignored) but are excluded from `fail_on` threshold checks and do not affect the exit code.
+
+This is useful for:
+- Known CVEs that are not exploitable in your context
+- Accepted risks in non-production environments
+- False positives from security scanners
+- Linting rules that conflict with project conventions
+
+**Configuration:**
+
+```yaml
+ignore_issues:
+  # Simple form: just the rule ID
+  - E501
+  - CVE-2021-3807
+
+  # Structured form: with reason and/or expiry
+  - rule_id: CKV_AWS_18
+    reason: "Access logging not required for internal dev buckets"
+  - rule_id: CVE-2024-1234
+    reason: "Not exploitable -- we don't use the affected API"
+    expires: 2026-06-01
+```
+
+**Supported fields:**
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `rule_id` | yes | string | Native scanner rule ID (e.g., `E501`, `CVE-2021-3807`, `CKV_AWS_1`, `py/sql-injection`) |
+| `reason` | no | string | Why this issue is being ignored |
+| `expires` | no | date | ISO date (`YYYY-MM-DD`). After this date, the ignore stops working and a warning is emitted |
+
+**Behavior:**
+
+- Matched issues are tagged with `ignored: true` and `ignore_reason` in the output
+- Ignored issues appear in all output formats (`json`, `table`, `sarif`, `ai`) but are visually distinguished
+- Ignored issues are **excluded** from `fail_on` threshold checks (they do not affect the exit code)
+- **Expired ignores** stop suppressing issues -- the issue is reported normally and a warning is emitted about the expired ignore entry
+- **Unmatched rule IDs** (rule IDs that don't match any issue in the scan) produce a warning, helping catch typos and stale entries
+- Rule IDs are matched against the `rule_id` field of `UnifiedIssue`, which uses each tool's native identifier format
+
+**Comparison with other exclusion mechanisms:**
+
+| Mechanism | Scope | Effect |
+|-----------|-------|--------|
+| `exclude` / `.lucidsharkignore` | Files/directories | Entire files skipped by scanners |
+| Inline ignores (`# noqa`, `# nosemgrep`) | Single code location | Tool-native, per-line suppression |
+| `ignore_issues` | All occurrences of a rule | Acknowledged in output, excluded from fail thresholds |
 
 ### 5.5 Tool Management
 
@@ -1029,6 +1087,10 @@ class UnifiedIssue:
     # Domain-specific fields
     dependency: str | None         # For SCA (e.g., "lodash@4.17.20")
     iac_resource: str | None       # For IaC (e.g., "aws_s3_bucket.public")
+
+    # Ignore status
+    ignored: bool                  # Whether this issue is ignored via ignore_issues config
+    ignore_reason: str | None      # Reason from the ignore_issues entry
 
     # Extensibility
     metadata: dict[str, Any]       # Tool-specific data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.42"
+version = "0.5.43"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lucidshark/cli/commands/scan.py
+++ b/src/lucidshark/cli/commands/scan.py
@@ -109,7 +109,8 @@ class ScanCommand(Command):
             # CLI --fail-on overrides all config thresholds
             if args.fail_on:
                 # CLI flag applies to all issues regardless of domain
-                if check_severity_threshold(result.issues, args.fail_on):
+                active_issues = [i for i in result.issues if not i.ignored]
+                if check_severity_threshold(active_issues, args.fail_on):
                     return EXIT_ISSUES_FOUND
             else:
                 # Check per-domain thresholds from config
@@ -394,6 +395,14 @@ class ScanCommand(Command):
                 pipeline_result = executor.execute(needed_scanners, context)
                 all_issues.extend(pipeline_result.issues)
 
+        # Apply ignore_issues
+        if config.ignore_issues:
+            from lucidshark.core.ignore_issues import apply_ignore_issues
+
+            ignore_warnings = apply_ignore_issues(all_issues, config.ignore_issues)
+            for w in ignore_warnings:
+                LOGGER.warning(w)
+
         # Build final result
         result = ScanResult(issues=all_issues)
         result.summary = result.compute_summary()
@@ -422,7 +431,8 @@ class ScanCommand(Command):
         """
         from lucidshark.core.models import ScanDomain, ToolDomain
 
-        issues = result.issues
+        # Filter out ignored issues before threshold checks
+        issues = [i for i in result.issues if not i.ignored]
 
         # Map issue domains to config domain names
         # ScanDomain values (SCA, CONTAINER, IAC, SAST) all map to "security"

--- a/src/lucidshark/config/loader.py
+++ b/src/lucidshark/config/loader.py
@@ -21,6 +21,7 @@ from lucidshark.config.models import (
     DomainPipelineConfig,
     DuplicationPipelineConfig,
     FailOnConfig,
+    IgnoreIssueEntry,
     LucidSharkConfig,
     OutputConfig,
     PipelineConfig,
@@ -465,10 +466,30 @@ def dict_to_config(data: Dict[str, Any]) -> LucidSharkConfig:
                 duplication=fail_on_data.get("duplication"),
             )
 
+    # Parse ignore_issues
+    ignore_issues: list[IgnoreIssueEntry] = []
+    ignore_issues_data = data.get("ignore_issues", [])
+    if isinstance(ignore_issues_data, list):
+        for item in ignore_issues_data:
+            if isinstance(item, str):
+                ignore_issues.append(IgnoreIssueEntry(rule_id=item))
+            elif isinstance(item, dict):
+                # PyYAML auto-converts bare dates (e.g. 2026-06-01) to
+                # datetime.date objects; normalise to string.
+                raw_expires = item.get("expires")
+                if raw_expires is not None and not isinstance(raw_expires, str):
+                    raw_expires = str(raw_expires)
+                ignore_issues.append(IgnoreIssueEntry(
+                    rule_id=item.get("rule_id", ""),
+                    reason=item.get("reason"),
+                    expires=raw_expires,
+                ))
+
     return LucidSharkConfig(
         project=project,
         fail_on=fail_on,
         ignore=data.get("exclude", data.get("ignore", [])),
+        ignore_issues=ignore_issues,
         output=output,
         scanners=scanners,
         enrichers=enrichers,

--- a/src/lucidshark/config/models.py
+++ b/src/lucidshark/config/models.py
@@ -29,6 +29,19 @@ SPECIAL_FAIL_ON_VALUES = {"error", "any", "none", "below_threshold", "above_thre
 
 
 @dataclass
+class IgnoreIssueEntry:
+    """A single ignore_issues entry.
+
+    Allows users to acknowledge specific rule IDs so they still appear
+    in output but don't affect exit codes.
+    """
+
+    rule_id: str
+    reason: Optional[str] = None
+    expires: Optional[str] = None  # ISO date string YYYY-MM-DD
+
+
+@dataclass
 class FailOnConfig:
     """Failure threshold configuration.
 
@@ -235,6 +248,7 @@ class LucidSharkConfig:
     # fail_on can be a string (legacy) or FailOnConfig (per-domain thresholds)
     fail_on: Optional[Union[str, FailOnConfig]] = None
     ignore: List[str] = field(default_factory=list)
+    ignore_issues: List[IgnoreIssueEntry] = field(default_factory=list)
     output: OutputConfig = field(default_factory=OutputConfig)
 
     # Scanner configs per domain (plugin-specific options passed through)

--- a/src/lucidshark/config/validation.py
+++ b/src/lucidshark/config/validation.py
@@ -58,6 +58,7 @@ VALID_TOP_LEVEL_KEYS: Set[str] = {
     "fail_on",
     "ignore",
     "exclude",  # Alias for ignore
+    "ignore_issues",
     "output",
     "scanners",
     "enrichers",
@@ -323,6 +324,80 @@ def validate_config(
                 source=source,
                 key="exclude",
             ))
+
+    # Validate ignore_issues
+    ignore_issues = data.get("ignore_issues")
+    if ignore_issues is not None:
+        if not isinstance(ignore_issues, list):
+            warnings.append(ConfigValidationWarning(
+                message=f"'ignore_issues' must be a list, got {type(ignore_issues).__name__}",
+                source=source,
+                key="ignore_issues",
+            ))
+        else:
+            _VALID_IGNORE_ISSUE_KEYS = {"rule_id", "reason", "expires"}
+            for i, entry in enumerate(ignore_issues):
+                if isinstance(entry, str):
+                    if not entry.strip():
+                        warnings.append(ConfigValidationWarning(
+                            message=f"'ignore_issues[{i}]' is an empty string",
+                            source=source,
+                            key=f"ignore_issues[{i}]",
+                        ))
+                elif isinstance(entry, dict):
+                    if "rule_id" not in entry:
+                        warnings.append(ConfigValidationWarning(
+                            message=f"'ignore_issues[{i}]' must have a 'rule_id' field",
+                            source=source,
+                            key=f"ignore_issues[{i}].rule_id",
+                        ))
+                    elif not isinstance(entry["rule_id"], str):
+                        warnings.append(ConfigValidationWarning(
+                            message=f"'ignore_issues[{i}].rule_id' must be a string",
+                            source=source,
+                            key=f"ignore_issues[{i}].rule_id",
+                        ))
+                    reason = entry.get("reason")
+                    if reason is not None and not isinstance(reason, str):
+                        warnings.append(ConfigValidationWarning(
+                            message=f"'ignore_issues[{i}].reason' must be a string",
+                            source=source,
+                            key=f"ignore_issues[{i}].reason",
+                        ))
+                    expires = entry.get("expires")
+                    if expires is not None:
+                        import datetime as _dt
+                        # PyYAML auto-converts bare dates to datetime.date;
+                        # accept those as valid alongside strings.
+                        if isinstance(expires, _dt.date):
+                            pass  # valid date object
+                        elif not isinstance(expires, str):
+                            warnings.append(ConfigValidationWarning(
+                                message=f"'ignore_issues[{i}].expires' must be a string (YYYY-MM-DD)",
+                                source=source,
+                                key=f"ignore_issues[{i}].expires",
+                            ))
+                        else:
+                            import re
+                            if not re.match(r"^\d{4}-\d{2}-\d{2}$", expires):
+                                warnings.append(ConfigValidationWarning(
+                                    message=f"'ignore_issues[{i}].expires' must be YYYY-MM-DD format, got '{expires}'",
+                                    source=source,
+                                    key=f"ignore_issues[{i}].expires",
+                                ))
+                    for key in entry:
+                        if key not in _VALID_IGNORE_ISSUE_KEYS:
+                            warnings.append(ConfigValidationWarning(
+                                message=f"Unknown key 'ignore_issues[{i}].{key}'",
+                                source=source,
+                                key=f"ignore_issues[{i}].{key}",
+                            ))
+                else:
+                    warnings.append(ConfigValidationWarning(
+                        message=f"'ignore_issues[{i}]' must be a string or mapping, got {type(entry).__name__}",
+                        source=source,
+                        key=f"ignore_issues[{i}]",
+                    ))
 
     # Validate output section
     output = data.get("output")

--- a/src/lucidshark/core/ignore_issues.py
+++ b/src/lucidshark/core/ignore_issues.py
@@ -1,0 +1,75 @@
+"""Core logic for applying ignore_issues rules to scan results.
+
+Matches issues by rule_id against configured ignore entries,
+tagging matched issues as ignored while tracking expiry and
+unmatched entries for warnings.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Set
+
+from lucidshark.config.models import IgnoreIssueEntry
+from lucidshark.core.models import UnifiedIssue
+
+
+def apply_ignore_issues(
+    issues: List[UnifiedIssue],
+    ignore_entries: List[IgnoreIssueEntry],
+) -> List[str]:
+    """Tag matching issues as ignored. Returns list of warning messages.
+
+    For each ignore entry:
+    - If expired, add a warning and skip it
+    - Otherwise, mark all issues with matching rule_id as ignored
+    - Track which rule IDs matched; unmatched ones produce a warning
+
+    Args:
+        issues: List of issues to process (modified in place).
+        ignore_entries: List of ignore rules from config.
+
+    Returns:
+        List of warning strings for expired/unmatched entries.
+    """
+    warnings: List[str] = []
+    today = date.today()
+
+    # Build active rule_id -> entry mapping, checking expiry
+    active_entries: dict[str, IgnoreIssueEntry] = {}
+    for entry in ignore_entries:
+        if entry.expires:
+            try:
+                expires_date = datetime.strptime(entry.expires, "%Y-%m-%d").date()
+                if expires_date < today:
+                    warnings.append(
+                        f"ignore_issues entry for '{entry.rule_id}' expired on "
+                        f"{entry.expires} and is no longer suppressing issues"
+                    )
+                    continue
+            except ValueError:
+                warnings.append(
+                    f"ignore_issues entry for '{entry.rule_id}' has invalid "
+                    f"expires date '{entry.expires}', ignoring expiry"
+                )
+        active_entries[entry.rule_id] = entry
+
+    # Track which rule IDs actually matched
+    matched_rule_ids: Set[str] = set()
+
+    # Apply ignores
+    for issue in issues:
+        if issue.rule_id in active_entries:
+            entry = active_entries[issue.rule_id]
+            issue.ignored = True
+            issue.ignore_reason = entry.reason
+            matched_rule_ids.add(issue.rule_id)
+
+    # Warn about unmatched entries
+    for rule_id in active_entries:
+        if rule_id not in matched_rule_ids:
+            warnings.append(
+                f"ignore_issues entry for '{rule_id}' did not match any issues"
+            )
+
+    return warnings

--- a/src/lucidshark/core/models.py
+++ b/src/lucidshark/core/models.py
@@ -143,6 +143,10 @@ class UnifiedIssue:
     dependency: Optional[str] = None  # For SCA (e.g., "lodash@4.17.20")
     iac_resource: Optional[str] = None  # For IaC (e.g., "aws_s3_bucket.public")
 
+    # Ignore tracking (set by apply_ignore_issues)
+    ignored: bool = False
+    ignore_reason: Optional[str] = None
+
     # Extensibility
     metadata: Dict[str, Any] = field(default_factory=dict)
 
@@ -255,6 +259,7 @@ class ScanSummary:
     """Summary statistics for scan results."""
 
     total: int = 0
+    ignored_total: int = 0
     by_severity: Dict[str, int] = field(default_factory=dict)
     by_scanner: Dict[str, int] = field(default_factory=dict)
 
@@ -305,6 +310,7 @@ class ScanResult:
         """Compute summary statistics from issues."""
         by_severity: Dict[str, int] = {}
         by_domain: Dict[str, int] = {}
+        ignored_total = 0
 
         for issue in self.issues:
             sev = issue.severity.value
@@ -313,8 +319,12 @@ class ScanResult:
             domain = issue.domain.value
             by_domain[domain] = by_domain.get(domain, 0) + 1
 
+            if issue.ignored:
+                ignored_total += 1
+
         return ScanSummary(
             total=len(self.issues),
+            ignored_total=ignored_total,
             by_severity=by_severity,
             by_scanner=by_domain,  # Keep field name for backwards compatibility
         )

--- a/src/lucidshark/mcp/formatter.py
+++ b/src/lucidshark/mcp/formatter.py
@@ -83,18 +83,21 @@ class InstructionFormatter:
             - instructions: Sorted list of fix instructions
             - recommended_action: Suggested next step
         """
-        instructions = [self._issue_to_instruction(issue) for issue in issues]
+        # Separate active vs ignored issues
+        active_issues = [i for i in issues if not i.ignored]
+
+        instructions = [self._issue_to_instruction(issue) for issue in active_issues]
 
         # Sort by priority
         instructions.sort(key=lambda x: x.priority)
 
-        # Count by severity
+        # Count by severity (active issues only)
         severity_counts: dict[str, int] = {}
-        for issue in issues:
+        for issue in active_issues:
             sev_name = issue.severity.value if issue.severity else "unknown"
             severity_counts[sev_name] = severity_counts.get(sev_name, 0) + 1
 
-        # Group issues by domain
+        # Group issues by domain (all issues, including ignored — they carry the tag)
         issues_by_domain: Dict[str, List[Dict[str, Any]]] = {}
         for issue in issues:
             domain_name = issue.domain.value if issue.domain else "unknown"
@@ -105,6 +108,7 @@ class InstructionFormatter:
             )
 
         # Build domain status (pass/fail for each checked domain)
+        # Only active (non-ignored) issues count toward pass/fail
         domain_status: Dict[str, Dict[str, Any]] = {}
         if checked_domains:
             for domain in checked_domains:
@@ -124,8 +128,9 @@ class InstructionFormatter:
                     continue
 
                 domain_issues = issues_by_domain.get(domain, [])
-                issue_count = len(domain_issues)
-                fixable_count = sum(1 for i in domain_issues if i.get("fixable", False))
+                active_domain_issues = [i for i in domain_issues if not i.get("ignored", False)]
+                issue_count = len(active_domain_issues)
+                fixable_count = sum(1 for i in active_domain_issues if i.get("fixable", False))
 
                 if issue_count == 0:
                     status = "pass"
@@ -146,11 +151,11 @@ class InstructionFormatter:
 
         # Generate recommended action
         recommended_action = self._generate_recommended_action(
-            issues, severity_counts, domain_status
+            active_issues, severity_counts, domain_status
         )
 
         return {
-            "total_issues": len(issues),
+            "total_issues": len(active_issues),
             "blocking": any(i.priority <= 2 for i in instructions),
             "summary": self._generate_summary(issues, severity_counts),
             "severity_counts": severity_counts,
@@ -471,13 +476,18 @@ class InstructionFormatter:
         if issue.line_start:
             location = f"{file_path}:{issue.line_start}"
 
-        return {
+        brief: Dict[str, Any] = {
             "id": issue.id,
             "location": location,
             "severity": issue.severity.value if issue.severity else "unknown",
             "title": issue.title or "",
             "fixable": issue.fixable,
         }
+        if issue.ignored:
+            brief["ignored"] = True
+            if issue.ignore_reason:
+                brief["ignore_reason"] = issue.ignore_reason
+        return brief
 
     def _generate_recommended_action(
         self,

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -292,6 +292,14 @@ class MCPToolExecutor:
                 elif result is not None:
                     all_issues.extend(result)
 
+        # Apply ignore_issues
+        if self.config.ignore_issues:
+            from lucidshark.core.ignore_issues import apply_ignore_issues
+
+            ignore_warnings = apply_ignore_issues(all_issues, self.config.ignore_issues)
+            for w in ignore_warnings:
+                LOGGER.warning(w)
+
         # Cache issues for later reference
         for issue in all_issues:
             self._issue_cache[issue.id] = issue

--- a/src/lucidshark/plugins/reporters/json_reporter.py
+++ b/src/lucidshark/plugins/reporters/json_reporter.py
@@ -78,5 +78,7 @@ class JSONReporter(ReporterPlugin):
             "suggested_fix": issue.suggested_fix,
             "dependency": issue.dependency,
             "iac_resource": issue.iac_resource,
+            "ignored": issue.ignored,
+            "ignore_reason": issue.ignore_reason,
             "metadata": issue.metadata,
         }

--- a/src/lucidshark/plugins/reporters/sarif_reporter.py
+++ b/src/lucidshark/plugins/reporters/sarif_reporter.py
@@ -214,6 +214,16 @@ class SARIFReporter(ReporterPlugin):
         if location:
             result["locations"] = [location]
 
+        # Add suppressions for ignored issues
+        if issue.ignored:
+            suppression: Dict[str, Any] = {
+                "kind": "inSource",
+                "status": "accepted",
+            }
+            if issue.ignore_reason:
+                suppression["justification"] = issue.ignore_reason
+            result["suppressions"] = [suppression]
+
         return result
 
     def _build_location(self, issue: UnifiedIssue) -> Optional[Dict[str, Any]]:

--- a/src/lucidshark/plugins/reporters/table_reporter.py
+++ b/src/lucidshark/plugins/reporters/table_reporter.py
@@ -80,7 +80,10 @@ class TableReporter(ReporterPlugin):
         lines.append("")
         lines.append("-" * 100)
         if result.summary:
-            lines.append(f"Total: {result.summary.total} issues")
+            total_line = f"Total: {result.summary.total} issues"
+            if result.summary.ignored_total > 0:
+                total_line += f" ({result.summary.ignored_total} ignored)"
+            lines.append(total_line)
             sev_parts = [
                 f"{sev}: {count}"
                 for sev, count in result.summary.by_severity.items()
@@ -111,13 +114,16 @@ class TableReporter(ReporterPlugin):
 
         for issue in issues:
             sev = issue.severity.value.upper()
+            if issue.ignored:
+                sev = f"{sev}*"
             location = issue.file_path.as_posix() if issue.file_path else ""
             if issue.line_start is not None:
                 location = f"{location}:{issue.line_start}"
             location = location[:35]
             rule = (issue.rule_id or "")[:20]
             title = issue.title[:60] if len(issue.title) > 60 else issue.title
-            lines.append(f"{sev:<10} {location:<35} {rule:<20} {title}")
+            ignored_tag = " [ignored]" if issue.ignored else ""
+            lines.append(f"{sev:<10} {location:<35} {rule:<20} {title}{ignored_tag}")
 
     def _render_dependency_table(
         self, issues: List[UnifiedIssue], lines: List[str]
@@ -128,8 +134,11 @@ class TableReporter(ReporterPlugin):
 
         for issue in issues:
             sev = issue.severity.value.upper()
+            if issue.ignored:
+                sev = f"{sev}*"
             rule_id = issue.rule_id or issue.metadata.get("vulnerability_id", issue.id)
             rule_id = rule_id[:20]
             dep = (issue.dependency or "")[:40]
             title = issue.title[:60] if len(issue.title) > 60 else issue.title
-            lines.append(f"{sev:<10} {rule_id:<20} {dep:<40} {title}")
+            ignored_tag = " [ignored]" if issue.ignored else ""
+            lines.append(f"{sev:<10} {rule_id:<20} {dep:<40} {title}{ignored_tag}")

--- a/tests/unit/cli/commands/test_scan.py
+++ b/tests/unit/cli/commands/test_scan.py
@@ -20,7 +20,6 @@ from lucidshark.config.models import (
     DuplicationPipelineConfig,
     CoveragePipelineConfig,
     FailOnConfig,
-    IgnoreIssueEntry,
     LucidSharkConfig,
     OutputConfig,
     PipelineConfig,

--- a/tests/unit/cli/commands/test_scan.py
+++ b/tests/unit/cli/commands/test_scan.py
@@ -20,6 +20,7 @@ from lucidshark.config.models import (
     DuplicationPipelineConfig,
     CoveragePipelineConfig,
     FailOnConfig,
+    IgnoreIssueEntry,
     LucidSharkConfig,
     OutputConfig,
     PipelineConfig,
@@ -1010,3 +1011,71 @@ class TestDryRun:
         captured = capsys.readouterr()
         assert "ruff" in captured.out
         assert "Tools that would run:" in captured.out
+
+
+class TestIgnoreIssuesIntegration:
+    """Tests for ignore_issues integration in scan command."""
+
+    @patch.object(ScanCommand, "_run_scan")
+    @patch("lucidshark.cli.commands.scan.get_reporter_plugin")
+    def test_ignored_issues_dont_affect_cli_fail_on(
+        self, mock_get_reporter, mock_run_scan, tmp_path: Path
+    ) -> None:
+        """Ignored issues should not trigger --fail-on exit code."""
+        issue = _make_issue(severity=Severity.HIGH)
+        issue.ignored = True
+        mock_run_scan.return_value = ScanResult(issues=[issue])
+        mock_get_reporter.return_value = MagicMock()
+
+        cmd = ScanCommand(version="1.0.0")
+        config = _make_config()
+        args = _make_args(tmp_path, fail_on="high")
+
+        result = cmd.execute(args, config)
+
+        assert result == EXIT_SUCCESS
+
+    @patch.object(ScanCommand, "_run_scan")
+    @patch("lucidshark.cli.commands.scan.get_reporter_plugin")
+    def test_non_ignored_issues_still_trigger_fail_on(
+        self, mock_get_reporter, mock_run_scan, tmp_path: Path
+    ) -> None:
+        """Non-ignored issues should still trigger --fail-on."""
+        issue = _make_issue(severity=Severity.HIGH)
+        # issue.ignored is False by default
+        mock_run_scan.return_value = ScanResult(issues=[issue])
+        mock_get_reporter.return_value = MagicMock()
+
+        cmd = ScanCommand(version="1.0.0")
+        config = _make_config()
+        args = _make_args(tmp_path, fail_on="high")
+
+        result = cmd.execute(args, config)
+
+        assert result == EXIT_ISSUES_FOUND
+
+    def test_ignored_issues_excluded_from_domain_thresholds(self) -> None:
+        """Ignored issues should not count in domain threshold checks."""
+        config = _make_config(
+            fail_on=FailOnConfig(linting="any")
+        )
+        issue = _make_issue(domain=ToolDomain.LINTING)
+        issue.ignored = True
+        result = ScanResult(issues=[issue])
+
+        cmd = ScanCommand(version="1.0.0")
+        # Only ignored issues -> should not trigger threshold
+        assert cmd._check_domain_thresholds(result, config) is False
+
+    def test_mixed_ignored_and_active_in_domain_thresholds(self) -> None:
+        """Mix of ignored and active issues - only active should trigger."""
+        config = _make_config(
+            fail_on=FailOnConfig(linting="any")
+        )
+        ignored_issue = _make_issue(domain=ToolDomain.LINTING)
+        ignored_issue.ignored = True
+        active_issue = _make_issue(domain=ToolDomain.LINTING)
+        result = ScanResult(issues=[ignored_issue, active_issue])
+
+        cmd = ScanCommand(version="1.0.0")
+        assert cmd._check_domain_thresholds(result, config) is True

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -556,7 +556,7 @@ class TestDictToConfigIgnoreIssues:
         assert config.ignore_issues[1].reason == "accepted"
 
     def test_empty_ignore_issues(self) -> None:
-        data = {"ignore_issues": []}
+        data: dict = {"ignore_issues": []}
         config = dict_to_config(data)
         assert config.ignore_issues == []
 

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -514,6 +514,78 @@ class TestParseDomainPipelineConfigCommand:
         assert config.pipeline.testing.post_command == "rm -rf .pytest_cache"
 
 
+class TestDictToConfigIgnoreIssues:
+    """Tests for dict_to_config handling of ignore_issues."""
+
+    def test_parses_simple_string_entries(self) -> None:
+        data = {"ignore_issues": ["E501", "CVE-2021-1234"]}
+        config = dict_to_config(data)
+        assert len(config.ignore_issues) == 2
+        assert config.ignore_issues[0].rule_id == "E501"
+        assert config.ignore_issues[0].reason is None
+        assert config.ignore_issues[1].rule_id == "CVE-2021-1234"
+
+    def test_parses_structured_entries(self) -> None:
+        data = {
+            "ignore_issues": [
+                {
+                    "rule_id": "CVE-2021-1234",
+                    "reason": "Accepted risk",
+                    "expires": "2026-12-31",
+                }
+            ]
+        }
+        config = dict_to_config(data)
+        assert len(config.ignore_issues) == 1
+        entry = config.ignore_issues[0]
+        assert entry.rule_id == "CVE-2021-1234"
+        assert entry.reason == "Accepted risk"
+        assert entry.expires == "2026-12-31"
+
+    def test_parses_mixed_entries(self) -> None:
+        data = {
+            "ignore_issues": [
+                "E501",
+                {"rule_id": "CVE-2021-1234", "reason": "accepted"},
+            ]
+        }
+        config = dict_to_config(data)
+        assert len(config.ignore_issues) == 2
+        assert config.ignore_issues[0].rule_id == "E501"
+        assert config.ignore_issues[1].rule_id == "CVE-2021-1234"
+        assert config.ignore_issues[1].reason == "accepted"
+
+    def test_empty_ignore_issues(self) -> None:
+        data = {"ignore_issues": []}
+        config = dict_to_config(data)
+        assert config.ignore_issues == []
+
+    def test_no_ignore_issues_key(self) -> None:
+        config = dict_to_config({})
+        assert config.ignore_issues == []
+
+    def test_structured_entry_without_optional_fields(self) -> None:
+        data = {"ignore_issues": [{"rule_id": "E501"}]}
+        config = dict_to_config(data)
+        assert len(config.ignore_issues) == 1
+        assert config.ignore_issues[0].rule_id == "E501"
+        assert config.ignore_issues[0].reason is None
+        assert config.ignore_issues[0].expires is None
+
+    def test_pyyaml_date_object_normalised_to_string(self) -> None:
+        """PyYAML parses bare dates as datetime.date objects; loader should normalise."""
+        from datetime import date
+
+        data = {
+            "ignore_issues": [
+                {"rule_id": "CVE-2021-1234", "expires": date(2026, 6, 1)}
+            ]
+        }
+        config = dict_to_config(data)
+        assert config.ignore_issues[0].expires == "2026-06-01"
+        assert isinstance(config.ignore_issues[0].expires, str)
+
+
 class TestParseCoveragePipelineConfigExclude:
     """Tests for _parse_coverage_pipeline_config handling of exclude."""
 

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -7,6 +7,7 @@ from lucidshark.config.models import (
     CoveragePipelineConfig,
     DEFAULT_PLUGINS,
     DomainPipelineConfig,
+    IgnoreIssueEntry,
     LucidSharkConfig,
     OutputConfig,
     ScannerDomainConfig,
@@ -213,3 +214,42 @@ class TestLucidSharkConfigGetScannerOptions:
         options = config.get_scanner_options("sca")
         assert options["ignore_unfixed"] is True
         assert options["severity"] == ["HIGH"]
+
+
+class TestIgnoreIssueEntry:
+    """Tests for IgnoreIssueEntry dataclass."""
+
+    def test_simple_rule_id(self) -> None:
+        entry = IgnoreIssueEntry(rule_id="E501")
+        assert entry.rule_id == "E501"
+        assert entry.reason is None
+        assert entry.expires is None
+
+    def test_with_reason_and_expires(self) -> None:
+        entry = IgnoreIssueEntry(
+            rule_id="CVE-2021-1234",
+            reason="Accepted risk",
+            expires="2026-12-31",
+        )
+        assert entry.rule_id == "CVE-2021-1234"
+        assert entry.reason == "Accepted risk"
+        assert entry.expires == "2026-12-31"
+
+
+class TestLucidSharkConfigIgnoreIssues:
+    """Tests for ignore_issues field on LucidSharkConfig."""
+
+    def test_default_ignore_issues_is_empty(self) -> None:
+        config = LucidSharkConfig()
+        assert config.ignore_issues == []
+
+    def test_custom_ignore_issues(self) -> None:
+        config = LucidSharkConfig(
+            ignore_issues=[
+                IgnoreIssueEntry(rule_id="E501"),
+                IgnoreIssueEntry(rule_id="CVE-2021-1234", reason="accepted"),
+            ]
+        )
+        assert len(config.ignore_issues) == 2
+        assert config.ignore_issues[0].rule_id == "E501"
+        assert config.ignore_issues[1].reason == "accepted"

--- a/tests/unit/config/test_validation.py
+++ b/tests/unit/config/test_validation.py
@@ -707,6 +707,97 @@ class TestValidateConfigDuplication:
         assert any("must be a list" in w.message for w in warnings)
 
 
+class TestValidateConfigIgnoreIssues:
+    """Tests for ignore_issues validation."""
+
+    def test_ignore_issues_is_valid_top_level_key(self) -> None:
+        """ignore_issues should not trigger unknown key warning."""
+        data = {"ignore_issues": ["E501"]}
+        warnings = validate_config(data, source="test.yml")
+        assert not any("Unknown" in w.message for w in warnings)
+
+    def test_ignore_issues_must_be_list(self) -> None:
+        data = {"ignore_issues": "E501"}
+        warnings = validate_config(data, source="test.yml")
+        assert any("must be a list" in w.message for w in warnings)
+
+    def test_valid_string_entries(self) -> None:
+        data = {"ignore_issues": ["E501", "CVE-2021-1234"]}
+        warnings = validate_config(data, source="test.yml")
+        assert len(warnings) == 0
+
+    def test_warns_on_empty_string_entry(self) -> None:
+        data = {"ignore_issues": [""]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("empty string" in w.message for w in warnings)
+
+    def test_valid_structured_entry(self) -> None:
+        data = {
+            "ignore_issues": [
+                {"rule_id": "E501", "reason": "accepted", "expires": "2026-12-31"}
+            ]
+        }
+        warnings = validate_config(data, source="test.yml")
+        assert len(warnings) == 0
+
+    def test_warns_on_missing_rule_id(self) -> None:
+        data = {"ignore_issues": [{"reason": "some reason"}]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("rule_id" in w.message for w in warnings)
+
+    def test_warns_on_non_string_rule_id(self) -> None:
+        data = {"ignore_issues": [{"rule_id": 123}]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("must be a string" in w.message for w in warnings)
+
+    def test_warns_on_non_string_reason(self) -> None:
+        data = {"ignore_issues": [{"rule_id": "E501", "reason": 123}]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("reason" in w.message and "must be a string" in w.message for w in warnings)
+
+    def test_warns_on_non_string_expires(self) -> None:
+        data = {"ignore_issues": [{"rule_id": "E501", "expires": 20261231}]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("expires" in w.message and "must be a string" in w.message for w in warnings)
+
+    def test_warns_on_invalid_expires_format(self) -> None:
+        data = {"ignore_issues": [{"rule_id": "E501", "expires": "12/31/2026"}]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("YYYY-MM-DD" in w.message for w in warnings)
+
+    def test_warns_on_unknown_keys_in_structured_entry(self) -> None:
+        data = {"ignore_issues": [{"rule_id": "E501", "unknown_key": "value"}]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("Unknown key" in w.message and "unknown_key" in w.message for w in warnings)
+
+    def test_warns_on_invalid_entry_type(self) -> None:
+        data = {"ignore_issues": [123]}
+        warnings = validate_config(data, source="test.yml")
+        assert any("must be a string or mapping" in w.message for w in warnings)
+
+    def test_mixed_valid_entries(self) -> None:
+        data = {
+            "ignore_issues": [
+                "E501",
+                {"rule_id": "CVE-2021-1234", "reason": "accepted"},
+            ]
+        }
+        warnings = validate_config(data, source="test.yml")
+        assert len(warnings) == 0
+
+    def test_pyyaml_date_object_is_accepted(self) -> None:
+        """PyYAML parses bare dates as datetime.date; validation should accept them."""
+        from datetime import date
+
+        data = {
+            "ignore_issues": [
+                {"rule_id": "E501", "expires": date(2026, 12, 31)}
+            ]
+        }
+        warnings = validate_config(data, source="test.yml")
+        assert len(warnings) == 0
+
+
 class TestValidateConfigExclude:
     """Tests for the exclude pattern system validation."""
 

--- a/tests/unit/core/test_ignore_issues.py
+++ b/tests/unit/core/test_ignore_issues.py
@@ -41,7 +41,7 @@ class TestApplyIgnoreIssuesBasic:
         issues = [_make_issue("E501")]
         entries = [IgnoreIssueEntry(rule_id="E502")]
 
-        warnings = apply_ignore_issues(issues, entries)
+        apply_ignore_issues(issues, entries)
 
         assert issues[0].ignored is False
 
@@ -160,7 +160,7 @@ class TestApplyIgnoreIssuesExpiry:
         today = date.today().isoformat()
         entries = [IgnoreIssueEntry(rule_id="E501", expires=today)]
 
-        warnings = apply_ignore_issues(issues, entries)
+        apply_ignore_issues(issues, entries)
 
         assert issues[0].ignored is True
 

--- a/tests/unit/core/test_ignore_issues.py
+++ b/tests/unit/core/test_ignore_issues.py
@@ -1,0 +1,204 @@
+"""Tests for lucidshark.core.ignore_issues."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from lucidshark.config.models import IgnoreIssueEntry
+from lucidshark.core.ignore_issues import apply_ignore_issues
+from lucidshark.core.models import Severity, ToolDomain, UnifiedIssue
+
+
+def _make_issue(
+    rule_id: str = "TEST001",
+    domain=ToolDomain.LINTING,
+    severity=Severity.MEDIUM,
+) -> UnifiedIssue:
+    return UnifiedIssue(
+        id=f"test-{rule_id}",
+        domain=domain,
+        source_tool="test",
+        severity=severity,
+        rule_id=rule_id,
+        title=f"Issue {rule_id}",
+        description=f"Description for {rule_id}",
+    )
+
+
+class TestApplyIgnoreIssuesBasic:
+    """Basic matching behavior."""
+
+    def test_matching_rule_id_marks_ignored(self) -> None:
+        issues = [_make_issue("E501")]
+        entries = [IgnoreIssueEntry(rule_id="E501")]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is True
+        assert warnings == []
+
+    def test_non_matching_rule_id_not_ignored(self) -> None:
+        issues = [_make_issue("E501")]
+        entries = [IgnoreIssueEntry(rule_id="E502")]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is False
+
+    def test_reason_is_set(self) -> None:
+        issues = [_make_issue("CVE-2021-1234")]
+        entries = [IgnoreIssueEntry(
+            rule_id="CVE-2021-1234",
+            reason="Accepted risk per security review",
+        )]
+
+        apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is True
+        assert issues[0].ignore_reason == "Accepted risk per security review"
+
+    def test_no_reason_leaves_none(self) -> None:
+        issues = [_make_issue("E501")]
+        entries = [IgnoreIssueEntry(rule_id="E501")]
+
+        apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignore_reason is None
+
+    def test_empty_entries_no_changes(self) -> None:
+        issues = [_make_issue("E501")]
+
+        warnings = apply_ignore_issues(issues, [])
+
+        assert issues[0].ignored is False
+        assert warnings == []
+
+    def test_empty_issues_no_warnings_for_unmatched(self) -> None:
+        """No issues means entries don't match -> warnings."""
+        entries = [IgnoreIssueEntry(rule_id="E501")]
+
+        warnings = apply_ignore_issues([], entries)
+
+        assert len(warnings) == 1
+        assert "did not match" in warnings[0]
+
+
+class TestApplyIgnoreIssuesMultiple:
+    """Multiple entries and issues."""
+
+    def test_multiple_issues_same_rule(self) -> None:
+        issues = [_make_issue("E501"), _make_issue("E501")]
+        entries = [IgnoreIssueEntry(rule_id="E501")]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert all(i.ignored for i in issues)
+        assert warnings == []
+
+    def test_multiple_entries_different_rules(self) -> None:
+        issues = [
+            _make_issue("E501"),
+            _make_issue("CVE-2021-1234"),
+            _make_issue("W503"),
+        ]
+        entries = [
+            IgnoreIssueEntry(rule_id="E501"),
+            IgnoreIssueEntry(rule_id="CVE-2021-1234", reason="accepted"),
+        ]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is True
+        assert issues[1].ignored is True
+        assert issues[1].ignore_reason == "accepted"
+        assert issues[2].ignored is False
+        assert warnings == []
+
+    def test_mixed_simple_and_structured_entries(self) -> None:
+        issues = [_make_issue("E501"), _make_issue("W503")]
+        entries = [
+            IgnoreIssueEntry(rule_id="E501"),  # simple
+            IgnoreIssueEntry(rule_id="W503", reason="known issue"),  # structured
+        ]
+
+        apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is True
+        assert issues[0].ignore_reason is None
+        assert issues[1].ignored is True
+        assert issues[1].ignore_reason == "known issue"
+
+
+class TestApplyIgnoreIssuesExpiry:
+    """Expiry date handling."""
+
+    def test_expired_entry_does_not_suppress(self) -> None:
+        issues = [_make_issue("E501")]
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        entries = [IgnoreIssueEntry(rule_id="E501", expires=yesterday)]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is False
+        assert len(warnings) == 1
+        assert "expired" in warnings[0]
+
+    def test_future_expiry_still_suppresses(self) -> None:
+        issues = [_make_issue("E501")]
+        tomorrow = (date.today() + timedelta(days=1)).isoformat()
+        entries = [IgnoreIssueEntry(rule_id="E501", expires=tomorrow)]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is True
+        # No expiry warning, but possible unmatched warning won't fire
+        assert not any("expired" in w for w in warnings)
+
+    def test_today_expiry_still_suppresses(self) -> None:
+        """Expiry date == today means it hasn't expired yet."""
+        issues = [_make_issue("E501")]
+        today = date.today().isoformat()
+        entries = [IgnoreIssueEntry(rule_id="E501", expires=today)]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert issues[0].ignored is True
+
+    def test_invalid_expires_format_warns_but_still_applies(self) -> None:
+        issues = [_make_issue("E501")]
+        entries = [IgnoreIssueEntry(rule_id="E501", expires="not-a-date")]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        # Invalid date -> warning about format, but entry is still active
+        assert issues[0].ignored is True
+        assert len(warnings) == 1
+        assert "invalid" in warnings[0].lower()
+
+
+class TestApplyIgnoreIssuesUnmatched:
+    """Unmatched entry warnings."""
+
+    def test_unmatched_entry_produces_warning(self) -> None:
+        issues = [_make_issue("E501")]
+        entries = [
+            IgnoreIssueEntry(rule_id="E501"),
+            IgnoreIssueEntry(rule_id="NONEXISTENT"),
+        ]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert len(warnings) == 1
+        assert "NONEXISTENT" in warnings[0]
+        assert "did not match" in warnings[0]
+
+    def test_all_matched_no_warning(self) -> None:
+        issues = [_make_issue("E501"), _make_issue("W503")]
+        entries = [
+            IgnoreIssueEntry(rule_id="E501"),
+            IgnoreIssueEntry(rule_id="W503"),
+        ]
+
+        warnings = apply_ignore_issues(issues, entries)
+
+        assert warnings == []

--- a/tests/unit/reporters/test_reporters.py
+++ b/tests/unit/reporters/test_reporters.py
@@ -704,6 +704,164 @@ class TestSARIFReporter:
         assert region["endLine"] == 45
 
 
+class TestJSONReporterIgnored:
+    """Tests for JSON reporter handling of ignored issues."""
+
+    def test_ignored_fields_included(self) -> None:
+        issue = UnifiedIssue(
+            id="test-1",
+            domain=ToolDomain.LINTING,
+            source_tool="ruff",
+            severity=Severity.LOW,
+            rule_id="E501",
+            title="Line too long",
+            description="Line too long",
+            ignored=True,
+            ignore_reason="Accepted",
+        )
+        result = ScanResult(issues=[issue])
+        result.summary = result.compute_summary()
+
+        reporter = JSONReporter()
+        output = io.StringIO()
+        reporter.report(result, output)
+
+        data = json.loads(output.getvalue())
+        assert data["issues"][0]["ignored"] is True
+        assert data["issues"][0]["ignore_reason"] == "Accepted"
+
+    def test_non_ignored_fields_default(self) -> None:
+        issue = UnifiedIssue(
+            id="test-1",
+            domain=ToolDomain.LINTING,
+            source_tool="ruff",
+            severity=Severity.LOW,
+            rule_id="E501",
+            title="Line too long",
+            description="Line too long",
+        )
+        result = ScanResult(issues=[issue])
+        result.summary = result.compute_summary()
+
+        reporter = JSONReporter()
+        output = io.StringIO()
+        reporter.report(result, output)
+
+        data = json.loads(output.getvalue())
+        assert data["issues"][0]["ignored"] is False
+        assert data["issues"][0]["ignore_reason"] is None
+
+
+class TestTableReporterIgnored:
+    """Tests for table reporter handling of ignored issues."""
+
+    def test_ignored_issue_shows_marker(self) -> None:
+        issue = UnifiedIssue(
+            id="test-1",
+            domain=ToolDomain.LINTING,
+            source_tool="ruff",
+            severity=Severity.LOW,
+            rule_id="E501",
+            title="Line too long",
+            description="Line too long",
+            file_path=Path("src/main.py"),
+            line_start=42,
+            ignored=True,
+        )
+        result = ScanResult(issues=[issue])
+        result.summary = result.compute_summary()
+
+        reporter = TableReporter()
+        output = io.StringIO()
+        reporter.report(result, output)
+
+        content = output.getvalue()
+        assert "[ignored]" in content
+
+    def test_ignored_count_in_summary(self) -> None:
+        issues = [
+            UnifiedIssue(
+                id="test-1",
+                domain=ToolDomain.LINTING,
+                source_tool="ruff",
+                severity=Severity.LOW,
+                rule_id="E501",
+                title="Line too long",
+                description="Line too long",
+                ignored=True,
+            ),
+            UnifiedIssue(
+                id="test-2",
+                domain=ToolDomain.LINTING,
+                source_tool="ruff",
+                severity=Severity.LOW,
+                rule_id="E502",
+                title="Another issue",
+                description="Another issue",
+            ),
+        ]
+        result = ScanResult(issues=issues)
+        result.summary = result.compute_summary()
+
+        reporter = TableReporter()
+        output = io.StringIO()
+        reporter.report(result, output)
+
+        content = output.getvalue()
+        assert "1 ignored" in content
+
+
+class TestSARIFReporterIgnored:
+    """Tests for SARIF reporter handling of ignored issues."""
+
+    def test_ignored_issue_has_suppressions(self) -> None:
+        issue = UnifiedIssue(
+            id="test-1",
+            domain=ScanDomain.SCA,
+            source_tool="trivy",
+            severity=Severity.HIGH,
+            rule_id="CVE-2021-1234",
+            title="Vulnerability",
+            description="A vulnerability",
+            ignored=True,
+            ignore_reason="Accepted risk",
+        )
+        result = ScanResult(issues=[issue])
+        result.summary = result.compute_summary()
+
+        reporter = SARIFReporter()
+        output = io.StringIO()
+        reporter.report(result, output)
+
+        data = json.loads(output.getvalue())
+        sarif_result = data["runs"][0]["results"][0]
+        assert "suppressions" in sarif_result
+        assert len(sarif_result["suppressions"]) == 1
+        assert sarif_result["suppressions"][0]["kind"] == "inSource"
+        assert sarif_result["suppressions"][0]["justification"] == "Accepted risk"
+
+    def test_non_ignored_issue_no_suppressions(self) -> None:
+        issue = UnifiedIssue(
+            id="test-1",
+            domain=ScanDomain.SCA,
+            source_tool="trivy",
+            severity=Severity.HIGH,
+            rule_id="CVE-2021-1234",
+            title="Vulnerability",
+            description="A vulnerability",
+        )
+        result = ScanResult(issues=[issue])
+        result.summary = result.compute_summary()
+
+        reporter = SARIFReporter()
+        output = io.StringIO()
+        reporter.report(result, output)
+
+        data = json.loads(output.getvalue())
+        sarif_result = data["runs"][0]["results"][0]
+        assert "suppressions" not in sarif_result
+
+
 class TestReporterDiscovery:
     """Tests for reporter plugin discovery."""
 


### PR DESCRIPTION
## Summary

- Adds `ignore_issues` top-level config option that lets users acknowledge specific rule IDs (CVEs, linting rules, etc.) so they still appear in output but are excluded from `fail_on` thresholds and exit codes
- Supports simple string entries (`- E501`), structured entries with `reason` and `expires` fields, and handles PyYAML bare-date auto-conversion (`expires: 2026-06-01` without quotes)
- Emits warnings for expired ignores and unmatched rule IDs (catches typos/stale entries)
- Integrated across CLI scan command, MCP tools, and all reporters (JSON, table, SARIF)

## Changes

**Core:**
- `src/lucidshark/core/ignore_issues.py` — new module with `apply_ignore_issues()` logic
- `src/lucidshark/core/models.py` — `ignored`/`ignore_reason` fields on `UnifiedIssue`, `ignored_total` on `ScanSummary`
- `src/lucidshark/config/models.py` — `IgnoreIssueEntry` dataclass, `ignore_issues` field on `LucidSharkConfig`

**Config parsing & validation:**
- `src/lucidshark/config/loader.py` — parses `ignore_issues` from YAML, normalizes PyYAML `datetime.date` objects to strings
- `src/lucidshark/config/validation.py` — validates structure, types, date format, unknown keys

**CLI & MCP integration:**
- `src/lucidshark/cli/commands/scan.py` — applies ignore rules, filters ignored issues from threshold checks
- `src/lucidshark/mcp/tools.py` — applies ignore rules in MCP scan path
- `src/lucidshark/mcp/formatter.py` — excluded ignored issues from `blocking`, `total_issues`, `severity_counts`, `domain_status`; surfaces `ignored`/`ignore_reason` in brief output

**Reporters:**
- JSON: includes `ignored` and `ignore_reason` fields
- Table: `[ignored]` tag and `*` severity marker, ignored count in summary
- SARIF: `suppressions` array with `justification` for ignored issues

**Docs:** Updated `README.md`, `docs/main.md`, `docs/help.md`, `docs/exclude-patterns.md`

## Test plan

- [x] 321 unit tests passing (including 25+ new tests for ignore_issues)
- [x] Linting: pass
- [x] Type checking: pass
- [x] SAST/SCA: pass
- [x] Duplication: 4.5% (under 5% threshold)
- [x] Verified PyYAML bare-date handling with dedicated tests
- [x] Verified expired/unmatched entry warnings
- [x] Verified ignored issues excluded from CLI `--fail-on` and per-domain thresholds
- [x] Verified MCP formatter excludes ignored issues from blocking/status

🤖 Generated with [Claude Code](https://claude.com/claude-code)