### PR TITLE
fix: add missing PyInstaller plugins and improve SpotBugs detection

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -743,7 +743,7 @@ All other tools must be installed manually before use. If you configure a tool t
 | `karma` | JavaScript, TypeScript | `npm install karma` |
 | `playwright` | JavaScript, TypeScript | `npm install @playwright/test` |
 | `maven` | Java | `brew install maven` (macOS) or download from maven.apache.org |
-| `cargo_test` | Rust | Included with Rust toolchain (`rustup`) |
+| `cargo` | Rust | Included with Rust toolchain (`rustup`) |
 
 **Coverage Tools:**
 
@@ -1205,6 +1205,8 @@ lucidshark init
 This creates:
 - `.mcp.json` - MCP server configuration (auto-detects lucidshark path)
 - `.claude/skills/lucidshark/SKILL.md` - Proactive scanning skill for Claude
+- `.claude/CLAUDE.md` - Adds a managed section with scanning instructions
+- `.claude/settings.json` - PostToolUse hooks for scan reminders after code edits
 
 Or manually create `.mcp.json`:
 ```json

--- a/docs/main.md
+++ b/docs/main.md
@@ -253,7 +253,6 @@ pipeline:
     post_command: "make clean" # Optional: runs after command completes
     tools:
       - name: pytest
-        args: ["-v"]
 
 #### Custom Commands
 
@@ -501,7 +500,7 @@ pipeline:
     tools:
       - name: string
         config: string  # Path to tool config
-        args: [string]  # Additional arguments
+        options: {...}  # Tool-specific options (passed through)
 
   type_checking:
     enabled: boolean
@@ -512,7 +511,7 @@ pipeline:
     tools:
       - name: string
         strict: boolean
-        args: [string]
+        options: {...}  # Tool-specific options
 
   security:
     enabled: boolean
@@ -530,8 +529,7 @@ pipeline:
     exclude: [string]     # Patterns to exclude from testing
     tools:
       - name: string
-        args: [string]
-        coverage: boolean
+        options: {...}  # Tool-specific options
 
   coverage:
     enabled: boolean
@@ -681,9 +679,9 @@ LucidShark pins versions for tools it downloads directly (security scanners and 
 # pyproject.toml
 [tool.lucidshark.tools]
 # Security scanners
-trivy = "0.69.2"
-opengrep = "1.15.0"
-checkov = "3.2.499"
+trivy = "0.69.3"
+opengrep = "1.16.3"
+checkov = "3.2.506"
 # Duplication detection
 duplo = "0.1.6"
 ```

--- a/src/lucidshark/plugins/type_checkers/spotbugs.py
+++ b/src/lucidshark/plugins/type_checkers/spotbugs.py
@@ -90,15 +90,78 @@ class SpotBugsChecker(TypeCheckerPlugin):
         java_path = shutil.which("java")
         return Path(java_path) if java_path else None
 
+    def _find_spotbugs_dir_from_jar(self, jar_path: Path) -> Optional[Path]:
+        """Get the SpotBugs directory from a spotbugs.jar path.
+
+        Args:
+            jar_path: Path to spotbugs.jar
+
+        Returns:
+            Parent directory containing lib/spotbugs.jar, or None if invalid.
+        """
+        if jar_path.exists() and jar_path.name == "spotbugs.jar":
+            # jar is at <dir>/lib/spotbugs.jar, return <dir>
+            return jar_path.parent.parent
+        return None
+
+    def _search_for_spotbugs_jar(self, base_dir: Path) -> Optional[Path]:
+        """Search for spotbugs.jar in common locations relative to base_dir.
+
+        Args:
+            base_dir: Directory to search from.
+
+        Returns:
+            Path to directory containing lib/spotbugs.jar, or None.
+        """
+        # Common relative paths where spotbugs.jar might be found
+        # relative to a binary or installation directory
+        search_paths = [
+            # Standard layout: base/lib/spotbugs.jar
+            base_dir / "lib" / "spotbugs.jar",
+            # Homebrew libexec layout: base/libexec/lib/spotbugs.jar
+            base_dir / "libexec" / "lib" / "spotbugs.jar",
+            # Parent directory (if binary is in bin/)
+            base_dir.parent / "lib" / "spotbugs.jar",
+            # Homebrew: binary in bin/, jar in ../libexec/lib/
+            base_dir.parent / "libexec" / "lib" / "spotbugs.jar",
+            # Two levels up (common for nested bin directories)
+            base_dir.parent.parent / "lib" / "spotbugs.jar",
+            base_dir.parent.parent / "libexec" / "lib" / "spotbugs.jar",
+            # Share directory (Linux package managers)
+            base_dir / "share" / "spotbugs" / "lib" / "spotbugs.jar",
+            base_dir.parent / "share" / "spotbugs" / "lib" / "spotbugs.jar",
+        ]
+
+        for jar_path in search_paths:
+            try:
+                if jar_path.exists():
+                    result = self._find_spotbugs_dir_from_jar(jar_path)
+                    if result:
+                        LOGGER.debug(f"Found spotbugs.jar at {jar_path}")
+                        return result
+            except (OSError, PermissionError):
+                # Skip paths we can't access
+                continue
+
+        return None
+
     def ensure_binary(self) -> Path:
         """Ensure SpotBugs is available.
 
-        Checks for spotbugs in:
-        1. System PATH
-        2. SPOTBUGS_HOME environment variable
+        Searches for SpotBugs installation in this order:
+        1. SPOTBUGS_HOME environment variable (explicit user config)
+        2. spotbugs command in PATH (follows symlinks, searches nearby)
+        3. Common system installation paths
+
+        Supports various installation methods:
+        - Homebrew (macOS): libexec/lib/spotbugs.jar layout
+        - apt/yum (Linux): /usr/share/spotbugs/lib/spotbugs.jar
+        - Manual download: standard lib/spotbugs.jar layout
+        - SDKMAN: ~/.sdkman/candidates/spotbugs/current/
+        - Chocolatey/Scoop (Windows): standard layout
 
         Returns:
-            Path to SpotBugs directory containing the lib folder.
+            Path to SpotBugs directory containing the lib folder with spotbugs.jar.
 
         Raises:
             FileNotFoundError: If Java or SpotBugs is not installed.
@@ -110,28 +173,80 @@ class SpotBugsChecker(TypeCheckerPlugin):
                 "Install Java JDK/JRE to use SpotBugs."
             )
 
-        # Check for spotbugs in PATH
-        spotbugs_path = shutil.which("spotbugs")
-        if spotbugs_path:
-            # spotbugs script is usually in bin/, lib/ is a sibling
-            spotbugs_bin = Path(spotbugs_path).resolve()
-            spotbugs_dir = spotbugs_bin.parent.parent
-            spotbugs_jar = spotbugs_dir / "lib" / "spotbugs.jar"
-            if spotbugs_jar.exists():
-                return spotbugs_dir
-
-        # Check SPOTBUGS_HOME environment variable
+        # 1. Check SPOTBUGS_HOME environment variable first (explicit user config)
         spotbugs_home = os.environ.get("SPOTBUGS_HOME")
         if spotbugs_home:
             spotbugs_dir = Path(spotbugs_home)
-            spotbugs_jar = spotbugs_dir / "lib" / "spotbugs.jar"
-            if spotbugs_jar.exists():
+            result = self._search_for_spotbugs_jar(spotbugs_dir)
+            if result:
+                LOGGER.debug(f"Found SpotBugs via SPOTBUGS_HOME: {result}")
+                return result
+            # Also check if SPOTBUGS_HOME points directly to dir with lib/
+            jar_path = spotbugs_dir / "lib" / "spotbugs.jar"
+            if jar_path.exists():
+                LOGGER.debug(f"Found SpotBugs via SPOTBUGS_HOME: {spotbugs_dir}")
                 return spotbugs_dir
 
+        # 2. Check for spotbugs in PATH
+        spotbugs_path = shutil.which("spotbugs")
+        if spotbugs_path:
+            spotbugs_bin = Path(spotbugs_path)
+
+            # Try the original path first
+            result = self._search_for_spotbugs_jar(spotbugs_bin.parent)
+            if result:
+                LOGGER.debug(f"Found SpotBugs via PATH: {result}")
+                return result
+
+            # Resolve symlinks and try again (handles symlinked installations)
+            try:
+                resolved_bin = spotbugs_bin.resolve()
+                if resolved_bin != spotbugs_bin:
+                    result = self._search_for_spotbugs_jar(resolved_bin.parent)
+                    if result:
+                        LOGGER.debug(f"Found SpotBugs via resolved PATH: {result}")
+                        return result
+            except (OSError, RuntimeError):
+                pass  # Skip if symlink resolution fails
+
+        # 3. Check common system installation paths
+        common_paths = [
+            # Linux package manager locations
+            Path("/usr/share/spotbugs"),
+            Path("/usr/local/share/spotbugs"),
+            Path("/opt/spotbugs"),
+            # SDKMAN installation
+            Path.home() / ".sdkman" / "candidates" / "spotbugs" / "current",
+            # macOS Homebrew (Intel and Apple Silicon)
+            Path("/usr/local/opt/spotbugs/libexec"),
+            Path("/opt/homebrew/opt/spotbugs/libexec"),
+            # Windows Chocolatey
+            Path("C:/ProgramData/chocolatey/lib/spotbugs/tools"),
+            # Windows Scoop
+            Path.home() / "scoop" / "apps" / "spotbugs" / "current",
+        ]
+
+        for base_path in common_paths:
+            try:
+                if base_path.exists():
+                    result = self._search_for_spotbugs_jar(base_path)
+                    if result:
+                        LOGGER.debug(f"Found SpotBugs at common path: {result}")
+                        return result
+                    # Direct check for lib/spotbugs.jar
+                    jar_path = base_path / "lib" / "spotbugs.jar"
+                    if jar_path.exists():
+                        LOGGER.debug(f"Found SpotBugs at common path: {base_path}")
+                        return base_path
+            except (OSError, PermissionError):
+                continue
+
         raise FileNotFoundError(
-            "SpotBugs is not installed. Install it with:\n"
+            "SpotBugs is not installed or not found. Install it with:\n"
             "  brew install spotbugs  (macOS)\n"
             "  apt install spotbugs   (Debian/Ubuntu)\n"
+            "  choco install spotbugs (Windows)\n"
+            "  sdk install spotbugs   (SDKMAN)\n"
             "  OR download from https://spotbugs.github.io/ and set SPOTBUGS_HOME"
         )
 

--- a/tests/unit/plugins/type_checkers/test_spotbugs.py
+++ b/tests/unit/plugins/type_checkers/test_spotbugs.py
@@ -300,3 +300,240 @@ class TestSpotBugsIssueIdGeneration:
         issue_id = checker._generate_issue_id("NP_NULL", "file.java", 42, "msg")
 
         assert issue_id.startswith("spotbugs-NP_NULL-")
+
+
+class TestSpotBugsBinaryDetection:
+    """Tests for SpotBugs binary/installation detection."""
+
+    def test_find_spotbugs_dir_from_valid_jar(self) -> None:
+        """Test finding SpotBugs dir from a valid jar path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            lib_dir = base_dir / "lib"
+            lib_dir.mkdir()
+            jar_path = lib_dir / "spotbugs.jar"
+            jar_path.touch()
+
+            checker = SpotBugsChecker()
+            result = checker._find_spotbugs_dir_from_jar(jar_path)
+
+            assert result == base_dir
+
+    def test_find_spotbugs_dir_from_invalid_jar_name(self) -> None:
+        """Test returns None for jar with wrong name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            lib_dir = base_dir / "lib"
+            lib_dir.mkdir()
+            jar_path = lib_dir / "other.jar"
+            jar_path.touch()
+
+            checker = SpotBugsChecker()
+            result = checker._find_spotbugs_dir_from_jar(jar_path)
+
+            assert result is None
+
+    def test_find_spotbugs_dir_from_nonexistent_jar(self) -> None:
+        """Test returns None for non-existent jar."""
+        checker = SpotBugsChecker()
+        result = checker._find_spotbugs_dir_from_jar(Path("/nonexistent/spotbugs.jar"))
+        assert result is None
+
+    def test_search_standard_layout(self) -> None:
+        """Test searching in standard layout (lib/spotbugs.jar)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            lib_dir = base_dir / "lib"
+            lib_dir.mkdir()
+            (lib_dir / "spotbugs.jar").touch()
+
+            checker = SpotBugsChecker()
+            result = checker._search_for_spotbugs_jar(base_dir)
+
+            assert result == base_dir
+
+    def test_search_homebrew_libexec_layout(self) -> None:
+        """Test searching in Homebrew layout (libexec/lib/spotbugs.jar)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            libexec_lib = base_dir / "libexec" / "lib"
+            libexec_lib.mkdir(parents=True)
+            (libexec_lib / "spotbugs.jar").touch()
+
+            checker = SpotBugsChecker()
+            result = checker._search_for_spotbugs_jar(base_dir)
+
+            assert result == base_dir / "libexec"
+
+    def test_search_from_bin_directory(self) -> None:
+        """Test searching from bin directory finds sibling lib."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            bin_dir = base_dir / "bin"
+            bin_dir.mkdir()
+            lib_dir = base_dir / "lib"
+            lib_dir.mkdir()
+            (lib_dir / "spotbugs.jar").touch()
+
+            checker = SpotBugsChecker()
+            # Search from bin directory, should find ../lib/spotbugs.jar
+            result = checker._search_for_spotbugs_jar(bin_dir)
+
+            assert result == base_dir
+
+    def test_search_homebrew_from_bin_directory(self) -> None:
+        """Test searching from Homebrew bin finds libexec/lib."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Simulate Homebrew: base/bin/spotbugs, base/libexec/lib/spotbugs.jar
+            base_dir = Path(tmpdir)
+            bin_dir = base_dir / "bin"
+            bin_dir.mkdir()
+            libexec_lib = base_dir / "libexec" / "lib"
+            libexec_lib.mkdir(parents=True)
+            (libexec_lib / "spotbugs.jar").touch()
+
+            checker = SpotBugsChecker()
+            result = checker._search_for_spotbugs_jar(bin_dir)
+
+            assert result == base_dir / "libexec"
+
+    def test_search_share_layout(self) -> None:
+        """Test searching in Linux share layout (share/spotbugs/lib/)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            share_lib = base_dir / "share" / "spotbugs" / "lib"
+            share_lib.mkdir(parents=True)
+            (share_lib / "spotbugs.jar").touch()
+
+            checker = SpotBugsChecker()
+            result = checker._search_for_spotbugs_jar(base_dir)
+
+            assert result == base_dir / "share" / "spotbugs"
+
+    def test_search_returns_none_when_not_found(self) -> None:
+        """Test returns None when spotbugs.jar not found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+
+            checker = SpotBugsChecker()
+            result = checker._search_for_spotbugs_jar(base_dir)
+
+            assert result is None
+
+    @patch("shutil.which")
+    def test_ensure_binary_via_spotbugs_home(self, mock_which) -> None:
+        """Test ensure_binary finds SpotBugs via SPOTBUGS_HOME."""
+        mock_which.side_effect = lambda cmd: "/usr/bin/java" if cmd == "java" else None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spotbugs_dir = Path(tmpdir)
+            lib_dir = spotbugs_dir / "lib"
+            lib_dir.mkdir()
+            (lib_dir / "spotbugs.jar").touch()
+
+            checker = SpotBugsChecker()
+            with patch.dict("os.environ", {"SPOTBUGS_HOME": str(spotbugs_dir)}):
+                result = checker.ensure_binary()
+
+            assert result == spotbugs_dir
+
+    @patch("shutil.which")
+    def test_ensure_binary_via_path_standard_layout(self, mock_which) -> None:
+        """Test ensure_binary finds SpotBugs via PATH (standard layout)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spotbugs_dir = Path(tmpdir)
+            bin_dir = spotbugs_dir / "bin"
+            bin_dir.mkdir()
+            spotbugs_script = bin_dir / "spotbugs"
+            spotbugs_script.touch()
+            lib_dir = spotbugs_dir / "lib"
+            lib_dir.mkdir()
+            (lib_dir / "spotbugs.jar").touch()
+
+            def which_side_effect(cmd: str):
+                if cmd == "java":
+                    return "/usr/bin/java"
+                if cmd == "spotbugs":
+                    return str(spotbugs_script)
+                return None
+
+            mock_which.side_effect = which_side_effect
+
+            checker = SpotBugsChecker()
+            with patch.dict("os.environ", {}, clear=False):
+                # Remove SPOTBUGS_HOME if set
+                import os
+                env_backup = os.environ.pop("SPOTBUGS_HOME", None)
+                try:
+                    result = checker.ensure_binary()
+                finally:
+                    if env_backup:
+                        os.environ["SPOTBUGS_HOME"] = env_backup
+
+            assert result == spotbugs_dir
+
+    @patch("shutil.which")
+    def test_ensure_binary_via_path_homebrew_layout(self, mock_which) -> None:
+        """Test ensure_binary finds SpotBugs via PATH (Homebrew layout)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spotbugs_dir = Path(tmpdir)
+            bin_dir = spotbugs_dir / "bin"
+            bin_dir.mkdir()
+            spotbugs_script = bin_dir / "spotbugs"
+            spotbugs_script.touch()
+            # Homebrew layout: libexec/lib/spotbugs.jar
+            libexec_lib = spotbugs_dir / "libexec" / "lib"
+            libexec_lib.mkdir(parents=True)
+            (libexec_lib / "spotbugs.jar").touch()
+
+            def which_side_effect(cmd: str):
+                if cmd == "java":
+                    return "/usr/bin/java"
+                if cmd == "spotbugs":
+                    return str(spotbugs_script)
+                return None
+
+            mock_which.side_effect = which_side_effect
+
+            checker = SpotBugsChecker()
+            with patch.dict("os.environ", {}, clear=False):
+                import os
+                env_backup = os.environ.pop("SPOTBUGS_HOME", None)
+                try:
+                    result = checker.ensure_binary()
+                finally:
+                    if env_backup:
+                        os.environ["SPOTBUGS_HOME"] = env_backup
+
+            assert result == spotbugs_dir / "libexec"
+
+    @patch("lucidshark.plugins.type_checkers.spotbugs.shutil.which")
+    def test_ensure_binary_raises_when_not_found(self, mock_which) -> None:
+        """Test ensure_binary raises FileNotFoundError when not found."""
+        mock_which.side_effect = lambda cmd: "/usr/bin/java" if cmd == "java" else None
+
+        checker = SpotBugsChecker()
+
+        # Patch _search_for_spotbugs_jar to return None for all calls
+        # This simulates an environment where SpotBugs is not installed anywhere
+        with patch.object(checker, "_search_for_spotbugs_jar", return_value=None):
+            with patch.dict("os.environ", {}, clear=False):
+                import os
+                env_backup = os.environ.pop("SPOTBUGS_HOME", None)
+                try:
+                    # Also patch Path.exists for the direct jar checks in common paths
+                    original_exists = Path.exists
+
+                    def mock_exists(self):
+                        # Return False for spotbugs.jar paths
+                        if "spotbugs.jar" in str(self):
+                            return False
+                        return original_exists(self)
+
+                    with patch.object(Path, "exists", mock_exists):
+                        with pytest.raises(FileNotFoundError) as exc:
+                            checker.ensure_binary()
+                        assert "SpotBugs is not installed" in str(exc.value)
+                finally:
+                    if env_backup:
+                        os.environ["SPOTBUGS_HOME"] = env_backup


### PR DESCRIPTION
## Summary

- Add missing plugins to PyInstaller spec for standalone binary builds
- Fix SpotBugs detection to work across all installation methods and operating systems

## Changes

### PyInstaller Fixes
- Added missing plugin modules to the PyInstaller spec

### SpotBugs Detection Improvements
- Rewrote `ensure_binary()` to comprehensively search for SpotBugs installations
- Now supports:
  - `SPOTBUGS_HOME` environment variable
  - Standard layout (`lib/spotbugs.jar`)
  - Homebrew layout (`libexec/lib/spotbugs.jar`) - fixes macOS Homebrew installations
  - Linux package managers (`/usr/share/spotbugs`)
  - SDKMAN (`~/.sdkman/candidates/spotbugs/current`)
  - Chocolatey and Scoop on Windows

### Tests
- Added 13 new tests covering all SpotBugs detection scenarios

## Test plan

- [x] All existing tests pass
- [x] New SpotBugs detection tests pass (36 total)
- [x] Verified SpotBugs detection works on macOS with Homebrew installation
- [x] Linting and type checking pass