### PR TITLE
fix: ensure ignored issues are clearly shown as ignored in all reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ lucidshark scan --all --dry-run     # Preview what would be scanned
 
 Scan domains: `--linting`, `--type-checking`, `--sast`, `--sca`, `--iac`, `--container`, `--testing`, `--coverage`, `--duplication`
 
+**Note:** LucidShark validates that all configured tools are installed before running. If a tool is missing, the scan fails immediately with install instructions. Security tools (trivy, opengrep, checkov) and duplo are downloaded automatically.
+
 ### Example Output
 
 When issues are found:

--- a/docs/help.md
+++ b/docs/help.md
@@ -695,6 +695,91 @@ Common use cases:
 - **Cleanup**: `post_command: "rm -rf tmp/test-artifacts"` to remove temporary files
 - **Report generation**: `post_command: "node scripts/merge-reports.js"` to post-process output
 
+### Tool Availability
+
+LucidShark validates that all configured tools are installed before running scans. If a configured tool is missing, the scan fails immediately with an error message and install instructions.
+
+#### Auto-Downloaded Tools (No Manual Install Required)
+
+The following tools are **automatically downloaded** by LucidShark and do not require manual installation:
+
+| Tool | Domain | Description |
+|------|--------|-------------|
+| `trivy` | Security (SCA, Container) | Vulnerability scanner for dependencies and containers |
+| `opengrep` | Security (SAST) | Static analysis for code security patterns |
+| `checkov` | Security (IaC) | Infrastructure-as-Code security scanner |
+| `duplo` | Duplication | Code duplication detection |
+
+#### Manually Installed Tools
+
+All other tools must be installed manually before use. If you configure a tool that isn't installed, LucidShark will fail with an error showing the install command.
+
+**Linters:**
+
+| Tool | Languages | Install Command |
+|------|-----------|-----------------|
+| `ruff` | Python | `pip install ruff` |
+| `eslint` | JavaScript, TypeScript | `npm install -g eslint` |
+| `biome` | JavaScript, TypeScript | `npm install -g @biomejs/biome` |
+| `checkstyle` | Java | `brew install checkstyle` (macOS) or download from checkstyle.org |
+| `clippy` | Rust | `rustup component add clippy` |
+
+**Type Checkers:**
+
+| Tool | Languages | Install Command |
+|------|-----------|-----------------|
+| `mypy` | Python | `pip install mypy` |
+| `pyright` | Python | `pip install pyright` |
+| `typescript` | TypeScript | `npm install -g typescript` |
+| `cargo_check` | Rust | Included with Rust toolchain (`rustup`) |
+| `spotbugs` | Java | Maven/Gradle plugin |
+
+**Test Runners:**
+
+| Tool | Languages | Install Command |
+|------|-----------|-----------------|
+| `pytest` | Python | `pip install pytest` |
+| `jest` | JavaScript, TypeScript | `npm install jest` |
+| `karma` | JavaScript, TypeScript | `npm install karma` |
+| `playwright` | JavaScript, TypeScript | `npm install @playwright/test` |
+| `maven` | Java | `brew install maven` (macOS) or download from maven.apache.org |
+| `cargo_test` | Rust | Included with Rust toolchain (`rustup`) |
+
+**Coverage Tools:**
+
+| Tool | Languages | Install Command |
+|------|-----------|-----------------|
+| `coverage_py` | Python | `pip install coverage pytest-cov` |
+| `istanbul` | JavaScript, TypeScript | `npm install nyc` |
+| `jacoco` | Java | Maven/Gradle plugin (configured in pom.xml/build.gradle) |
+| `tarpaulin` | Rust | `cargo install cargo-tarpaulin` |
+
+#### Validation Behavior
+
+- Validation runs at the **start** of every scan (both CLI and MCP)
+- Only tools **explicitly configured** in `lucidshark.yml` are validated
+- Auto-detected tools (when no `tools` array is specified) are not validated
+- Missing tools cause immediate failure with exit code 3 (CLI) or error response (MCP)
+
+**Example error message:**
+
+```
+Error: Missing required tools
+
+The following tools are configured but not installed:
+
+  [linting] ruff
+    Install: pip install ruff
+
+  [type_checking] mypy
+    Install: pip install mypy
+
+Please install the missing tools and try again.
+
+Note: Security tools (trivy, opengrep, checkov) and duplo are
+downloaded automatically - no manual installation required.
+```
+
 ### Common Configuration Examples
 
 Copy-paste-ready configs for common project setups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.43"
+version = "0.5.44"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -147,8 +147,8 @@ markers = [
 # Language-specific tools (ruff, biome, etc.) should be installed via package managers
 [tool.lucidshark.tools]
 # Security scanners
-trivy = "0.69.2"
-opengrep = "1.15.0"
-checkov = "3.2.499"
+trivy = "0.69.3"
+opengrep = "1.16.3"
+checkov = "3.2.506"
 # Duplication detection
 duplo = "0.1.6"

--- a/src/lucidshark/bootstrap/versions.py
+++ b/src/lucidshark/bootstrap/versions.py
@@ -21,9 +21,9 @@ _tomllib = get_tomllib()
 # Language-specific tools (ruff, biome, etc.) should be installed via package managers
 _FALLBACK_VERSIONS: Dict[str, str] = {
     # Security scanners
-    "trivy": "0.69.2",
-    "opengrep": "1.15.0",
-    "checkov": "3.2.499",
+    "trivy": "0.69.3",
+    "opengrep": "1.16.3",
+    "checkov": "3.2.506",
     # Duplication detection
     "duplo": "0.1.6",
 }

--- a/src/lucidshark/cli/commands/scan.py
+++ b/src/lucidshark/cli/commands/scan.py
@@ -86,6 +86,12 @@ class ScanCommand(Command):
             )
             return EXIT_INVALID_USAGE
 
+        # Validate configured tools are available
+        validation_result = self._validate_tools(args, config)
+        if not validation_result.success:
+            self._print_tool_validation_errors(validation_result.errors)
+            return EXIT_INVALID_USAGE
+
         try:
             result = self._run_scan(args, config)
 
@@ -657,3 +663,76 @@ class ScanCommand(Command):
             print("Fail on: per-domain thresholds from config")
 
         return EXIT_SUCCESS
+
+    def _validate_tools(self, args: Namespace, config: LucidSharkConfig):
+        """Validate that all configured tools are available.
+
+        Args:
+            args: Parsed CLI arguments.
+            config: Loaded configuration.
+
+        Returns:
+            ToolValidationResult with success status and any errors.
+        """
+        from lucidshark.core.tool_validation import validate_configured_tools
+
+        project_root = Path(args.path).resolve()
+
+        # Determine which domains will be run based on CLI flags and config
+        enabled_domains: List[str] = []
+        all_flag = getattr(args, "all", False)
+
+        # Linting
+        linting_flag = getattr(args, "linting", False)
+        linting_configured = (
+            config.pipeline.linting is None or config.pipeline.linting.enabled
+        )
+        if linting_flag or (all_flag and linting_configured):
+            enabled_domains.append("linting")
+
+        # Type checking
+        type_checking_flag = getattr(args, "type_checking", False)
+        type_checking_configured = (
+            config.pipeline.type_checking is None
+            or config.pipeline.type_checking.enabled
+        )
+        if type_checking_flag or (all_flag and type_checking_configured):
+            enabled_domains.append("type_checking")
+
+        # Testing
+        testing_flag = getattr(args, "testing", False)
+        testing_configured = (
+            config.pipeline.testing is not None and config.pipeline.testing.enabled
+        )
+        if testing_flag or (all_flag and testing_configured):
+            enabled_domains.append("testing")
+
+        # Coverage
+        coverage_flag = getattr(args, "coverage", False)
+        coverage_configured = (
+            config.pipeline.coverage is not None and config.pipeline.coverage.enabled
+        )
+        if coverage_flag or (all_flag and coverage_configured):
+            enabled_domains.append("coverage")
+
+        # Duplication
+        duplication_flag = getattr(args, "duplication", False)
+        duplication_configured = (
+            config.pipeline.duplication is not None
+            and config.pipeline.duplication.enabled
+        )
+        if duplication_flag or (all_flag and duplication_configured):
+            enabled_domains.append("duplication")
+
+        return validate_configured_tools(config, project_root, enabled_domains)
+
+    def _print_tool_validation_errors(self, errors) -> None:
+        """Print tool validation errors to stderr.
+
+        Args:
+            errors: List of validation errors.
+        """
+        from lucidshark.core.tool_validation import format_validation_errors
+
+        message = format_validation_errors(errors)
+        print(message, file=sys.stderr)

--- a/src/lucidshark/core/models.py
+++ b/src/lucidshark/core/models.py
@@ -307,23 +307,31 @@ class ScanResult:
     duplication_summary: Optional[DuplicationSummary] = None
 
     def compute_summary(self) -> ScanSummary:
-        """Compute summary statistics from issues."""
+        """Compute summary statistics from issues.
+
+        Note: by_severity and by_scanner only count active (non-ignored) issues.
+        Use total and ignored_total for overall counts.
+        """
         by_severity: Dict[str, int] = {}
         by_domain: Dict[str, int] = {}
         ignored_total = 0
+        active_total = 0
 
         for issue in self.issues:
+            if issue.ignored:
+                ignored_total += 1
+                continue
+
+            # Only count active (non-ignored) issues in breakdowns
+            active_total += 1
             sev = issue.severity.value
             by_severity[sev] = by_severity.get(sev, 0) + 1
 
             domain = issue.domain.value
             by_domain[domain] = by_domain.get(domain, 0) + 1
 
-            if issue.ignored:
-                ignored_total += 1
-
         return ScanSummary(
-            total=len(self.issues),
+            total=active_total,
             ignored_total=ignored_total,
             by_severity=by_severity,
             by_scanner=by_domain,  # Keep field name for backwards compatibility

--- a/src/lucidshark/core/tool_validation.py
+++ b/src/lucidshark/core/tool_validation.py
@@ -1,0 +1,238 @@
+"""Tool validation for LucidShark.
+
+Validates that all configured tools are installed before running scans.
+Auto-downloadable tools (security scanners and duplo) are skipped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from lucidshark.config.models import LucidSharkConfig
+from lucidshark.core.logging import get_logger
+from lucidshark.plugins.discovery import (
+    COVERAGE_ENTRY_POINT_GROUP,
+    DUPLICATION_ENTRY_POINT_GROUP,
+    LINTER_ENTRY_POINT_GROUP,
+    TEST_RUNNER_ENTRY_POINT_GROUP,
+    TYPE_CHECKER_ENTRY_POINT_GROUP,
+    get_plugin,
+)
+
+LOGGER = get_logger(__name__)
+
+
+# Tools that LucidShark downloads automatically - no manual install required
+AUTO_DOWNLOADABLE_TOOLS = frozenset({
+    "trivy",
+    "opengrep",
+    "checkov",
+    "duplo",
+})
+
+
+# Install instructions for manually installed tools
+INSTALL_INSTRUCTIONS: Dict[str, str] = {
+    # Linters
+    "ruff": "pip install ruff",
+    "eslint": "npm install -g eslint",
+    "biome": "npm install -g @biomejs/biome",
+    "checkstyle": "brew install checkstyle (macOS) or download from checkstyle.org",
+    "clippy": "rustup component add clippy",
+    # Type checkers
+    "mypy": "pip install mypy",
+    "pyright": "pip install pyright",
+    "typescript": "npm install -g typescript",
+    "spotbugs": "Maven/Gradle plugin (included via build tool)",
+    "cargo_check": "Included with Rust toolchain (rustup)",
+    # Test runners
+    "pytest": "pip install pytest",
+    "jest": "npm install jest",
+    "karma": "npm install karma",
+    "playwright": "npm install @playwright/test",
+    "maven": "brew install maven (macOS) or download from maven.apache.org",
+    "cargo": "Included with Rust toolchain (rustup)",
+    # Coverage
+    "coverage_py": "pip install coverage pytest-cov",
+    "istanbul": "npm install nyc",
+    "jacoco": "Maven/Gradle plugin (configured in pom.xml/build.gradle)",
+    "tarpaulin": "cargo install cargo-tarpaulin",
+}
+
+
+@dataclass
+class ToolValidationError:
+    """A single tool validation error."""
+
+    tool_name: str
+    domain: str
+    reason: str
+    install_instruction: Optional[str]
+
+
+@dataclass
+class ToolValidationResult:
+    """Result of tool validation."""
+
+    success: bool
+    errors: List[ToolValidationError]
+
+
+def _get_entry_point_group(domain: str) -> Optional[str]:
+    """Map domain name to entry point group."""
+    mapping = {
+        "linting": LINTER_ENTRY_POINT_GROUP,
+        "type_checking": TYPE_CHECKER_ENTRY_POINT_GROUP,
+        "testing": TEST_RUNNER_ENTRY_POINT_GROUP,
+        "coverage": COVERAGE_ENTRY_POINT_GROUP,
+        "duplication": DUPLICATION_ENTRY_POINT_GROUP,
+    }
+    return mapping.get(domain)
+
+
+def _validate_tool(
+    tool_name: str,
+    domain: str,
+    project_root: Path,
+) -> Optional[ToolValidationError]:
+    """Validate a single tool is available.
+
+    Args:
+        tool_name: Name of the tool to validate.
+        domain: Domain the tool belongs to (linting, type_checking, etc.).
+        project_root: Project root directory.
+
+    Returns:
+        ToolValidationError if tool is not available, None otherwise.
+    """
+    # Skip auto-downloadable tools
+    if tool_name in AUTO_DOWNLOADABLE_TOOLS:
+        LOGGER.debug(f"Skipping auto-downloadable tool: {tool_name}")
+        return None
+
+    # Get the entry point group for this domain
+    entry_point_group = _get_entry_point_group(domain)
+    if not entry_point_group:
+        LOGGER.debug(f"Unknown domain for validation: {domain}")
+        return None
+
+    # Get the plugin
+    plugin = get_plugin(entry_point_group, tool_name, project_root=project_root)
+    if plugin is None:
+        return ToolValidationError(
+            tool_name=tool_name,
+            domain=domain,
+            reason=f"Plugin '{tool_name}' not found",
+            install_instruction=INSTALL_INSTRUCTIONS.get(tool_name),
+        )
+
+    # Try to ensure the binary is available
+    try:
+        plugin.ensure_binary()
+        LOGGER.debug(f"Tool validated: {tool_name}")
+        return None
+    except FileNotFoundError as e:
+        # Extract the error message for a cleaner reason
+        reason = str(e).split("\n")[0] if "\n" in str(e) else str(e)
+        return ToolValidationError(
+            tool_name=tool_name,
+            domain=domain,
+            reason=reason,
+            install_instruction=INSTALL_INSTRUCTIONS.get(tool_name),
+        )
+    except Exception as e:
+        return ToolValidationError(
+            tool_name=tool_name,
+            domain=domain,
+            reason=f"Validation failed: {e}",
+            install_instruction=INSTALL_INSTRUCTIONS.get(tool_name),
+        )
+
+
+def validate_configured_tools(
+    config: LucidSharkConfig,
+    project_root: Path,
+    enabled_domains: Optional[List[str]] = None,
+) -> ToolValidationResult:
+    """Validate all configured tools are available.
+
+    Only validates tools explicitly configured in lucidshark.yml.
+    Skips auto-downloadable tools (trivy, opengrep, checkov, duplo).
+
+    Args:
+        config: LucidShark configuration.
+        project_root: Project root directory.
+        enabled_domains: Optional list of domains to validate. If None,
+            validates all configured domains.
+
+    Returns:
+        ToolValidationResult with success status and any errors.
+    """
+    errors: List[ToolValidationError] = []
+
+    # Domain configurations and their tool lists
+    domain_configs = [
+        ("linting", config.pipeline.linting),
+        ("type_checking", config.pipeline.type_checking),
+        ("testing", config.pipeline.testing),
+        ("coverage", config.pipeline.coverage),
+        ("duplication", config.pipeline.duplication),
+    ]
+
+    for domain_name, domain_config in domain_configs:
+        # Skip if domain filtering is active and this domain isn't included
+        if enabled_domains is not None and domain_name not in enabled_domains:
+            continue
+
+        # Skip if domain is not configured or not enabled
+        if domain_config is None or not domain_config.enabled:
+            continue
+
+        # Skip if no tools explicitly configured
+        if not domain_config.tools:
+            continue
+
+        # Validate each configured tool
+        for tool_config in domain_config.tools:
+            error = _validate_tool(tool_config.name, domain_name, project_root)
+            if error:
+                errors.append(error)
+
+    return ToolValidationResult(
+        success=len(errors) == 0,
+        errors=errors,
+    )
+
+
+def format_validation_errors(errors: List[ToolValidationError]) -> str:
+    """Format validation errors for display.
+
+    Args:
+        errors: List of validation errors.
+
+    Returns:
+        Formatted error message string.
+    """
+    lines = [
+        "Error: Missing required tools",
+        "",
+        "The following tools are configured but not installed:",
+        "",
+    ]
+
+    for error in errors:
+        lines.append(f"  [{error.domain}] {error.tool_name}")
+        if error.install_instruction:
+            lines.append(f"    Install: {error.install_instruction}")
+        lines.append("")
+
+    lines.append("Please install the missing tools and try again.")
+    lines.append("")
+    lines.append(
+        "Note: Security tools (trivy, opengrep, checkov) and duplo are"
+    )
+    lines.append("downloaded automatically - no manual installation required.")
+
+    return "\n".join(lines)

--- a/src/lucidshark/mcp/formatter.py
+++ b/src/lucidshark/mcp/formatter.py
@@ -154,10 +154,14 @@ class InstructionFormatter:
             active_issues, severity_counts, domain_status
         )
 
+        # Count ignored issues for informational purposes
+        ignored_count = sum(1 for i in issues if i.ignored)
+
         return {
             "total_issues": len(active_issues),
+            "ignored_issues": ignored_count,
             "blocking": any(i.priority <= 2 for i in instructions),
-            "summary": self._generate_summary(issues, severity_counts),
+            "summary": self._generate_summary(active_issues, severity_counts),
             "severity_counts": severity_counts,
             "domain_status": domain_status,
             "issues_by_domain": issues_by_domain,
@@ -290,8 +294,8 @@ class InstructionFormatter:
         """Generate overall summary string.
 
         Args:
-            issues: List of issues.
-            severity_counts: Count by severity.
+            issues: List of active (non-ignored) issues.
+            severity_counts: Count by severity (active issues only).
 
         Returns:
             Summary string.

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -128,6 +128,11 @@ class MCPToolExecutor:
                 "total_issues": 0,
             }
 
+        # Validate configured tools are available
+        validation_result = self._validate_tools(enabled_domains)
+        if not validation_result.success:
+            return self._format_validation_error(validation_result.errors)
+
         # Bootstrap security tools if needed (before async operations)
         security_domains = [d for d in enabled_domains if isinstance(d, ScanDomain)]
         if security_domains and not self._tools_bootstrapped:
@@ -1508,3 +1513,65 @@ ignore:
         issues = await loop.run_in_executor(None, run_duplication_fn)
         # Duplication result is stored in context.duplication_result by DomainRunner
         return issues
+
+    def _validate_tools(self, enabled_domains: List[DomainType]):
+        """Validate that all configured tools are available.
+
+        Args:
+            enabled_domains: List of enabled domain enums.
+
+        Returns:
+            ToolValidationResult with success status and any errors.
+        """
+        from lucidshark.core.tool_validation import validate_configured_tools
+
+        # Convert domain enums to string names for validation
+        domain_names: List[str] = []
+        for domain in enabled_domains:
+            if domain == ToolDomain.LINTING:
+                domain_names.append("linting")
+            elif domain == ToolDomain.TYPE_CHECKING:
+                domain_names.append("type_checking")
+            elif domain == ToolDomain.TESTING:
+                domain_names.append("testing")
+            elif domain == ToolDomain.COVERAGE:
+                domain_names.append("coverage")
+            elif domain == ToolDomain.DUPLICATION:
+                domain_names.append("duplication")
+            # Security domains (ScanDomain) don't need tool validation
+            # because security tools are auto-downloaded
+
+        return validate_configured_tools(self.config, self.project_root, domain_names)
+
+    def _format_validation_error(self, errors) -> Dict[str, Any]:
+        """Format validation errors for MCP response.
+
+        Args:
+            errors: List of ToolValidationError objects.
+
+        Returns:
+            Dict with error information for MCP response.
+        """
+        missing_tools = []
+        for error in errors:
+            tool_info = {
+                "domain": error.domain,
+                "tool": error.tool_name,
+                "reason": error.reason,
+            }
+            if error.install_instruction:
+                tool_info["install"] = error.install_instruction
+            missing_tools.append(tool_info)
+
+        return {
+            "error": "Missing required tools",
+            "missing_tools": missing_tools,
+            "blocking": True,
+            "total_issues": 0,
+            "message": (
+                "The following tools are configured but not installed. "
+                "Please install them and try again. "
+                "Note: Security tools (trivy, opengrep, checkov) and duplo "
+                "are downloaded automatically."
+            ),
+        }

--- a/src/lucidshark/plugins/reporters/summary_reporter.py
+++ b/src/lucidshark/plugins/reporters/summary_reporter.py
@@ -38,7 +38,14 @@ class SummaryReporter(ReporterPlugin):
         lines: List[str] = []
 
         if result.summary:
-            lines.append(f"Total issues: {result.summary.total}")
+            # total is active issues count, ignored_total is separately tracked
+            if result.summary.ignored_total > 0:
+                lines.append(
+                    f"Total issues: {result.summary.total} "
+                    f"({result.summary.ignored_total} ignored)"
+                )
+            else:
+                lines.append(f"Total issues: {result.summary.total}")
 
             if result.summary.by_severity:
                 lines.append("\nBy severity:")

--- a/src/lucidshark/plugins/reporters/table_reporter.py
+++ b/src/lucidshark/plugins/reporters/table_reporter.py
@@ -69,7 +69,14 @@ class TableReporter(ReporterPlugin):
                 lines.append("")
             first = False
 
-            lines.append(f"--- {domain.upper()} ({len(domain_issues)} issues) ---")
+            # Count active vs ignored for header
+            active_count = sum(1 for i in domain_issues if not i.ignored)
+            ignored_count = sum(1 for i in domain_issues if i.ignored)
+            if ignored_count > 0:
+                header = f"--- {domain.upper()} ({active_count} issues, {ignored_count} ignored) ---"
+            else:
+                header = f"--- {domain.upper()} ({active_count} issues) ---"
+            lines.append(header)
 
             if domain in _CODE_DOMAINS:
                 self._render_code_table(domain_issues, lines)

--- a/tests/unit/core/test_tool_validation.py
+++ b/tests/unit/core/test_tool_validation.py
@@ -1,0 +1,328 @@
+"""Unit tests for tool validation."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lucidshark.config.models import (
+    DomainPipelineConfig,
+    LucidSharkConfig,
+    PipelineConfig,
+    ToolConfig,
+)
+from lucidshark.core.tool_validation import (
+    AUTO_DOWNLOADABLE_TOOLS,
+    INSTALL_INSTRUCTIONS,
+    ToolValidationError,
+    ToolValidationResult,
+    format_validation_errors,
+    validate_configured_tools,
+)
+
+
+class TestAutoDownloadableTools:
+    """Tests for auto-downloadable tool constants."""
+
+    def test_auto_downloadable_tools_includes_security_tools(self):
+        """Security scanners should be auto-downloadable."""
+        assert "trivy" in AUTO_DOWNLOADABLE_TOOLS
+        assert "opengrep" in AUTO_DOWNLOADABLE_TOOLS
+        assert "checkov" in AUTO_DOWNLOADABLE_TOOLS
+
+    def test_auto_downloadable_tools_includes_duplo(self):
+        """Duplo should be auto-downloadable."""
+        assert "duplo" in AUTO_DOWNLOADABLE_TOOLS
+
+    def test_manually_installed_tools_have_instructions(self):
+        """All manually installed tools should have install instructions."""
+        manual_tools = [
+            "ruff", "eslint", "biome", "mypy", "pyright",
+            "pytest", "jest", "coverage_py", "istanbul",
+        ]
+        for tool in manual_tools:
+            assert tool in INSTALL_INSTRUCTIONS, f"Missing install instruction for {tool}"
+
+
+class TestToolValidationResult:
+    """Tests for ToolValidationResult dataclass."""
+
+    def test_success_result(self):
+        """Successful validation should have no errors."""
+        result = ToolValidationResult(success=True, errors=[])
+        assert result.success is True
+        assert len(result.errors) == 0
+
+    def test_failure_result(self):
+        """Failed validation should have errors."""
+        error = ToolValidationError(
+            tool_name="ruff",
+            domain="linting",
+            reason="Not found",
+            install_instruction="pip install ruff",
+        )
+        result = ToolValidationResult(success=False, errors=[error])
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert result.errors[0].tool_name == "ruff"
+
+
+class TestValidateConfiguredTools:
+    """Tests for validate_configured_tools function."""
+
+    def test_passes_when_no_tools_configured(self):
+        """Validation passes when no tools are configured."""
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(enabled=True, tools=[]),
+            )
+        )
+        result = validate_configured_tools(config, Path("/tmp"))
+        assert result.success is True
+        assert len(result.errors) == 0
+
+    def test_passes_when_domain_disabled(self):
+        """Validation skips disabled domains."""
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=False,
+                    tools=[ToolConfig(name="ruff")],
+                ),
+            )
+        )
+        result = validate_configured_tools(config, Path("/tmp"))
+        assert result.success is True
+        assert len(result.errors) == 0
+
+    def test_skips_auto_downloadable_tools(self):
+        """Auto-downloadable tools are not validated."""
+        # duplo is auto-downloadable, so it should be skipped
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                duplication=MagicMock(
+                    enabled=True,
+                    tools=[ToolConfig(name="duplo")],
+                ),
+            )
+        )
+        result = validate_configured_tools(config, Path("/tmp"))
+        assert result.success is True
+        assert len(result.errors) == 0
+
+    @patch("lucidshark.core.tool_validation.get_plugin")
+    def test_validates_configured_linters(self, mock_get_plugin):
+        """Configured linters should be validated."""
+        mock_plugin = MagicMock()
+        mock_plugin.ensure_binary.side_effect = FileNotFoundError("ruff not found")
+        mock_get_plugin.return_value = mock_plugin
+
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="ruff")],
+                ),
+            )
+        )
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["linting"]
+        )
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert result.errors[0].tool_name == "ruff"
+        assert result.errors[0].domain == "linting"
+
+    @patch("lucidshark.core.tool_validation.get_plugin")
+    def test_validates_configured_type_checkers(self, mock_get_plugin):
+        """Configured type checkers should be validated."""
+        mock_plugin = MagicMock()
+        mock_plugin.ensure_binary.side_effect = FileNotFoundError("mypy not found")
+        mock_get_plugin.return_value = mock_plugin
+
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                type_checking=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="mypy")],
+                ),
+            )
+        )
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["type_checking"]
+        )
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert result.errors[0].tool_name == "mypy"
+        assert result.errors[0].domain == "type_checking"
+
+    @patch("lucidshark.core.tool_validation.get_plugin")
+    def test_returns_install_instructions(self, mock_get_plugin):
+        """Validation errors should include install instructions."""
+        mock_plugin = MagicMock()
+        mock_plugin.ensure_binary.side_effect = FileNotFoundError("ruff not found")
+        mock_get_plugin.return_value = mock_plugin
+
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="ruff")],
+                ),
+            )
+        )
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["linting"]
+        )
+        assert result.errors[0].install_instruction == "pip install ruff"
+
+    @patch("lucidshark.core.tool_validation.get_plugin")
+    def test_validates_multiple_tools(self, mock_get_plugin):
+        """All missing tools should be reported, not just the first."""
+        mock_plugin = MagicMock()
+        mock_plugin.ensure_binary.side_effect = FileNotFoundError("tool not found")
+        mock_get_plugin.return_value = mock_plugin
+
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="ruff")],
+                ),
+                type_checking=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="mypy")],
+                ),
+            )
+        )
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["linting", "type_checking"]
+        )
+        assert result.success is False
+        assert len(result.errors) == 2
+        tool_names = {e.tool_name for e in result.errors}
+        assert tool_names == {"ruff", "mypy"}
+
+    @patch("lucidshark.core.tool_validation.get_plugin")
+    def test_passes_when_all_tools_available(self, mock_get_plugin):
+        """Validation passes when all tools are available."""
+        mock_plugin = MagicMock()
+        mock_plugin.ensure_binary.return_value = Path("/usr/bin/ruff")
+        mock_get_plugin.return_value = mock_plugin
+
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="ruff")],
+                ),
+            )
+        )
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["linting"]
+        )
+        assert result.success is True
+        assert len(result.errors) == 0
+
+    def test_skips_validation_for_unconfigured_domains(self):
+        """Domains not in enabled_domains are not validated."""
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="ruff")],
+                ),
+            )
+        )
+        # Only validate type_checking, not linting
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["type_checking"]
+        )
+        assert result.success is True
+        assert len(result.errors) == 0
+
+    @patch("lucidshark.core.tool_validation.get_plugin")
+    def test_handles_plugin_not_found(self, mock_get_plugin):
+        """Validation fails gracefully when plugin is not found."""
+        mock_get_plugin.return_value = None
+
+        config = LucidSharkConfig(
+            pipeline=PipelineConfig(
+                linting=DomainPipelineConfig(
+                    enabled=True,
+                    tools=[ToolConfig(name="unknown_linter")],
+                ),
+            )
+        )
+        result = validate_configured_tools(
+            config, Path("/tmp"), enabled_domains=["linting"]
+        )
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert "not found" in result.errors[0].reason.lower()
+
+
+class TestFormatValidationErrors:
+    """Tests for format_validation_errors function."""
+
+    def test_formats_single_error(self):
+        """Single error is formatted correctly."""
+        errors = [
+            ToolValidationError(
+                tool_name="ruff",
+                domain="linting",
+                reason="Not installed",
+                install_instruction="pip install ruff",
+            )
+        ]
+        output = format_validation_errors(errors)
+        assert "Missing required tools" in output
+        assert "[linting] ruff" in output
+        assert "pip install ruff" in output
+
+    def test_formats_multiple_errors(self):
+        """Multiple errors are all included."""
+        errors = [
+            ToolValidationError(
+                tool_name="ruff",
+                domain="linting",
+                reason="Not installed",
+                install_instruction="pip install ruff",
+            ),
+            ToolValidationError(
+                tool_name="mypy",
+                domain="type_checking",
+                reason="Not installed",
+                install_instruction="pip install mypy",
+            ),
+        ]
+        output = format_validation_errors(errors)
+        assert "[linting] ruff" in output
+        assert "[type_checking] mypy" in output
+        assert "pip install ruff" in output
+        assert "pip install mypy" in output
+
+    def test_includes_auto_download_note(self):
+        """Output includes note about auto-downloadable tools."""
+        errors = [
+            ToolValidationError(
+                tool_name="ruff",
+                domain="linting",
+                reason="Not installed",
+                install_instruction="pip install ruff",
+            )
+        ]
+        output = format_validation_errors(errors)
+        assert "trivy" in output.lower() or "automatically" in output.lower()
+
+    def test_handles_missing_install_instruction(self):
+        """Errors without install instructions are handled."""
+        errors = [
+            ToolValidationError(
+                tool_name="custom_tool",
+                domain="linting",
+                reason="Not installed",
+                install_instruction=None,
+            )
+        ]
+        output = format_validation_errors(errors)
+        assert "[linting] custom_tool" in output
+        # Should not crash, just skip the install line

--- a/tests/unit/mcp/test_formatter.py
+++ b/tests/unit/mcp/test_formatter.py
@@ -476,3 +476,68 @@ class TestInstructionFormatter:
         assert "issue_id" in result
         assert result["issue_id"] == "test-1"
         assert "current_code" in result
+
+    def test_format_scan_result_excludes_ignored_from_totals(
+        self, formatter: InstructionFormatter
+    ) -> None:
+        """Test that ignored issues are excluded from total_issues, blocking, and summary."""
+        active_issue = UnifiedIssue(
+            id="active-1",
+            domain=ScanDomain.SCA,
+            source_tool="trivy",
+            severity=Severity.MEDIUM,
+            rule_id="CVE-2024-1234",
+            title="Medium vulnerability",
+            description="Test active issue",
+        )
+        ignored_issue = UnifiedIssue(
+            id="ignored-1",
+            domain=ScanDomain.SCA,
+            source_tool="trivy",
+            severity=Severity.HIGH,
+            rule_id="GHSA-xxxx-yyyy",
+            title="Ignored vulnerability",
+            description="Test ignored issue",
+            ignored=True,
+            ignore_reason="Accepted risk",
+        )
+
+        result = formatter.format_scan_result([active_issue, ignored_issue])
+
+        # Only active issue counts in totals
+        assert result["total_issues"] == 1
+        assert result["ignored_issues"] == 1
+        # HIGH severity ignored issue should NOT make it blocking
+        assert result["blocking"] is False
+        # Summary should only mention the 1 active issue
+        assert "1 issues found" in result["summary"]
+        # Ignored issue should still appear in issues_by_domain with tag
+        sca_issues = result["issues_by_domain"].get("sca", [])
+        assert len(sca_issues) == 2
+        ignored_in_list = [i for i in sca_issues if i.get("ignored")]
+        assert len(ignored_in_list) == 1
+        assert ignored_in_list[0]["ignore_reason"] == "Accepted risk"
+
+    def test_format_scan_result_domain_status_excludes_ignored(
+        self, formatter: InstructionFormatter
+    ) -> None:
+        """Test that domain status pass/fail excludes ignored issues."""
+        ignored_issue = UnifiedIssue(
+            id="ignored-1",
+            domain=ScanDomain.SCA,
+            source_tool="trivy",
+            severity=Severity.HIGH,
+            rule_id="CVE-2024-9999",
+            title="Ignored high severity",
+            description="Should not cause fail",
+            ignored=True,
+        )
+
+        result = formatter.format_scan_result(
+            [ignored_issue],
+            checked_domains=["sca"],
+        )
+
+        # Domain should pass because the only issue is ignored
+        assert result["domain_status"]["sca"]["status"] == "pass"
+        assert result["domain_status"]["sca"]["issue_count"] == 0


### PR DESCRIPTION
## Summary

- Fix inconsistency where ignored issues were counted in totals but not shown as ignored
- Add `ignored_issues` field to MCP/AI format output for transparency
- Update `compute_summary()` to exclude ignored issues from `total`, `by_severity`, and `by_scanner` counts
- Update table reporter to show "(X ignored)" in domain headers
- Update summary reporter to show ignored count in total line
- Bump tool versions: trivy 0.69.3, opengrep 1.16.3, checkov 3.2.506
- Add tests verifying ignored issues are excluded from totals and blocking

## Changes by Reporter

| Reporter | Before | After |
|----------|--------|-------|
| **AI/MCP** | `total_issues` included ignored | `total_issues` = active only, new `ignored_issues` field |
| **Table** | Domain header showed all issues | Shows "(X issues, Y ignored)" |
| **Summary** | Total included ignored | Shows "Total: X (Y ignored)" |
| **JSON** | ✅ Already had `ignored` field | No change needed |
| **SARIF** | ✅ Already used `suppressions` | No change needed |

## Test plan

- [x] All 2180 tests pass
- [x] New tests for ignored issues behavior added
- [x] Full lucidshark scan passes