### PR TITLE
fix: add missing plugins to PyInstaller spec

### DIFF
--- a/lucidshark.spec
+++ b/lucidshark.spec
@@ -39,6 +39,7 @@ a = Analysis(
         'lucidshark.plugins.linters.eslint',
         'lucidshark.plugins.linters.biome',
         'lucidshark.plugins.linters.checkstyle',
+        'lucidshark.plugins.linters.clippy',
         # Plugin entry points - scanners
         'lucidshark.plugins.scanners.trivy',
         'lucidshark.plugins.scanners.opengrep',
@@ -53,14 +54,20 @@ a = Analysis(
         'lucidshark.plugins.type_checkers.mypy',
         'lucidshark.plugins.type_checkers.pyright',
         'lucidshark.plugins.type_checkers.typescript',
+        'lucidshark.plugins.type_checkers.spotbugs',
+        'lucidshark.plugins.type_checkers.cargo_check',
         # Plugin entry points - test runners
         'lucidshark.plugins.test_runners.pytest',
         'lucidshark.plugins.test_runners.jest',
         'lucidshark.plugins.test_runners.karma',
         'lucidshark.plugins.test_runners.playwright',
+        'lucidshark.plugins.test_runners.maven',
+        'lucidshark.plugins.test_runners.cargo',
         # Plugin entry points - coverage
         'lucidshark.plugins.coverage.coverage_py',
         'lucidshark.plugins.coverage.istanbul',
+        'lucidshark.plugins.coverage.jacoco',
+        'lucidshark.plugins.coverage.tarpaulin',
         # Plugin entry points - duplication
         'lucidshark.plugins.duplication.duplo',
         # Dependencies that may need explicit import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.44"
+version = "0.5.45"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Add 7 missing plugin imports to `lucidshark.spec` for PyInstaller bundling
- Fixes "No module named 'lucidshark.plugins.test_runners.maven'" and similar errors
- Enables Java/Kotlin and Rust ecosystem support in standalone binary

## Missing Plugins Added
| Category | Plugins |
|----------|---------|
| Linters | `clippy` |
| Type Checkers | `spotbugs`, `cargo_check` |
| Test Runners | `maven`, `cargo` |
| Coverage | `jacoco`, `tarpaulin` |

## Test plan
- [x] Built standalone binary with `pyinstaller lucidshark.spec`
- [x] Tested on Java project with Maven wrapper (`./mvnw`)
- [x] Verified all domains work: SCA, SAST, testing, coverage, duplication