### PR TITLE
fix: separate ignored issues from active issues in AI formatter output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.46"
+version = "0.5.47"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lucidshark/mcp/formatter.py
+++ b/src/lucidshark/mcp/formatter.py
@@ -97,15 +97,23 @@ class InstructionFormatter:
             sev_name = issue.severity.value if issue.severity else "unknown"
             severity_counts[sev_name] = severity_counts.get(sev_name, 0) + 1
 
-        # Group issues by domain (all issues, including ignored — they carry the tag)
+        # Group active issues by domain (ignored issues go in a separate structure)
         issues_by_domain: Dict[str, List[Dict[str, Any]]] = {}
+        ignored_issues_by_domain: Dict[str, List[Dict[str, Any]]] = {}
         for issue in issues:
             domain_name = issue.domain.value if issue.domain else "unknown"
-            if domain_name not in issues_by_domain:
-                issues_by_domain[domain_name] = []
-            issues_by_domain[domain_name].append(
-                self._issue_to_brief(issue)
-            )
+            if issue.ignored:
+                if domain_name not in ignored_issues_by_domain:
+                    ignored_issues_by_domain[domain_name] = []
+                ignored_issues_by_domain[domain_name].append(
+                    self._issue_to_brief(issue)
+                )
+            else:
+                if domain_name not in issues_by_domain:
+                    issues_by_domain[domain_name] = []
+                issues_by_domain[domain_name].append(
+                    self._issue_to_brief(issue)
+                )
 
         # Build domain status (pass/fail for each checked domain)
         # Only active (non-ignored) issues count toward pass/fail
@@ -127,10 +135,10 @@ class InstructionFormatter:
                     }
                     continue
 
+                # issues_by_domain now only contains active (non-ignored) issues
                 domain_issues = issues_by_domain.get(domain, [])
-                active_domain_issues = [i for i in domain_issues if not i.get("ignored", False)]
-                issue_count = len(active_domain_issues)
-                fixable_count = sum(1 for i in active_domain_issues if i.get("fixable", False))
+                issue_count = len(domain_issues)
+                fixable_count = sum(1 for i in domain_issues if i.get("fixable", False))
 
                 if issue_count == 0:
                     status = "pass"
@@ -157,7 +165,7 @@ class InstructionFormatter:
         # Count ignored issues for informational purposes
         ignored_count = sum(1 for i in issues if i.ignored)
 
-        return {
+        result = {
             "total_issues": len(active_issues),
             "ignored_issues": ignored_count,
             "blocking": any(i.priority <= 2 for i in instructions),
@@ -168,6 +176,10 @@ class InstructionFormatter:
             "instructions": [asdict(i) for i in instructions],
             "recommended_action": recommended_action,
         }
+        # Only include ignored_issues_by_domain if there are ignored issues
+        if ignored_issues_by_domain:
+            result["ignored_issues_by_domain"] = ignored_issues_by_domain
+        return result
 
     def format_single_issue(
         self,

--- a/tests/unit/mcp/test_formatter.py
+++ b/tests/unit/mcp/test_formatter.py
@@ -511,12 +511,15 @@ class TestInstructionFormatter:
         assert result["blocking"] is False
         # Summary should only mention the 1 active issue
         assert "1 issues found" in result["summary"]
-        # Ignored issue should still appear in issues_by_domain with tag
+        # Active issues should be in issues_by_domain
         sca_issues = result["issues_by_domain"].get("sca", [])
-        assert len(sca_issues) == 2
-        ignored_in_list = [i for i in sca_issues if i.get("ignored")]
-        assert len(ignored_in_list) == 1
-        assert ignored_in_list[0]["ignore_reason"] == "Accepted risk"
+        assert len(sca_issues) == 1
+        assert sca_issues[0]["id"] == "active-1"
+        # Ignored issues should be in separate ignored_issues_by_domain
+        ignored_sca = result.get("ignored_issues_by_domain", {}).get("sca", [])
+        assert len(ignored_sca) == 1
+        assert ignored_sca[0]["ignored"] is True
+        assert ignored_sca[0]["ignore_reason"] == "Accepted risk"
 
     def test_format_scan_result_domain_status_excludes_ignored(
         self, formatter: InstructionFormatter


### PR DESCRIPTION
## Summary
- Fixed confusing AI formatter output where ignored issues were mixed with active issues in `issues_by_domain`
- `issues_by_domain` now contains only **active** (non-ignored) issues
- Added `ignored_issues_by_domain` containing **ignored** issues separately (only present when there are ignored issues)
- Simplified domain status calculation
- Bumped version to 0.5.47

## Problem
When running `lucidshark scan --format ai` with `ignore_issues` configured, the output was confusing:
- `total_issues: 10` (correct - only active)
- `issues_by_domain.type_checking` contained 279 issues (both active AND ignored mixed together)

This made it difficult for AI agents to understand which issues they actually needed to fix.

## Solution
Now the output clearly separates:
```json
{
  "total_issues": 10,
  "ignored_issues": 269,
  "issues_by_domain": {
    "type_checking": [/* only 10 active issues */]
  },
  "ignored_issues_by_domain": {
    "type_checking": [/* 269 ignored issues with reasons */]
  }
}
```

## Test plan
- [x] All 397 unit tests pass
- [x] Verified JSON reporter still includes all issues with `ignored` field
- [x] Verified SARIF reporter still uses `suppressions` for ignored issues
- [x] Verified Summary reporter shows "X (Y ignored)" correctly
- [x] Verified Table reporter marks ignored with `*` and `[ignored]` tag
- [x] Tested with real project (user-service) with 269 ignored SpotBugs issues