### PR TITLE
feat: improve incremental scanning with bug fixes and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ lucidshark scan --all --dry-run     # Preview what would be scanned
 
 Scan domains: `--linting`, `--type-checking`, `--sast`, `--sca`, `--iac`, `--container`, `--testing`, `--coverage`, `--duplication`
 
+### Incremental Scanning
+
+By default, LucidShark scans only uncommitted changes (staged, unstaged, untracked files):
+
+```bash
+# Default: scan only changed files (no extra flags needed)
+lucidshark scan --linting --type-checking
+
+# Full project scan
+lucidshark scan --all --all-files
+
+# PR/CI: filter results to files changed since a branch
+lucidshark scan --all --base-branch origin/main
+```
+
+See [Incremental Scanning](docs/incremental-scanning.md) for threshold scopes, CI integration, and advanced usage.
+
 **Note:** LucidShark validates that all configured tools are installed before running. If a tool is missing, the scan fails immediately with install instructions. Security tools (trivy, opengrep, checkov) and duplo are downloaded automatically.
 
 ### Example Output
@@ -213,6 +230,7 @@ pytest tests/
 ## Documentation
 
 - [Supported Languages](docs/languages/README.md) - Per-language tool coverage, detection, and configuration
+- [Incremental Scanning](docs/incremental-scanning.md) - PR-based filtering, threshold scopes, CI integration
 - [LLM Reference Documentation](docs/help.md) - For AI agents and detailed reference
 - [Exclude Patterns & Issue Ignoring](docs/exclude-patterns.md) - File exclusions, per-domain excludes, and ignoring specific issues
 - [Full Specification](docs/main.md)

--- a/docs/help.md
+++ b/docs/help.md
@@ -26,6 +26,7 @@ Your AI assistant will analyze your codebase, ask a few questions, and generate 
 
 ```bash
 # Default: scan only changed files (uncommitted changes)
+# No --base-branch needed for local development!
 lucidshark scan --linting --type-checking
 
 # Full project scan (all domains, all files)
@@ -39,6 +40,11 @@ lucidshark scan --sast           # Code security analysis
 
 # Auto-fix linting issues (on changed files)
 lucidshark scan --linting --fix
+
+# PR/CI: filter results to files changed since branch
+# (Note: this is different from default mode - full analysis runs,
+# only reporting is filtered)
+lucidshark scan --all --base-branch origin/main
 ```
 
 ---
@@ -99,6 +105,7 @@ Run the quality/security pipeline. By default, scans only changed files (uncommi
 | `--files FILE [FILE ...]` | Specific files to scan (overrides default changed-files behavior) |
 | `--all-files` | Scan entire project instead of just changed files |
 | `--image IMAGE` | Container image to scan; can be specified multiple times (with `--container`) |
+| `--base-branch BRANCH` | **For PR/CI workflows:** Filter results to files changed since this branch (e.g., `origin/main`). Unlike the default mode (which scans only uncommitted changes), this runs full analysis then filters results. Applies to all domains: linting, type_checking, coverage, duplication. See [Incremental Scanning](incremental-scanning.md). |
 
 #### Output Options
 
@@ -112,7 +119,11 @@ Run the quality/security pipeline. By default, scans only changed files (uncommi
 |--------|-------------|
 | `--fail-on {critical,high,medium,low}` | Failure threshold for security issues |
 | `--coverage-threshold PERCENT` | Coverage threshold (default: 80) |
+| `--coverage-threshold-scope {changed,project,both}` | With `--base-branch`: apply coverage threshold to changed files (default), project, or both |
+| `--linting-threshold-scope {changed,project,both}` | With `--base-branch`: apply linting threshold to changed files (default), project, or both |
+| `--type-checking-threshold-scope {changed,project,both}` | With `--base-branch`: apply type checking threshold to changed files (default), project, or both |
 | `--duplication-threshold PERCENT` | Maximum allowed duplication percentage (default: 10) |
+| `--duplication-threshold-scope {changed,project,both}` | With `--base-branch`: apply duplication threshold to changed files (default), project, or both |
 | `--min-lines N` | Minimum lines for a duplicate block (default: 4) |
 | `--config PATH` | Path to config file |
 
@@ -150,7 +161,52 @@ lucidshark scan --container --image myapp:latest
 
 # Stream output during scan
 lucidshark scan --all --stream
+
+# PR-based incremental coverage (see CI Platform Integration section)
+lucidshark scan --testing --coverage --base-branch origin/main
 ```
+
+#### CI Platform Integration
+
+Use `--base-branch` to filter results to files changed in a PR. All scans run fully — only reporting is filtered. Works with all domains: linting, type_checking, coverage, and duplication. See [Incremental Scanning](incremental-scanning.md) for comprehensive documentation.
+
+**GitHub Actions:**
+```yaml
+- name: Run LucidShark Incremental Scan
+  run: |
+    lucidshark scan --all \
+      --base-branch origin/${{ github.base_ref }} \
+      --coverage-threshold 80 \
+      --duplication-threshold 10
+```
+
+**GitLab CI:**
+```yaml
+test:
+  script:
+    - lucidshark scan --all \
+        --base-branch origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME \
+        --coverage-threshold 80
+```
+
+**Bitbucket Pipelines:**
+```yaml
+- step:
+    script:
+      - lucidshark scan --all \
+          --base-branch origin/$BITBUCKET_PR_DESTINATION_BRANCH \
+          --coverage-threshold 80
+```
+
+**Azure DevOps:**
+```yaml
+- script: |
+    lucidshark scan --all \
+      --base-branch origin/$(System.PullRequest.TargetBranch) \
+      --coverage-threshold 80
+```
+
+**Important:** Use `fetch-depth: 0` (or equivalent) in your CI checkout step to ensure full git history is available for branch comparison.
 
 ### `lucidshark status`
 
@@ -259,6 +315,11 @@ Run quality checks on the codebase or specific files. Supports partial scanning 
 | `files` | array of strings | (none) | Specific files to check (relative paths). When provided, only these files are scanned. |
 | `all_files` | boolean | `false` | Scan entire project instead of just changed files. By default, only uncommitted changes are scanned. |
 | `fix` | boolean | `false` | Apply auto-fixes for linting issues |
+| `base_branch` | string | (none) | Filter results to files changed since this branch (e.g., `origin/main`). Full analysis runs; only reporting is filtered. |
+| `coverage_threshold_scope` | string | `"changed"` | With `base_branch`: apply coverage threshold to `changed`, `project`, or `both` |
+| `linting_threshold_scope` | string | `"changed"` | With `base_branch`: apply linting threshold to `changed`, `project`, or `both` |
+| `type_checking_threshold_scope` | string | `"changed"` | With `base_branch`: apply type checking threshold to `changed`, `project`, or `both` |
+| `duplication_threshold_scope` | string | `"changed"` | With `base_branch`: apply duplication threshold to `changed`, `project`, or `both` |
 
 **Valid domains:** `linting`, `type_checking`, `sast`, `sca`, `iac`, `container`, `testing`, `coverage`, `duplication`, `all`
 
@@ -315,6 +376,17 @@ scan(domains=["linting"], fix=true)
 
 # Security scan - SAST scans changed files, SCA always project-wide
 scan(domains=["sca", "sast"])
+
+# Incremental scan - filter to files changed since main
+scan(domains=["all"], base_branch="origin/main")
+
+# Incremental scan with scope configuration
+scan(
+    domains=["all"],
+    base_branch="origin/main",
+    coverage_threshold_scope="changed",
+    linting_threshold_scope="changed"
+)
 ```
 
 ### `check_file`
@@ -1066,9 +1138,11 @@ exclude:
 | `max_workers` | int | 4 | Maximum parallel workers |
 | `linting.enabled` | bool | true | Enable linting |
 | `linting.exclude` | array | [] | Patterns to exclude from linting (combined with global `exclude`) |
+| `linting.threshold_scope` | string | "changed" | With `--base-branch`: apply threshold to `changed`, `project`, or `both` |
 | `linting.tools` | array | (auto) | List of linting tools |
 | `type_checking.enabled` | bool | true | Enable type checking |
 | `type_checking.exclude` | array | [] | Patterns to exclude from type checking (combined with global `exclude`) |
+| `type_checking.threshold_scope` | string | "changed" | With `--base-branch`: apply threshold to `changed`, `project`, or `both` |
 | `type_checking.tools` | array | (auto) | List of type checkers |
 | `security.enabled` | bool | true | Enable security scanning |
 | `security.exclude` | array | [] | Patterns to exclude from security scanning (combined with global `exclude`) |
@@ -1092,12 +1166,17 @@ exclude:
 | `coverage.exclude` | array | [] | Patterns to exclude from coverage analysis (combined with global `exclude`) |
 | `coverage.tools` | array | **required** | Coverage tools (coverage_py, istanbul, jacoco, tarpaulin) |
 | `coverage.threshold` | int | 80 | Coverage percentage threshold |
+| `coverage.threshold_scope` | string | "changed" | With `--base-branch`: apply threshold to `changed`, `project`, or `both` |
 | `coverage.extra_args` | array | [] | Extra Maven/Gradle arguments (Java only) |
 | `duplication.enabled` | bool | false | Enable duplication detection |
 | `duplication.threshold` | float | 10.0 | Max allowed duplication percentage |
+| `duplication.threshold_scope` | string | "changed" | With `--base-branch`: apply threshold to `changed`, `project`, or `both` |
 | `duplication.min_lines` | int | 4 | Minimum lines for a duplicate block |
 | `duplication.min_chars` | int | 3 | Minimum characters per line |
 | `duplication.exclude` | array | [] | Patterns to exclude from duplication scan (combined with global `exclude`) |
+| `duplication.baseline` | bool | false | Only report NEW duplicates after first run |
+| `duplication.cache` | bool | true | Cache processed files for faster re-runs |
+| `duplication.use_git` | bool | true | Use git ls-files for file discovery when available |
 | `duplication.tools` | array | (auto) | Duplication detection tools (duplo) |
 
 #### Tool Configuration

--- a/docs/incremental-scanning.md
+++ b/docs/incremental-scanning.md
@@ -1,0 +1,537 @@
+# Incremental Scanning
+
+LucidShark supports two modes of incremental scanning:
+
+1. **Default Mode (Uncommitted Changes)** - Scans only files with uncommitted changes (staged, unstaged, untracked). No extra flags needed.
+2. **Branch Comparison Mode (`--base-branch`)** - Filters results to files changed since a branch. Useful for PR reviews and CI pipelines.
+
+## Default Mode: Uncommitted Changes
+
+**When developing locally, you don't need any special flags.** By default, LucidShark scans only uncommitted changes:
+
+```bash
+# Scans only uncommitted changes (default behavior)
+lucidshark scan --linting --type-checking
+
+# Same via MCP
+scan(domains=["linting", "type_checking"])
+```
+
+This mode:
+- Detects staged files (`git add`)
+- Detects unstaged modifications
+- Detects untracked files
+- Runs tools only on these files (where supported)
+
+Use `--all-files` (CLI) or `all_files=true` (MCP) for a full project scan.
+
+## Branch Comparison Mode: `--base-branch`
+
+Use `--base-branch` when you want to filter results based on branch comparison. This is useful for:
+
+- **Pull Request reviews**: Focus on the code being changed in the PR
+- **CI pipelines**: Enforce standards on new/modified code only
+- **Pre-merge checks**: Verify changes meet quality thresholds
+
+### How It Works
+
+1. **Full analysis runs** - All checks execute for accuracy (tests, linting, etc.)
+2. **Results are filtered** - Only changed files are reported
+3. **Threshold applies to filtered result** - Per-domain scope configuration
+
+This approach ensures data is accurate (tests aren't skipped, cross-file issues are detected) while focusing your attention on the code you're changing.
+
+## Quick Start
+
+### Local Development (Default - Uncommitted Changes)
+
+```bash
+# Scan only uncommitted changes (default behavior)
+lucidshark scan --linting --type-checking
+
+# Full project scan
+lucidshark scan --linting --type-checking --all-files
+```
+
+### PR/CI (Branch Comparison)
+
+```bash
+# Filter all results to files changed since main
+lucidshark scan --all --base-branch origin/main
+
+# With specific domains
+lucidshark scan --linting --type-checking --coverage --duplication \
+  --base-branch origin/main
+```
+
+### MCP (AI Agents)
+
+```python
+# Default: scan uncommitted changes
+mcp__lucidshark__scan(domains=["linting", "type_checking"])
+
+# Full project scan
+mcp__lucidshark__scan(domains=["all"], all_files=True)
+
+# PR/CI: filter to branch changes
+mcp__lucidshark__scan(domains=["all"], base_branch="origin/main")
+```
+
+## Domain-Specific Behavior
+
+### Linting & Type Checking
+
+**Display:** Issues are filtered to only those in changed files.
+
+**Threshold Checking:** The `threshold_scope` controls which issues are checked against `fail_on`:
+
+| Scope | Display | Threshold Check |
+|-------|---------|-----------------|
+| `changed` (default) | Changed files only | Check changed files issues |
+| `project` | Changed files only | Check ALL project issues |
+| `both` | Changed files only | Check both; fail if either has issues |
+
+**Example with `scope: project`:**
+```
+Display: 2 issues in changed files
+Project total: 15 issues
+fail_on: error
+Scope: project
+
+Result: FAIL (15 project issues checked, not just the 2 displayed)
+```
+
+This is useful when you want to see only your changes, but ensure the entire project stays clean.
+
+**Example with `scope: changed`:**
+```
+Display: 2 issues in changed files
+Project total: 15 issues
+fail_on: error
+Scope: changed
+
+Result: FAIL only if those 2 issues are errors (project issues ignored)
+```
+
+### Coverage
+
+**Display:** Coverage metrics are filtered to changed files only.
+
+**Threshold Checking:** The `threshold_scope` controls which coverage is checked:
+
+| Scope | Display | Threshold Check |
+|-------|---------|-----------------|
+| `changed` (default) | Changed files coverage | Check changed files coverage |
+| `project` | Changed files coverage | Check full project coverage |
+| `both` | Changed files coverage | Check both; fail if either below threshold |
+
+**Example:**
+```
+Display: 72% coverage on changed files
+Project coverage: 85%
+Threshold: 80%
+Scope: changed
+
+Result: FAIL (72% < 80% on changed files)
+```
+
+Unlike linting/type_checking, coverage filtering applies to both display AND the metrics used for threshold calculation (when scope=changed).
+
+### Duplication
+
+**Display:** Duplicates are filtered to those involving at least one changed file (file1 OR file2).
+
+**Threshold Checking:** The `threshold_scope` controls which duplication percentage is checked:
+
+| Scope | Display | Threshold Check |
+|-------|---------|-----------------|
+| `changed` (default) | Duplicates involving changed files | Check filtered duplication % |
+| `project` | Duplicates involving changed files | Check full project duplication % |
+| `both` | Duplicates involving changed files | Check both; fail if either exceeds threshold |
+
+**Example:**
+```
+Display: Duplicates involving changed files (12%)
+Project duplication: 8%
+Threshold: 10%
+Scope: changed
+
+Result: FAIL (12% > 10% on changed files)
+```
+
+Like coverage, duplication filtering applies to both display AND the metrics used for threshold calculation (when scope=changed).
+
+## What Gets Included
+
+### Default Mode (No `--base-branch`)
+
+When running without `--base-branch`, LucidShark scans only uncommitted changes:
+
+- **Staged changes** (`git add`)
+- **Unstaged modifications**
+- **Untracked files**
+
+This is determined by:
+```
+git diff --cached --name-only      # Staged
+git diff --name-only               # Unstaged
+git ls-files --others --exclude-standard  # Untracked
+```
+
+### Branch Comparison Mode (`--base-branch`)
+
+When using `--base-branch`, LucidShark includes:
+
+**1. Committed Changes (Branch Comparison)**
+
+Files committed to your branch since it diverged from the base:
+
+```
+git diff origin/main...HEAD --name-only
+```
+
+This uses git's three-dot syntax which compares against the merge-base.
+
+**2. Uncommitted Local Changes** (when working locally)
+
+- **Staged changes** (`git add`)
+- **Unstaged modifications**
+- **Untracked files**
+
+### Summary
+
+| Mode | Flag | What's Scanned/Filtered |
+|------|------|------------------------|
+| **Default (local dev)** | (none) | Uncommitted changes only |
+| **Full project** | `--all-files` | All files in project |
+| **Branch comparison (CI)** | `--base-branch origin/main` | Branch changes + uncommitted |
+
+| Environment | Working Tree | `--base-branch` Behavior |
+|-------------|--------------|--------------------------|
+| **CI Pipeline** | Clean | Committed branch changes only |
+| **Local Development** | Dirty | Committed + uncommitted changes |
+
+## Configuration
+
+### CLI Arguments
+
+| Option | Description |
+|--------|-------------|
+| `--base-branch BRANCH` | Filter to files changed since this branch |
+| `--coverage-threshold-scope` | Scope for coverage threshold |
+| `--linting-threshold-scope` | Scope for linting threshold |
+| `--type-checking-threshold-scope` | Scope for type checking threshold |
+| `--duplication-threshold-scope` | Scope for duplication threshold |
+
+### Configuration File (lucidshark.yml)
+
+```yaml
+pipeline:
+  linting:
+    enabled: true
+    threshold_scope: changed  # or "project" or "both"
+
+  type_checking:
+    enabled: true
+    threshold_scope: changed
+
+  coverage:
+    enabled: true
+    threshold: 80
+    threshold_scope: changed
+
+  duplication:
+    enabled: true
+    threshold: 10
+    threshold_scope: changed
+```
+
+### MCP Parameters
+
+```python
+mcp__lucidshark__scan(
+    domains=["all"],
+    base_branch="origin/main",
+    coverage_threshold_scope="changed",
+    linting_threshold_scope="changed",
+    type_checking_threshold_scope="changed",
+    duplication_threshold_scope="changed"
+)
+```
+
+## CI Platform Integration
+
+### GitHub Actions
+
+```yaml
+name: PR Quality Check
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for branch comparison
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install lucidshark
+          pip install -e ".[dev]"
+
+      - name: Run incremental scan
+        run: |
+          lucidshark scan --all \
+            --base-branch origin/${{ github.base_ref }} \
+            --coverage-threshold 80 \
+            --duplication-threshold 10
+```
+
+**Important:** Use `fetch-depth: 0` to ensure full git history is available.
+
+### GitLab CI
+
+```yaml
+stages:
+  - quality
+
+quality:
+  stage: quality
+  image: python:3.11
+  variables:
+    GIT_DEPTH: 0
+  script:
+    - pip install lucidshark
+    - pip install -e ".[dev]"
+    - lucidshark scan --all
+        --base-branch origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+        --coverage-threshold 80
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+### Bitbucket Pipelines
+
+```yaml
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: Quality Check
+          image: python:3.11
+          clone:
+            depth: full
+          script:
+            - pip install lucidshark
+            - pip install -e ".[dev]"
+            - lucidshark scan --all
+                --base-branch origin/$BITBUCKET_PR_DESTINATION_BRANCH
+                --coverage-threshold 80
+```
+
+### Azure DevOps
+
+```yaml
+pr:
+  - main
+  - develop
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - checkout: self
+    fetchDepth: 0
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.11'
+
+  - script: |
+      pip install lucidshark
+      pip install -e ".[dev]"
+    displayName: 'Install dependencies'
+
+  - script: |
+      lucidshark scan --all \
+        --base-branch origin/$(System.PullRequest.TargetBranch) \
+        --coverage-threshold 80
+    displayName: 'Run incremental scan'
+```
+
+## Example Scenarios
+
+### Scenario 1: Strict PR linting
+
+Fail if ANY linting issue in changed files, even if project has existing issues.
+
+```bash
+lucidshark scan --linting --base-branch origin/main \
+  --linting-threshold-scope changed
+```
+
+### Scenario 2: Coverage on changed files only
+
+Changed files must have 80% coverage, but overall project can be lower.
+
+```bash
+lucidshark scan --testing --coverage --base-branch origin/main \
+  --coverage-threshold 80 --coverage-threshold-scope changed
+```
+
+### Scenario 3: Enforce both project and changed files
+
+Fail if either project OR changed files exceed duplication threshold.
+
+```bash
+lucidshark scan --duplication --base-branch origin/main \
+  --duplication-threshold 10 --duplication-threshold-scope both
+```
+
+### Scenario 4: Full incremental scan before PR
+
+Run all checks filtered to changed files:
+
+```bash
+lucidshark scan --all --base-branch origin/main \
+  --coverage-threshold 80 \
+  --duplication-threshold 10 \
+  --coverage-threshold-scope changed \
+  --linting-threshold-scope changed
+```
+
+## Local Development Workflow
+
+### Check changes before committing
+
+```bash
+# On your feature branch
+git checkout feature/my-new-feature
+
+# Edit some files
+vim src/myapp/utils.py
+
+# Check all quality metrics for your changes
+lucidshark scan --all --base-branch main
+
+# Fix any issues, then commit
+git add .
+git commit -m "Add new utility function"
+```
+
+### Before creating a PR
+
+```bash
+# Ensure all changes meet quality standards
+lucidshark scan --all --base-branch origin/main \
+  --coverage-threshold 80 \
+  --duplication-threshold 10
+
+# If it passes, push
+git push origin feature/my-new-feature
+```
+
+## Known Behaviors
+
+### Domain Behavior Summary
+
+| Domain | Display Filtered | Threshold Scope Affects Display | Threshold Scope Affects Check |
+|--------|:----------------:|:-------------------------------:|:-----------------------------:|
+| Linting | Yes | No (always shows changed) | Yes |
+| Type Checking | Yes | No (always shows changed) | Yes |
+| Coverage | Yes | No (always shows changed) | Yes |
+| Duplication | Yes | No (always shows changed) | Yes |
+| Security | No | N/A | N/A |
+| Testing | No | N/A | N/A |
+
+**Key difference:** For linting/type_checking, `threshold_scope` only affects which issues are checked against `fail_on`, not what's displayed. For coverage/duplication, filtering affects both display and the metrics.
+
+### Security Domains Are Not Filtered
+
+Security scans (SAST, SCA, IAC, Container) always report full project results, even with `--base-branch`. This is intentional:
+- Security issues often span files or dependencies
+- Filtering could hide critical vulnerabilities in unchanged but affected code
+- Dependency vulnerabilities (SCA) apply project-wide
+
+### Deleted Files Not Reported
+
+Deleted files are excluded from changed files detection. When you delete a file in a PR:
+- Linting/type checking won't report old issues from the deleted file
+- Coverage won't include the deleted file's metrics
+- This is correct behavior—issues in deleted files don't matter
+
+### Duplication Percentage Context
+
+For filtered duplication results:
+- `duplicate_lines` = lines in filtered duplicates (involving changed files)
+- `total_lines` = original full project lines
+- Percentage reflects "what portion of the project these duplicates represent"
+
+This gives context: "50 duplicate lines involving your changes represent 0.5% of the project"
+
+### Testing Always Runs Full Suite
+
+Even with `--base-branch`, all tests run. Only coverage/failure **reporting** is filtered. This ensures:
+- Indirect coverage is measured (test for `module_a` covers `module_b`)
+- Regressions are caught
+- Coverage percentages are accurate
+
+## FAQ
+
+### Does this skip tests for unchanged files?
+
+No. All tests run for accurate coverage measurement. Only **reporting** is filtered.
+
+### What if I have no changes on my branch?
+
+Full project results are shown with a warning.
+
+### Why does CI need `fetch-depth: 0`?
+
+Branch comparison requires full git history. Shallow clones fail to find the merge-base.
+
+### Can I exclude uncommitted changes?
+
+Currently no. Commit your work first or run in CI where the working tree is clean.
+
+### Why run full analysis if only showing changed files?
+
+1. **Indirect coverage**: A test for `module_a.py` might cover code in `module_b.py`
+2. **Cross-file detection**: Linting and duplication can detect issues spanning files
+3. **Regression detection**: Running all tests catches regressions
+4. **Accurate metrics**: Partial runs produce misleading numbers
+
+### What about merge commits?
+
+The three-dot syntax (`main...HEAD`) compares against the merge-base, so merge commits from main into your branch don't count as "your changes."
+
+## Error Handling
+
+### Branch Not Found
+
+```
+Error: Could not compare against branch 'origin/main'.
+Ensure the branch exists and git history is available (use fetch-depth: 0 in CI).
+```
+
+**Solutions:**
+- Verify the branch name is correct
+- In CI, ensure `fetch-depth: 0` or equivalent is set
+- Run `git fetch origin main` to fetch the branch
+
+### No Changed Files
+
+```
+Warning: No files changed since origin/main, showing full results
+```
+
+Full project results are shown when there are no changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidshark"
-version = "0.5.47"
+version = "0.5.48"
 description = "LucidShark - The trust layer for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lucidshark/cli/arguments.py
+++ b/src/lucidshark/cli/arguments.py
@@ -161,6 +161,16 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         metavar="IMAGE",
         help="Container image to scan (can be specified multiple times).",
     )
+    target_group.add_argument(
+        "--base-branch",
+        metavar="BRANCH",
+        dest="base_branch",
+        help=(
+            "Filter coverage results to files changed since this branch "
+            "(e.g., 'origin/main'). Full tests still run; only reporting is filtered. "
+            "Use in CI pipelines for PR-based coverage."
+        ),
+    )
 
     # Output options
     output_group = scan_parser.add_argument_group("output")
@@ -187,6 +197,45 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Coverage percentage threshold (default: 80). Fail if below.",
     )
     config_group.add_argument(
+        "--coverage-threshold-scope",
+        choices=["changed", "project", "both"],
+        default=None,
+        metavar="SCOPE",
+        dest="coverage_threshold_scope",
+        help=(
+            "When using --base-branch, apply coverage threshold to: "
+            "'changed' (changed files only, default), "
+            "'project' (full project), or "
+            "'both' (fail if either is below threshold)."
+        ),
+    )
+    config_group.add_argument(
+        "--linting-threshold-scope",
+        choices=["changed", "project", "both"],
+        default=None,
+        metavar="SCOPE",
+        dest="linting_threshold_scope",
+        help=(
+            "When using --base-branch, apply linting threshold to: "
+            "'changed' (changed files only, default), "
+            "'project' (full project), or "
+            "'both' (fail if either has issues)."
+        ),
+    )
+    config_group.add_argument(
+        "--type-checking-threshold-scope",
+        choices=["changed", "project", "both"],
+        default=None,
+        metavar="SCOPE",
+        dest="type_checking_threshold_scope",
+        help=(
+            "When using --base-branch, apply type checking threshold to: "
+            "'changed' (changed files only, default), "
+            "'project' (full project), or "
+            "'both' (fail if either has errors)."
+        ),
+    )
+    config_group.add_argument(
         "--duplication-threshold",
         type=float,
         default=None,
@@ -199,6 +248,19 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         metavar="N",
         help="Minimum lines for a duplicate block (default: 4).",
+    )
+    config_group.add_argument(
+        "--duplication-threshold-scope",
+        choices=["changed", "project", "both"],
+        default=None,
+        metavar="SCOPE",
+        dest="duplication_threshold_scope",
+        help=(
+            "When using --base-branch, apply duplication threshold to: "
+            "'changed' (changed files only, default), "
+            "'project' (full project), or "
+            "'both' (fail if either exceeds threshold)."
+        ),
     )
     config_group.add_argument(
         "--config",

--- a/src/lucidshark/cli/commands/scan.py
+++ b/src/lucidshark/cli/commands/scan.py
@@ -120,7 +120,7 @@ class ScanCommand(Command):
                     return EXIT_ISSUES_FOUND
             else:
                 # Check per-domain thresholds from config
-                if self._check_domain_thresholds(result, config):
+                if self._check_domain_thresholds(result, config, args):
                     return EXIT_ISSUES_FOUND
 
             return EXIT_SUCCESS
@@ -313,7 +313,78 @@ class ScanCommand(Command):
 
             # Build coverage summary from context.coverage_result
             if context.coverage_result is not None:
-                coverage_summary = context.coverage_result.to_summary()
+                # Apply PR-based filtering if --base-branch is specified
+                base_branch = getattr(args, "base_branch", None)
+                if base_branch:
+                    from lucidshark.core.git import get_changed_files_since_branch
+
+                    changed_files = get_changed_files_since_branch(
+                        project_root, base_branch
+                    )
+                    if changed_files is None:
+                        # Git command failed - exit with error per design decision
+                        raise RuntimeError(
+                            f"Could not compare against branch '{base_branch}'. "
+                            "Ensure the branch exists and git history is available "
+                            "(use fetch-depth: 0 in CI)."
+                        )
+
+                    # Keep full project coverage for scope checking
+                    full_coverage_result = context.coverage_result
+
+                    if changed_files:
+                        LOGGER.info(
+                            f"Filtering coverage to {len(changed_files)} files "
+                            f"changed since {base_branch}"
+                        )
+                        changed_coverage_result = (
+                            full_coverage_result.filter_to_changed_files(
+                                changed_files, project_root
+                            )
+                        )
+                    else:
+                        LOGGER.warning(
+                            f"No files changed since {base_branch}, "
+                            "showing full coverage"
+                        )
+                        changed_coverage_result = full_coverage_result
+
+                    # Determine threshold scope
+                    # CLI arg takes precedence, then config, then default "changed"
+                    threshold_scope = getattr(args, "coverage_threshold_scope", None)
+                    if threshold_scope is None and config.pipeline.coverage:
+                        threshold_scope = config.pipeline.coverage.threshold_scope
+                    if threshold_scope is None:
+                        threshold_scope = "changed"
+
+                    # Compute effective passed based on scope
+                    if threshold_scope == "changed":
+                        effective_passed = changed_coverage_result.passed
+                    elif threshold_scope == "project":
+                        effective_passed = full_coverage_result.passed
+                    else:  # "both"
+                        effective_passed = (
+                            changed_coverage_result.passed
+                            and full_coverage_result.passed
+                        )
+
+                    LOGGER.debug(
+                        f"Coverage threshold scope: {threshold_scope}, "
+                        f"changed: {changed_coverage_result.percentage:.1f}% "
+                        f"(passed={changed_coverage_result.passed}), "
+                        f"project: {full_coverage_result.percentage:.1f}% "
+                        f"(passed={full_coverage_result.passed}), "
+                        f"effective_passed={effective_passed}"
+                    )
+
+                    # Display shows changed files coverage
+                    context.coverage_result = changed_coverage_result
+                    coverage_summary = changed_coverage_result.to_summary()
+                    # Override passed with scope-based result
+                    coverage_summary.passed = effective_passed
+                else:
+                    # No --base-branch: use full project coverage
+                    coverage_summary = context.coverage_result.to_summary()
 
         # Run duplication detection if requested or if --all and duplication is configured
         duplication_flag = getattr(args, "duplication", False)
@@ -409,6 +480,82 @@ class ScanCommand(Command):
             for w in ignore_warnings:
                 LOGGER.warning(w)
 
+        # Apply incremental filtering for linting/type_checking issues and duplication
+        # (Coverage filtering is already handled inline above)
+        base_branch = getattr(args, "base_branch", None)
+        full_issues = all_issues  # Keep reference to full issues for scope checking
+        full_duplication_result = context.duplication_result
+
+        if base_branch:
+            from lucidshark.core.git import get_changed_files_since_branch
+            from lucidshark.core.filtering import filter_issues_by_changed_files
+
+            # Get changed files (may have been fetched already for coverage)
+            changed_files = get_changed_files_since_branch(project_root, base_branch)
+            if changed_files is None:
+                raise RuntimeError(
+                    f"Could not compare against branch '{base_branch}'. "
+                    "Ensure the branch exists and git history is available "
+                    "(use fetch-depth: 0 in CI)."
+                )
+
+            if changed_files:
+                # Filter issues to only those in changed files
+                all_issues = filter_issues_by_changed_files(
+                    all_issues, changed_files, project_root
+                )
+                LOGGER.info(
+                    f"Filtered to {len(all_issues)} issues in "
+                    f"{len(changed_files)} changed files"
+                )
+
+                # Filter duplication to only those involving changed files
+                if context.duplication_result is not None:
+                    context.duplication_result = (
+                        context.duplication_result.filter_to_changed_files(
+                            changed_files, project_root
+                        )
+                    )
+                    duplication_summary = context.duplication_result.to_summary()
+
+                    # Apply duplication threshold scope
+                    dup_scope = getattr(args, "duplication_threshold_scope", None)
+                    if dup_scope is None and config.pipeline.duplication:
+                        dup_scope = config.pipeline.duplication.threshold_scope
+                    dup_scope = dup_scope or "changed"
+
+                    if dup_scope == "changed":
+                        dup_passed = context.duplication_result.passed
+                    elif dup_scope == "project":
+                        if full_duplication_result:
+                            dup_passed = full_duplication_result.passed
+                        else:
+                            LOGGER.warning(
+                                f"Duplication scope '{dup_scope}' requested but "
+                                "full project result unavailable, using 'changed' scope"
+                            )
+                            dup_passed = context.duplication_result.passed
+                    elif dup_scope == "both":
+                        if full_duplication_result:
+                            dup_passed = (
+                                context.duplication_result.passed
+                                and full_duplication_result.passed
+                            )
+                        else:
+                            LOGGER.warning(
+                                f"Duplication scope '{dup_scope}' requested but "
+                                "full project result unavailable, using 'changed' scope"
+                            )
+                            dup_passed = context.duplication_result.passed
+                    else:
+                        dup_passed = context.duplication_result.passed
+
+                    duplication_summary.passed = dup_passed
+            else:
+                LOGGER.warning(
+                    f"No files changed since {base_branch}, showing full results"
+                )
+
         # Build final result
         result = ScanResult(issues=all_issues)
         result.summary = result.compute_summary()
@@ -419,26 +566,39 @@ class ScanCommand(Command):
         if pipeline_result and pipeline_result.metadata:
             result.metadata = pipeline_result.metadata
 
+        # Store full (unfiltered) results for scope-based threshold checking
+        if base_branch and full_issues is not all_issues:
+            result.full_issues = full_issues
+            result.full_duplication_result = full_duplication_result
+
         return result
 
     def _check_domain_thresholds(
-        self, result: ScanResult, config: LucidSharkConfig
+        self, result: ScanResult, config: LucidSharkConfig, args: Namespace
     ) -> bool:
         """Check if any issues exceed their domain's fail_on threshold.
 
         Groups issues by domain and checks each against its configured threshold.
+        Supports incremental scanning with scope-based threshold checking.
 
         Args:
             result: Scan result containing issues and summaries.
             config: Configuration with per-domain thresholds.
+            args: CLI arguments for scope and base_branch.
 
         Returns:
             True if any domain exceeds its threshold, False otherwise.
         """
         from lucidshark.core.models import ScanDomain, ToolDomain
 
+        # Get incremental scanning context
+        base_branch = getattr(args, "base_branch", None)
+        full_issues = result.full_issues
+
         # Filter out ignored issues before threshold checks
         issues = [i for i in result.issues if not i.ignored]
+        if full_issues:
+            full_issues = [i for i in full_issues if not i.ignored]
 
         # Map issue domains to config domain names
         # ScanDomain values (SCA, CONTAINER, IAC, SAST) all map to "security"
@@ -455,27 +615,79 @@ class ScanCommand(Command):
             ScanDomain.SAST: "security",
         }
 
-        # Group issues by domain
+        # Group issues by domain (both filtered and full for scope checking)
         issues_by_domain: dict[str, List[UnifiedIssue]] = {}
+        full_issues_by_domain: dict[str, List[UnifiedIssue]] = {}
+
         for issue in issues:
             domain_name = domain_mapping.get(issue.domain, "security")
             if domain_name not in issues_by_domain:
                 issues_by_domain[domain_name] = []
             issues_by_domain[domain_name].append(issue)
 
+        if full_issues:
+            for issue in full_issues:
+                domain_name = domain_mapping.get(issue.domain, "security")
+                if domain_name not in full_issues_by_domain:
+                    full_issues_by_domain[domain_name] = []
+                full_issues_by_domain[domain_name].append(issue)
+
+        # Helper to get threshold scope for a domain
+        def get_scope(domain: str) -> str:
+            cli_scope = getattr(args, f"{domain}_threshold_scope", None)
+            if cli_scope:
+                return cli_scope
+            domain_config = getattr(config.pipeline, domain, None)
+            if domain_config and hasattr(domain_config, "threshold_scope"):
+                return domain_config.threshold_scope
+            return "changed"
+
         # Check each domain against its threshold
         for domain_name, domain_issues in issues_by_domain.items():
             threshold = config.get_fail_on_threshold(domain_name)
             if threshold:
+                # Get scope for this domain
+                scope = get_scope(domain_name)
+
+                # Determine which issues to check based on scope
+                if base_branch and domain_name in ("linting", "type_checking"):
+                    if scope == "project" and domain_name in full_issues_by_domain:
+                        check_issues = full_issues_by_domain[domain_name]
+                    elif scope == "both":
+                        # Will check both below
+                        check_issues = domain_issues
+                    else:  # "changed" or default
+                        check_issues = domain_issues
+                else:
+                    check_issues = domain_issues
+
                 # Handle special threshold values
-                if threshold == "any" and domain_issues:
-                    LOGGER.debug(f"Domain {domain_name}: {len(domain_issues)} issues exceed 'any' threshold")
-                    return True
+                if threshold == "any":
+                    # Check changed files first
+                    if check_issues:
+                        LOGGER.debug(f"Domain {domain_name}: {len(check_issues)} issues exceed 'any' threshold")
+                        return True
+                    # For "both" scope, also check full issues even if changed files have none
+                    if base_branch and scope == "both" and domain_name in full_issues_by_domain:
+                        full_check = full_issues_by_domain[domain_name]
+                        if full_check:
+                            LOGGER.debug(
+                                f"Domain {domain_name}: {len(full_check)} full project issues "
+                                f"exceed 'any' threshold (scope=both)"
+                            )
+                            return True
                 elif threshold == "error":
                     # For linting/type_checking: fail on any HIGH severity (errors)
-                    if any(i.severity.value in ("high", "critical") for i in domain_issues):
+                    has_errors = any(i.severity.value in ("high", "critical") for i in check_issues)
+                    if has_errors:
                         LOGGER.debug(f"Domain {domain_name}: issues exceed 'error' threshold")
                         return True
+                    # For "both" scope, also check full issues
+                    if base_branch and scope == "both" and domain_name in full_issues_by_domain:
+                        full_check = full_issues_by_domain[domain_name]
+                        if any(i.severity.value in ("high", "critical") for i in full_check):
+                            LOGGER.debug(f"Domain {domain_name}: full project issues exceed 'error' threshold (scope=both)")
+                            return True
                 elif threshold == "none":
                     # Never fail
                     continue

--- a/src/lucidshark/config/models.py
+++ b/src/lucidshark/config/models.py
@@ -94,6 +94,11 @@ class DomainPipelineConfig:
     enabled: bool = True
     tools: List[ToolConfig] = field(default_factory=list)
     exclude: List[str] = field(default_factory=list)  # Patterns to exclude from this domain
+    # Scope for threshold check when using --base-branch:
+    # "changed" - apply to changed files only (default)
+    # "project" - apply to full project
+    # "both" - fail if either changed files or full project exceeds threshold
+    threshold_scope: str = "changed"
     command: Optional[str] = None  # Custom shell command to run instead of plugins
     pre_command: Optional[str] = None  # Shell command to run before main command (e.g., cleanup)
     post_command: Optional[str] = None  # Shell command to run after main command
@@ -105,6 +110,11 @@ class CoveragePipelineConfig:
 
     enabled: bool = False
     threshold: int = 80
+    # Scope for threshold check when using --base-branch:
+    # "changed" - apply to changed files only (default)
+    # "project" - apply to full project coverage
+    # "both" - fail if either changed files or full project is below threshold
+    threshold_scope: str = "changed"
     tools: List[ToolConfig] = field(default_factory=list)
     # Extra arguments to pass to Maven/Gradle when running coverage tests
     # e.g., ["-DskipITs", "-Ddocker.skip=true"]
@@ -121,6 +131,11 @@ class DuplicationPipelineConfig:
 
     enabled: bool = False
     threshold: float = 10.0  # Max allowed duplication percentage
+    # Scope for threshold check when using --base-branch:
+    # "changed" - apply to changed files only (default)
+    # "project" - apply to full project
+    # "both" - fail if either changed files or full project exceeds threshold
+    threshold_scope: str = "changed"
     min_lines: int = 4  # Minimum lines for a duplicate block
     min_chars: int = 3  # Minimum characters per line
     exclude: List[str] = field(default_factory=list)  # Patterns to exclude from duplication scan

--- a/src/lucidshark/core/filtering.py
+++ b/src/lucidshark/core/filtering.py
@@ -1,0 +1,65 @@
+"""Utilities for filtering scan results to changed files.
+
+Provides functions for incremental scanning - filtering results to only
+show issues/metrics for files that have changed since a base branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Set
+
+from lucidshark.core.models import UnifiedIssue
+
+
+def filter_issues_by_changed_files(
+    issues: List[UnifiedIssue],
+    changed_files: Optional[List[Path]],
+    project_root: Path,
+) -> List[UnifiedIssue]:
+    """Filter issues to only those in changed files.
+
+    Args:
+        issues: List of issues to filter.
+        changed_files: List of changed file paths (absolute), or None.
+            If None (git command failed), returns original issues unfiltered.
+            If empty list (no changes), returns empty list.
+        project_root: Project root for path resolution.
+
+    Returns:
+        Filtered list containing only issues in changed files.
+        Returns original issues if changed_files is None.
+    """
+    # If changed_files is None (git failed), return original issues unfiltered
+    # This is a defensive fallback - callers should handle None explicitly
+    if changed_files is None:
+        return issues
+
+    # If empty list (git worked but no changes), return empty
+    if not changed_files:
+        return []
+
+    # Build set of changed file paths (both absolute and relative)
+    changed_set: Set[str] = set()
+    for f in changed_files:
+        changed_set.add(str(f))  # Absolute path
+        try:
+            changed_set.add(str(f.relative_to(project_root)))  # Relative path
+        except ValueError:
+            pass
+
+    filtered = []
+    for issue in issues:
+        if issue.file_path is None:
+            continue
+
+        file_str = str(issue.file_path)
+        try:
+            rel_str = str(issue.file_path.relative_to(project_root))
+        except ValueError:
+            rel_str = file_str
+
+        if file_str in changed_set or rel_str in changed_set:
+            filtered.append(issue)
+
+    return filtered

--- a/src/lucidshark/core/git.py
+++ b/src/lucidshark/core/git.py
@@ -150,6 +150,110 @@ def get_changed_files(
         return None
 
 
+def get_changed_files_since_branch(
+    project_root: Path,
+    base_branch: str,
+    include_uncommitted: bool = True,
+) -> Optional[List[Path]]:
+    """Get list of files changed between base branch and HEAD, plus uncommitted changes.
+
+    Uses 'git diff base...HEAD --name-only' (three-dot syntax) to get files
+    changed since the current branch diverged from base_branch. This is useful
+    for PR-based incremental coverage reporting.
+
+    When include_uncommitted is True (default), also includes:
+    - Staged changes (git add)
+    - Unstaged modifications
+    - Untracked files
+
+    This allows local development workflows where you want to see coverage
+    for both committed branch changes AND current uncommitted work.
+
+    Args:
+        project_root: Root directory of the project.
+        base_branch: Base branch to compare against (e.g., 'origin/main').
+        include_uncommitted: If True, also include uncommitted local changes.
+            This is useful for local development. In CI (where working tree
+            is clean), this has no effect.
+
+    Returns:
+        List of changed file paths (absolute), or None if not a git repo
+        or git command fails (e.g., branch doesn't exist).
+    """
+    if not is_git_repo(project_root):
+        LOGGER.debug(f"Not a git repository: {project_root}")
+        return None
+
+    changed_files: set[Path] = set()
+
+    try:
+        # Use three-dot syntax to get files changed since branch diverged
+        result = subprocess.run(
+            ["git", "diff", f"{base_branch}...HEAD", "--name-only"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            # Git command failed (e.g., branch doesn't exist)
+            stderr = result.stderr.strip()
+            LOGGER.error(f"git diff against '{base_branch}' failed: {stderr}")
+            return None
+
+        for line in result.stdout.strip().split("\n"):
+            if line:
+                file_path = project_root / line
+                if file_path.exists():
+                    changed_files.add(file_path)
+
+        committed_count = len(changed_files)
+        LOGGER.debug(
+            f"Found {committed_count} files changed since {base_branch}"
+        )
+
+        # Also include uncommitted local changes (for local development)
+        if include_uncommitted:
+            uncommitted_before = len(changed_files)
+
+            # Staged changes
+            _collect_files_from_git_command(
+                ["git", "diff", "--cached", "--name-only"],
+                project_root,
+                changed_files,
+            )
+
+            # Unstaged modifications
+            _collect_files_from_git_command(
+                ["git", "diff", "--name-only"],
+                project_root,
+                changed_files,
+            )
+
+            # Untracked files
+            _collect_files_from_git_command(
+                ["git", "ls-files", "--others", "--exclude-standard"],
+                project_root,
+                changed_files,
+            )
+
+            uncommitted_added = len(changed_files) - uncommitted_before
+            if uncommitted_added > 0:
+                LOGGER.debug(
+                    f"Also including {uncommitted_added} uncommitted file(s)"
+                )
+
+        return sorted(changed_files)
+
+    except subprocess.TimeoutExpired:
+        LOGGER.error(f"Git diff against '{base_branch}' timed out")
+        return None
+    except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
+        LOGGER.error(f"Git diff against '{base_branch}' failed: {e}")
+        return None
+
+
 def filter_files_by_extension(
     files: List[Path],
     extensions: Optional[List[str]] = None,

--- a/src/lucidshark/core/models.py
+++ b/src/lucidshark/core/models.py
@@ -305,6 +305,10 @@ class ScanResult:
     summary: Optional[ScanSummary] = None
     coverage_summary: Optional[CoverageSummary] = None
     duplication_summary: Optional[DuplicationSummary] = None
+    # For incremental scanning: unfiltered issues for scope-based threshold checking
+    full_issues: Optional[List[UnifiedIssue]] = None
+    # For incremental scanning: unfiltered duplication result for scope checking
+    full_duplication_result: Any = None
 
     def compute_summary(self) -> ScanSummary:
         """Compute summary statistics from issues.

--- a/src/lucidshark/core/paths.py
+++ b/src/lucidshark/core/paths.py
@@ -51,9 +51,9 @@ def determine_scan_paths(
         if paths:
             LOGGER.info(f"Scanning {len(paths)} specified file(s)")
             return paths
-        # Fall through to full scan if no valid files
-        LOGGER.warning("No valid files specified, falling back to full scan")
-        return [project_root]
+        # No valid files found - return empty list (consistent with no changed files)
+        LOGGER.warning("No valid files specified, nothing to scan")
+        return []
 
     # If all_files is specified, scan entire project
     if all_files:

--- a/src/lucidshark/mcp/server.py
+++ b/src/lucidshark/mcp/server.py
@@ -101,6 +101,48 @@ class LucidSharkMCPServer:
                                 "description": "Whether to apply auto-fixes for fixable issues",
                                 "default": False,
                             },
+                            "base_branch": {
+                                "type": "string",
+                                "description": (
+                                    "Filter coverage results to files changed since this branch "
+                                    "(e.g., 'origin/main'). Full tests still run; only reporting "
+                                    "is filtered. Use in CI pipelines for PR-based coverage."
+                                ),
+                            },
+                            "coverage_threshold_scope": {
+                                "type": "string",
+                                "enum": ["changed", "project", "both"],
+                                "description": (
+                                    "When using base_branch, apply coverage threshold to: "
+                                    "'changed' (changed files only, default), "
+                                    "'project' (full project), or "
+                                    "'both' (fail if either is below threshold)."
+                                ),
+                            },
+                            "linting_threshold_scope": {
+                                "type": "string",
+                                "enum": ["changed", "project", "both"],
+                                "description": (
+                                    "When using base_branch, apply linting threshold to: "
+                                    "'changed' (default), 'project', or 'both'."
+                                ),
+                            },
+                            "type_checking_threshold_scope": {
+                                "type": "string",
+                                "enum": ["changed", "project", "both"],
+                                "description": (
+                                    "When using base_branch, apply type checking threshold to: "
+                                    "'changed' (default), 'project', or 'both'."
+                                ),
+                            },
+                            "duplication_threshold_scope": {
+                                "type": "string",
+                                "enum": ["changed", "project", "both"],
+                                "description": (
+                                    "When using base_branch, apply duplication threshold to: "
+                                    "'changed' (default), 'project', or 'both'."
+                                ),
+                            },
                         },
                     },
                 ),
@@ -265,6 +307,11 @@ class LucidSharkMCPServer:
                         files=arguments.get("files"),
                         all_files=arguments.get("all_files", False),
                         fix=arguments.get("fix", False),
+                        base_branch=arguments.get("base_branch"),
+                        coverage_threshold_scope=arguments.get("coverage_threshold_scope"),
+                        linting_threshold_scope=arguments.get("linting_threshold_scope"),
+                        type_checking_threshold_scope=arguments.get("type_checking_threshold_scope"),
+                        duplication_threshold_scope=arguments.get("duplication_threshold_scope"),
                         on_progress=send_progress,
                     )
                 elif name == "check_file":

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -94,6 +94,11 @@ class MCPToolExecutor:
         files: Optional[List[str]] = None,
         all_files: bool = False,
         fix: bool = False,
+        base_branch: Optional[str] = None,
+        coverage_threshold_scope: Optional[str] = None,
+        linting_threshold_scope: Optional[str] = None,
+        type_checking_threshold_scope: Optional[str] = None,
+        duplication_threshold_scope: Optional[str] = None,
         on_progress: Optional[Callable[[Dict[str, Any]], Coroutine[Any, Any, None]]] = None,
     ) -> Dict[str, Any]:
         """Execute scan and return AI-formatted results.
@@ -108,6 +113,19 @@ class MCPToolExecutor:
             files: Optional list of specific files to scan.
             all_files: If True, scan entire project instead of just changed files.
             fix: Whether to apply auto-fixes (linting only).
+            base_branch: Filter results to files changed since this branch (e.g., 'origin/main').
+            coverage_threshold_scope: When using base_branch, apply coverage threshold to:
+                'changed' (changed files only, default), 'project' (full project),
+                or 'both' (fail if either is below threshold).
+            linting_threshold_scope: When using base_branch, apply linting threshold to:
+                'changed' (changed files only, default), 'project' (full project),
+                or 'both' (fail if either has issues).
+            type_checking_threshold_scope: When using base_branch, apply type checking threshold to:
+                'changed' (changed files only, default), 'project' (full project),
+                or 'both' (fail if either has errors).
+            duplication_threshold_scope: When using base_branch, apply duplication threshold to:
+                'changed' (changed files only, default), 'project' (full project),
+                or 'both' (fail if either exceeds threshold).
             on_progress: Optional async callback for progress events (MCP notifications).
 
         Returns:
@@ -305,6 +323,63 @@ class MCPToolExecutor:
             for w in ignore_warnings:
                 LOGGER.warning(w)
 
+        # Apply base-branch filtering if specified
+        # This filters results to only show issues/metrics for changed files
+        # Store full results for scope-based threshold checking
+        full_coverage_result = context.coverage_result
+        full_duplication_result = context.duplication_result
+        changed_files: Optional[List[Path]] = None
+
+        if base_branch:
+            from lucidshark.core.filtering import filter_issues_by_changed_files
+            from lucidshark.core.git import get_changed_files_since_branch
+
+            changed_files = get_changed_files_since_branch(
+                self.project_root, base_branch
+            )
+            if changed_files is None:
+                # Git command failed - return error
+                return {
+                    "error": (
+                        f"Could not compare against branch '{base_branch}'. "
+                        "Ensure the branch exists and git history is available "
+                        "(use fetch-depth: 0 in CI)."
+                    ),
+                    "blocking": True,
+                    "total_issues": 0,
+                }
+
+            if changed_files:
+                LOGGER.info(
+                    f"Filtering results to {len(changed_files)} files "
+                    f"changed since {base_branch}"
+                )
+
+                # Filter issues (linting, type_checking)
+                all_issues = filter_issues_by_changed_files(
+                    all_issues, changed_files, self.project_root
+                )
+
+                # Filter coverage
+                if context.coverage_result:
+                    context.coverage_result = (
+                        full_coverage_result.filter_to_changed_files(
+                            changed_files, self.project_root
+                        )
+                    )
+
+                # Filter duplication
+                if context.duplication_result:
+                    context.duplication_result = (
+                        full_duplication_result.filter_to_changed_files(
+                            changed_files, self.project_root
+                        )
+                    )
+            else:
+                LOGGER.warning(
+                    f"No files changed since {base_branch}, showing full results"
+                )
+
         # Cache issues for later reference
         for issue in all_issues:
             self._issue_cache[issue.id] = issue
@@ -321,13 +396,76 @@ class MCPToolExecutor:
             duplication_result=context.duplication_result,
         )
 
-        # Add coverage summary if coverage was run
-        if context.coverage_result is not None:
-            formatted_result["coverage_summary"] = context.coverage_result.to_dict()
+        # Add incremental scanning metadata if base_branch was used
+        if base_branch:
+            formatted_result["incremental_scan"] = {
+                "base_branch": base_branch,
+                "changed_files_count": len(changed_files) if changed_files else 0,
+            }
 
-        # Add duplication summary if duplication detection was run
+        # Add coverage summary with scope-based threshold checking
+        if context.coverage_result is not None:
+            if base_branch and changed_files:
+                scope = coverage_threshold_scope or "changed"
+
+                # Compute effective passed based on scope
+                if scope == "changed":
+                    effective_passed = context.coverage_result.passed
+                elif scope == "project":
+                    effective_passed = full_coverage_result.passed
+                else:  # "both"
+                    effective_passed = (
+                        context.coverage_result.passed
+                        and full_coverage_result.passed
+                    )
+
+                LOGGER.debug(
+                    f"Coverage threshold scope: {scope}, "
+                    f"changed: {context.coverage_result.percentage:.1f}% "
+                    f"(passed={context.coverage_result.passed}), "
+                    f"project: {full_coverage_result.percentage:.1f}% "
+                    f"(passed={full_coverage_result.passed}), "
+                    f"effective_passed={effective_passed}"
+                )
+
+                coverage_dict = context.coverage_result.to_dict()
+                coverage_dict["passed"] = effective_passed
+                coverage_dict["threshold_scope"] = scope
+                formatted_result["coverage_summary"] = coverage_dict
+            else:
+                formatted_result["coverage_summary"] = context.coverage_result.to_dict()
+
+        # Add duplication summary with scope-based threshold checking
         if context.duplication_result is not None:
-            formatted_result["duplication_summary"] = context.duplication_result.to_dict()
+            if base_branch and changed_files:
+                scope = duplication_threshold_scope or "changed"
+
+                # Compute effective passed based on scope
+                if scope == "changed":
+                    effective_passed = context.duplication_result.passed
+                elif scope == "project":
+                    effective_passed = full_duplication_result.passed
+                else:  # "both"
+                    effective_passed = (
+                        context.duplication_result.passed
+                        and full_duplication_result.passed
+                    )
+
+                LOGGER.debug(
+                    f"Duplication threshold scope: {scope}, "
+                    f"changed: {context.duplication_result.duplication_percent:.1f}% "
+                    f"(passed={context.duplication_result.passed}), "
+                    f"project: {full_duplication_result.duplication_percent:.1f}% "
+                    f"(passed={full_duplication_result.passed}), "
+                    f"effective_passed={effective_passed}"
+                )
+
+                duplication_dict = context.duplication_result.to_dict()
+                duplication_dict["passed"] = effective_passed
+                duplication_dict["threshold_scope"] = scope
+                formatted_result["duplication_summary"] = duplication_dict
+            else:
+                formatted_result["duplication_summary"] = context.duplication_result.to_dict()
 
         return formatted_result
 

--- a/src/lucidshark/plugins/coverage/base.py
+++ b/src/lucidshark/plugins/coverage/base.py
@@ -128,6 +128,77 @@ class CoverageResult:
             }
         return result
 
+    def filter_to_changed_files(
+        self,
+        changed_files: List[Path],
+        project_root: Path,
+    ) -> "CoverageResult":
+        """Create filtered copy with only coverage for changed files.
+
+        This is used for PR-based incremental coverage reporting. The full test
+        suite still runs, but only coverage for changed files is reported.
+
+        Args:
+            changed_files: List of changed file paths (absolute).
+            project_root: Project root for path resolution.
+
+        Returns:
+            New CoverageResult with filtered files and recalculated stats.
+        """
+        # Build a set of relative path strings for matching
+        changed_set: set[str] = set()
+        for f in changed_files:
+            try:
+                rel_path = f.relative_to(project_root)
+                changed_set.add(str(rel_path))
+            except ValueError:
+                # File is outside project root, use absolute path
+                changed_set.add(str(f))
+
+        # Filter files dict to only include changed files
+        filtered_files: Dict[str, FileCoverage] = {}
+        for path, cov in self.files.items():
+            # Check if this file matches any changed file
+            if path in changed_set:
+                filtered_files[path] = cov
+            else:
+                # Also check if paths match by suffix (handles src/foo.py vs foo.py)
+                # Use Path objects to ensure proper path comparison (not string suffix)
+                path_obj = Path(path)
+                for changed in changed_set:
+                    changed_path = Path(changed)
+                    # Check if one path ends with the other's parts
+                    # e.g., "src/utils/foo.py" matches "utils/foo.py" or "foo.py"
+                    try:
+                        # Try to check if path ends with changed or vice versa
+                        if path_obj.parts[-len(changed_path.parts):] == changed_path.parts:
+                            filtered_files[path] = cov
+                            break
+                        elif changed_path.parts[-len(path_obj.parts):] == path_obj.parts:
+                            filtered_files[path] = cov
+                            break
+                    except (IndexError, ValueError):
+                        continue
+
+        # Recalculate totals from filtered files
+        total_lines = sum(f.total_lines for f in filtered_files.values())
+        covered_lines = sum(f.covered_lines for f in filtered_files.values())
+        missing_lines = sum(len(f.missing_lines) for f in filtered_files.values())
+
+        # Create new result with filtered data
+        # Keep test_stats unchanged since tests still ran fully
+        return CoverageResult(
+            total_lines=total_lines,
+            covered_lines=covered_lines,
+            missing_lines=missing_lines,
+            excluded_lines=self.excluded_lines,
+            threshold=self.threshold,
+            files=filtered_files,
+            issues=[],  # Issues will be regenerated if coverage is below threshold
+            test_stats=self.test_stats,
+            tool=self.tool,
+        )
+
 
 class CoveragePlugin(ABC):
     """Abstract base class for coverage plugins.

--- a/src/lucidshark/plugins/duplication/base.py
+++ b/src/lucidshark/plugins/duplication/base.py
@@ -91,6 +91,87 @@ class DuplicationResult:
             "passed": self.passed,
         }
 
+    def filter_to_changed_files(
+        self,
+        changed_files: List[Path],
+        project_root: Path,
+    ) -> "DuplicationResult":
+        """Create filtered copy with only duplicates involving changed files.
+
+        A duplicate is included if either file1 OR file2 is in changed files.
+        This is useful for PR-based incremental scanning where you want to
+        see duplicates that involve the code being changed.
+
+        Args:
+            changed_files: List of changed file paths (absolute).
+            project_root: Project root for path resolution.
+
+        Returns:
+            New DuplicationResult with filtered duplicates and recalculated stats.
+        """
+        from typing import Set
+
+        if not changed_files:
+            return DuplicationResult(
+                files_analyzed=0,
+                total_lines=0,
+                duplicate_blocks=0,
+                duplicate_lines=0,
+                threshold=self.threshold,
+                duplicates=[],
+                issues=[],
+            )
+
+        # Build set of changed file paths (both absolute and relative)
+        changed_set: Set[str] = set()
+        for f in changed_files:
+            changed_set.add(str(f))  # Absolute path
+            try:
+                changed_set.add(str(f.relative_to(project_root)))  # Relative
+            except ValueError:
+                pass
+
+        def path_matches(p: Path) -> bool:
+            """Check if path matches any changed file."""
+            p_str = str(p)
+            try:
+                p_rel = str(p.relative_to(project_root))
+            except ValueError:
+                p_rel = p_str
+            return p_str in changed_set or p_rel in changed_set
+
+        # Filter duplicates to those involving at least one changed file
+        filtered_duplicates: List[DuplicateBlock] = []
+        filtered_lines = 0
+        involved_files: Set[str] = set()
+
+        for dup in self.duplicates:
+            if path_matches(dup.file1) or path_matches(dup.file2):
+                filtered_duplicates.append(dup)
+                filtered_lines += dup.line_count
+                involved_files.add(str(dup.file1))
+                involved_files.add(str(dup.file2))
+
+        # Filter issues to those involving changed files
+        from lucidshark.core.filtering import filter_issues_by_changed_files
+
+        filtered_issues = filter_issues_by_changed_files(
+            self.issues, changed_files, project_root
+        )
+
+        return DuplicationResult(
+            # Keep original counts for consistency and meaningful percentage calculation.
+            # The filtered result shows duplicates involving changed files, but the
+            # percentage is relative to the full project for context.
+            files_analyzed=self.files_analyzed,  # Keep original for consistency
+            total_lines=self.total_lines,  # Keep original for % calculation context
+            duplicate_blocks=len(filtered_duplicates),
+            duplicate_lines=filtered_lines,
+            threshold=self.threshold,
+            duplicates=filtered_duplicates,
+            issues=filtered_issues,
+        )
+
 
 class DuplicationPlugin(ABC):
     """Abstract base class for duplication detection plugins.

--- a/tests/unit/cli/commands/test_scan.py
+++ b/tests/unit/cli/commands/test_scan.py
@@ -689,24 +689,40 @@ class TestCheckDomainThresholds:
     def _cmd(self) -> ScanCommand:
         return ScanCommand(version="1.0.0")
 
+    def _make_args(self, **kwargs: object) -> Namespace:
+        """Create a minimal args namespace for threshold checking."""
+        defaults: dict[str, object] = {
+            "base_branch": None,
+            "linting_threshold_scope": None,
+            "type_checking_threshold_scope": None,
+            "coverage_threshold_scope": None,
+            "duplication_threshold_scope": None,
+        }
+        for key, value in kwargs.items():
+            defaults[key] = value
+        return Namespace(**defaults)
+
     def test_no_threshold_returns_false(self) -> None:
         config = _make_config(fail_on=None)
         result = ScanResult(issues=[_make_issue()])
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_any_with_issues(self) -> None:
         config = _make_config(
             fail_on=FailOnConfig(linting="any")
         )
         result = ScanResult(issues=[_make_issue(domain=ToolDomain.LINTING)])
-        assert self._cmd()._check_domain_thresholds(result, config) is True
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
     def test_threshold_any_no_issues(self) -> None:
         config = _make_config(
             fail_on=FailOnConfig(linting="any")
         )
         result = ScanResult(issues=[])
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_error_with_high_severity(self) -> None:
         config = _make_config(
@@ -714,7 +730,8 @@ class TestCheckDomainThresholds:
         )
         issue = _make_issue(domain=ToolDomain.LINTING, severity=Severity.HIGH)
         result = ScanResult(issues=[issue])
-        assert self._cmd()._check_domain_thresholds(result, config) is True
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
     def test_threshold_error_with_low_severity(self) -> None:
         config = _make_config(
@@ -722,7 +739,8 @@ class TestCheckDomainThresholds:
         )
         issue = _make_issue(domain=ToolDomain.LINTING, severity=Severity.LOW)
         result = ScanResult(issues=[issue])
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_none_never_fails(self) -> None:
         config = _make_config(
@@ -730,7 +748,8 @@ class TestCheckDomainThresholds:
         )
         issue = _make_issue(domain=ToolDomain.LINTING, severity=Severity.CRITICAL)
         result = ScanResult(issues=[issue])
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_above_threshold_duplication_fail(self) -> None:
         config = _make_config(
@@ -741,7 +760,8 @@ class TestCheckDomainThresholds:
         result.duplication_summary = DuplicationSummary(
             duplication_percent=15.0, threshold=10.0, passed=False
         )
-        assert self._cmd()._check_domain_thresholds(result, config) is True
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
     def test_threshold_above_threshold_duplication_pass(self) -> None:
         config = _make_config(
@@ -752,7 +772,8 @@ class TestCheckDomainThresholds:
         result.duplication_summary = DuplicationSummary(
             duplication_percent=5.0, threshold=10.0, passed=True
         )
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_below_threshold_coverage_fail(self) -> None:
         config = _make_config(
@@ -763,7 +784,8 @@ class TestCheckDomainThresholds:
         result.coverage_summary = CoverageSummary(
             coverage_percentage=60.0, threshold=80.0, passed=False
         )
-        assert self._cmd()._check_domain_thresholds(result, config) is True
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
     def test_threshold_below_threshold_coverage_pass(self) -> None:
         config = _make_config(
@@ -774,7 +796,8 @@ class TestCheckDomainThresholds:
         result.coverage_summary = CoverageSummary(
             coverage_percentage=90.0, threshold=80.0, passed=True
         )
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_percentage_duplication(self) -> None:
         config = _make_config(
@@ -785,7 +808,8 @@ class TestCheckDomainThresholds:
         result.duplication_summary = DuplicationSummary(
             duplication_percent=8.0, threshold=5.0, passed=False
         )
-        assert self._cmd()._check_domain_thresholds(result, config) is True
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
     def test_threshold_percentage_duplication_under(self) -> None:
         config = _make_config(
@@ -796,7 +820,8 @@ class TestCheckDomainThresholds:
         result.duplication_summary = DuplicationSummary(
             duplication_percent=3.0, threshold=10.0, passed=True
         )
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     def test_threshold_invalid_percentage(self) -> None:
         config = _make_config(
@@ -805,7 +830,8 @@ class TestCheckDomainThresholds:
         issue = _make_issue(domain=ToolDomain.DUPLICATION)
         result = ScanResult(issues=[issue])
         result.duplication_summary = DuplicationSummary()
-        assert self._cmd()._check_domain_thresholds(result, config) is False
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is False
 
     @patch("lucidshark.cli.commands.scan.check_severity_threshold", return_value=True)
     def test_threshold_severity_string(self, mock_check) -> None:
@@ -814,17 +840,19 @@ class TestCheckDomainThresholds:
         )
         issue = _make_issue(domain=ScanDomain.SCA, severity=Severity.HIGH)
         result = ScanResult(issues=[issue])
-        assert self._cmd()._check_domain_thresholds(result, config) is True
+        args = self._make_args()
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
     def test_scan_domain_maps_to_security(self) -> None:
         """SCA, CONTAINER, IAC, SAST issues all map to 'security' domain."""
         config = _make_config(
             fail_on=FailOnConfig(security="any")
         )
+        args = self._make_args()
         for domain in [ScanDomain.SCA, ScanDomain.CONTAINER, ScanDomain.IAC, ScanDomain.SAST]:
             issue = _make_issue(domain=domain)
             result = ScanResult(issues=[issue])
-            assert self._cmd()._check_domain_thresholds(result, config) is True
+            assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
 
 class TestDryRun:
@@ -1063,8 +1091,15 @@ class TestIgnoreIssuesIntegration:
         result = ScanResult(issues=[issue])
 
         cmd = ScanCommand(version="1.0.0")
+        args = Namespace(
+            base_branch=None,
+            linting_threshold_scope=None,
+            type_checking_threshold_scope=None,
+            coverage_threshold_scope=None,
+            duplication_threshold_scope=None,
+        )
         # Only ignored issues -> should not trigger threshold
-        assert cmd._check_domain_thresholds(result, config) is False
+        assert cmd._check_domain_thresholds(result, config, args) is False
 
     def test_mixed_ignored_and_active_in_domain_thresholds(self) -> None:
         """Mix of ignored and active issues - only active should trigger."""
@@ -1077,4 +1112,11 @@ class TestIgnoreIssuesIntegration:
         result = ScanResult(issues=[ignored_issue, active_issue])
 
         cmd = ScanCommand(version="1.0.0")
-        assert cmd._check_domain_thresholds(result, config) is True
+        args = Namespace(
+            base_branch=None,
+            linting_threshold_scope=None,
+            type_checking_threshold_scope=None,
+            coverage_threshold_scope=None,
+            duplication_threshold_scope=None,
+        )
+        assert cmd._check_domain_thresholds(result, config, args) is True

--- a/tests/unit/core/test_git.py
+++ b/tests/unit/core/test_git.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from lucidshark.core.git import (
     filter_files_by_extension,
     get_changed_files,
+    get_changed_files_since_branch,
     get_git_root,
     is_git_repo,
 )
@@ -181,3 +182,532 @@ class TestFilterFilesByExtension:
         files = [tmp_path / "a.PY", tmp_path / "b.py"]
         result = filter_files_by_extension(files, [".py"])
         assert len(result) == 2
+
+
+class TestGetChangedFilesSinceBranch:
+    """Tests for get_changed_files_since_branch function."""
+
+    def test_not_git_repo(self, tmp_path: Path) -> None:
+        """Test returns None for non-git directory."""
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is None
+
+    def test_branch_does_not_exist(self, tmp_path: Path) -> None:
+        """Test returns None when base branch doesn't exist."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Try to compare against non-existent branch
+        result = get_changed_files_since_branch(tmp_path, "nonexistent-branch")
+        assert result is None
+
+    def test_no_changes_since_branch(self, tmp_path: Path) -> None:
+        """Test returns empty list when no changes since branch."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # HEAD is same as main, no changes
+        result = get_changed_files_since_branch(tmp_path, "HEAD")
+        assert result == []
+
+    def test_detects_changes_on_feature_branch(self, tmp_path: Path) -> None:
+        """Test detection of files changed on feature branch."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Add a new file on feature branch
+        new_file = tmp_path / "new_feature.py"
+        new_file.write_text("print('new feature')")
+        subprocess.run(
+            ["git", "add", "new_feature.py"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "add feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Compare feature branch against main
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is not None
+        assert new_file in result
+        assert test_file not in result  # Original file unchanged
+
+    def test_detects_modified_files_on_feature_branch(self, tmp_path: Path) -> None:
+        """Test detection of modified files on feature branch."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Modify existing file
+        test_file.write_text("print('modified')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "modify file"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Compare feature branch against main
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is not None
+        assert test_file in result
+
+    def test_multiple_commits_on_feature_branch(self, tmp_path: Path) -> None:
+        """Test detection with multiple commits on feature branch."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # First commit - add file1
+        file1 = tmp_path / "file1.py"
+        file1.write_text("print('file1')")
+        subprocess.run(["git", "add", "file1.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add file1"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Second commit - add file2
+        file2 = tmp_path / "file2.py"
+        file2.write_text("print('file2')")
+        subprocess.run(["git", "add", "file2.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add file2"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Third commit - modify file1
+        file1.write_text("print('file1 modified')")
+        subprocess.run(["git", "add", "file1.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "modify file1"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Should detect both files changed since main
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is not None
+        assert file1 in result
+        assert file2 in result
+        assert len(result) == 2
+
+    def test_deleted_file_not_in_result(self, tmp_path: Path) -> None:
+        """Test that deleted files are not included (they don't exist)."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit with two files on main
+        file1 = tmp_path / "file1.py"
+        file2 = tmp_path / "file2.py"
+        file1.write_text("print('file1')")
+        file2.write_text("print('file2')")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Delete file2 on feature branch
+        subprocess.run(["git", "rm", "file2.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "delete file2"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Modify file1
+        file1.write_text("print('file1 modified')")
+        subprocess.run(["git", "add", "file1.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "modify file1"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # file2 doesn't exist anymore, so it shouldn't be in result
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is not None
+        assert file1 in result
+        assert file2 not in result  # Deleted file not included
+
+    def test_git_timeout(self, tmp_path: Path) -> None:
+        """Test handling of git command timeout."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=30)):
+            result = get_changed_files_since_branch(tmp_path, "main")
+            assert result is None
+
+    def test_git_command_error(self, tmp_path: Path) -> None:
+        """Test handling of git command error."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+
+        with patch("subprocess.run", side_effect=subprocess.SubprocessError("git error")):
+            result = get_changed_files_since_branch(tmp_path, "main")
+            assert result is None
+
+    def test_includes_uncommitted_changes_by_default(self, tmp_path: Path) -> None:
+        """Test that uncommitted changes are included by default."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Add committed change on feature branch
+        committed_file = tmp_path / "committed.py"
+        committed_file.write_text("print('committed')")
+        subprocess.run(["git", "add", "committed.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add committed file"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Add uncommitted changes
+        uncommitted_file = tmp_path / "uncommitted.py"
+        uncommitted_file.write_text("print('uncommitted')")
+
+        # Default behavior includes uncommitted changes
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is not None
+        assert committed_file in result
+        assert uncommitted_file in result
+
+    def test_excludes_uncommitted_when_disabled(self, tmp_path: Path) -> None:
+        """Test that uncommitted changes are excluded when include_uncommitted=False."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Add committed change on feature branch
+        committed_file = tmp_path / "committed.py"
+        committed_file.write_text("print('committed')")
+        subprocess.run(["git", "add", "committed.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add committed file"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Add uncommitted changes
+        uncommitted_file = tmp_path / "uncommitted.py"
+        uncommitted_file.write_text("print('uncommitted')")
+
+        # Excluding uncommitted changes
+        result = get_changed_files_since_branch(tmp_path, "main", include_uncommitted=False)
+        assert result is not None
+        assert committed_file in result
+        assert uncommitted_file not in result
+
+    def test_includes_staged_changes(self, tmp_path: Path) -> None:
+        """Test that staged changes are included with uncommitted."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Add a staged file (not committed)
+        staged_file = tmp_path / "staged.py"
+        staged_file.write_text("print('staged')")
+        subprocess.run(["git", "add", "staged.py"], cwd=tmp_path, capture_output=True)
+
+        # Should include staged file
+        result = get_changed_files_since_branch(tmp_path, "HEAD")
+        assert result is not None
+        assert staged_file in result
+
+    def test_includes_unstaged_modifications(self, tmp_path: Path) -> None:
+        """Test that unstaged modifications are included with uncommitted."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')")
+        subprocess.run(["git", "add", "test.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Modify the file without staging
+        test_file.write_text("print('modified')")
+
+        # Should include modified file
+        result = get_changed_files_since_branch(tmp_path, "HEAD")
+        assert result is not None
+        assert test_file in result
+
+    def test_combined_committed_and_uncommitted_changes(self, tmp_path: Path) -> None:
+        """Test detection of both committed branch changes and uncommitted changes."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create initial commit on main
+        initial_file = tmp_path / "initial.py"
+        initial_file.write_text("print('initial')")
+        subprocess.run(["git", "add", "initial.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Create and switch to feature branch
+        subprocess.run(
+            ["git", "checkout", "-b", "feature"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Committed change on feature branch
+        committed_file = tmp_path / "committed.py"
+        committed_file.write_text("print('committed')")
+        subprocess.run(["git", "add", "committed.py"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add committed"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Staged change (not committed)
+        staged_file = tmp_path / "staged.py"
+        staged_file.write_text("print('staged')")
+        subprocess.run(["git", "add", "staged.py"], cwd=tmp_path, capture_output=True)
+
+        # Unstaged modification
+        committed_file.write_text("print('committed modified')")
+
+        # Untracked file
+        untracked_file = tmp_path / "untracked.py"
+        untracked_file.write_text("print('untracked')")
+
+        # Should include all types of changes
+        result = get_changed_files_since_branch(tmp_path, "main")
+        assert result is not None
+        assert committed_file in result  # Committed + unstaged modification
+        assert staged_file in result  # Staged
+        assert untracked_file in result  # Untracked
+        assert initial_file not in result  # Not changed

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -53,8 +53,8 @@ class TestDetermineScanPaths:
             assert len(result) == 1
             assert result[0] == existing_file
 
-    def test_all_files_nonexistent_falls_back_to_project_root(self) -> None:
-        """Test fallback to project root when all specified files don't exist."""
+    def test_all_files_nonexistent_returns_empty_list(self) -> None:
+        """Test empty list returned when all specified files don't exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
 
@@ -63,8 +63,8 @@ class TestDetermineScanPaths:
                 files=["nonexistent1.py", "nonexistent2.py"]
             )
 
-            # Should fall back to project root
-            assert result == [project_root]
+            # Should return empty list (consistent with no changed files behavior)
+            assert result == []
 
     def test_no_changed_files_returns_empty_list(self) -> None:
         """Test that no changed files returns empty list (not project root)."""

--- a/tests/unit/plugins/coverage/test_base.py
+++ b/tests/unit/plugins/coverage/test_base.py
@@ -206,3 +206,336 @@ class TestCoveragePlugin:
         assert result.total_lines == 100
         assert result.covered_lines == 85
         assert result.passed is True
+
+
+class TestCoverageResultFilterToChangedFiles:
+    """Tests for CoverageResult.filter_to_changed_files method."""
+
+    def test_filter_to_single_changed_file(self, tmp_path: Path) -> None:
+        """Test filtering to a single changed file."""
+        result = CoverageResult(
+            total_lines=300,
+            covered_lines=240,
+            missing_lines=60,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                    missing_lines=[10, 20, 30],
+                ),
+                "src/utils.py": FileCoverage(
+                    file_path=Path("src/utils.py"),
+                    total_lines=100,
+                    covered_lines=90,
+                    missing_lines=[5],
+                ),
+                "src/models.py": FileCoverage(
+                    file_path=Path("src/models.py"),
+                    total_lines=100,
+                    covered_lines=70,
+                    missing_lines=[1, 2, 3, 4, 5],
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert len(filtered.files) == 1
+        assert "src/app.py" in filtered.files
+        assert filtered.total_lines == 100
+        assert filtered.covered_lines == 80
+        assert filtered.percentage == 80.0
+
+    def test_filter_to_multiple_changed_files(self, tmp_path: Path) -> None:
+        """Test filtering to multiple changed files."""
+        result = CoverageResult(
+            total_lines=300,
+            covered_lines=240,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+                "src/utils.py": FileCoverage(
+                    file_path=Path("src/utils.py"),
+                    total_lines=100,
+                    covered_lines=90,
+                ),
+                "src/models.py": FileCoverage(
+                    file_path=Path("src/models.py"),
+                    total_lines=100,
+                    covered_lines=70,
+                ),
+            },
+        )
+
+        changed_files = [
+            tmp_path / "src" / "app.py",
+            tmp_path / "src" / "utils.py",
+        ]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert len(filtered.files) == 2
+        assert "src/app.py" in filtered.files
+        assert "src/utils.py" in filtered.files
+        assert "src/models.py" not in filtered.files
+        assert filtered.total_lines == 200
+        assert filtered.covered_lines == 170
+        assert filtered.percentage == 85.0
+
+    def test_filter_no_matching_files(self, tmp_path: Path) -> None:
+        """Test filtering when no files match."""
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "other.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert len(filtered.files) == 0
+        assert filtered.total_lines == 0
+        assert filtered.covered_lines == 0
+        assert filtered.percentage == 100.0  # No lines = 100%
+
+    def test_filter_empty_changed_files(self, tmp_path: Path) -> None:
+        """Test filtering with empty changed files list."""
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        filtered = result.filter_to_changed_files([], tmp_path)
+
+        assert len(filtered.files) == 0
+        assert filtered.total_lines == 0
+
+    def test_filter_preserves_test_stats(self, tmp_path: Path) -> None:
+        """Test that filtering preserves test statistics."""
+        test_stats = TestStatistics(total=10, passed=10, failed=0)
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            threshold=80.0,
+            test_stats=test_stats,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert filtered.test_stats is not None
+        assert filtered.test_stats.total == 10
+        assert filtered.test_stats.passed == 10
+
+    def test_filter_preserves_threshold(self, tmp_path: Path) -> None:
+        """Test that filtering preserves threshold."""
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            threshold=75.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert filtered.threshold == 75.0
+
+    def test_filter_preserves_tool_name(self, tmp_path: Path) -> None:
+        """Test that filtering preserves tool name."""
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            tool="coverage_py",
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert filtered.tool == "coverage_py"
+
+    def test_filter_recalculates_missing_lines(self, tmp_path: Path) -> None:
+        """Test that missing lines count is recalculated from filtered files."""
+        result = CoverageResult(
+            total_lines=200,
+            covered_lines=150,
+            missing_lines=50,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                    missing_lines=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],  # 10 missing
+                ),
+                "src/utils.py": FileCoverage(
+                    file_path=Path("src/utils.py"),
+                    total_lines=100,
+                    covered_lines=70,
+                    missing_lines=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],  # 15 missing
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        # Only count missing lines from filtered files
+        assert filtered.missing_lines == 10
+
+    def test_filter_clears_issues(self, tmp_path: Path) -> None:
+        """Test that filtering clears old issues (to be regenerated if needed)."""
+        from lucidshark.core.models import Severity, UnifiedIssue
+
+        mock_issue = UnifiedIssue(
+            id="cov-1",
+            title="Coverage below threshold",
+            description="Coverage is below the configured threshold",
+            domain=ToolDomain.COVERAGE,
+            source_tool="coverage_py",
+            severity=Severity.MEDIUM,
+            rule_id="coverage_below_threshold",
+        )
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=70,
+            threshold=80.0,
+            issues=[mock_issue],
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=70,
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        # Issues are cleared (will be regenerated based on new threshold check)
+        assert filtered.issues == []
+
+    def test_filter_with_path_suffix_matching(self, tmp_path: Path) -> None:
+        """Test path matching works with different path formats."""
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        # Changed file with full absolute path
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        assert len(filtered.files) == 1
+        assert "src/app.py" in filtered.files
+
+    def test_filter_threshold_applies_to_filtered_result(self, tmp_path: Path) -> None:
+        """Test that threshold check applies to filtered coverage percentage."""
+        result = CoverageResult(
+            total_lines=300,
+            covered_lines=270,  # 90% overall
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=50,  # 50% for this file
+                ),
+                "src/utils.py": FileCoverage(
+                    file_path=Path("src/utils.py"),
+                    total_lines=100,
+                    covered_lines=100,  # 100% for this file
+                ),
+                "src/models.py": FileCoverage(
+                    file_path=Path("src/models.py"),
+                    total_lines=100,
+                    covered_lines=100,  # 100% for this file - not changed
+                ),
+            },
+        )
+
+        # Only changed files: app.py (50%) and utils.py (100%)
+        changed_files = [
+            tmp_path / "src" / "app.py",
+            tmp_path / "src" / "utils.py",
+        ]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        # Filtered coverage: (50 + 100) / 200 = 75%
+        assert filtered.total_lines == 200
+        assert filtered.covered_lines == 150
+        assert filtered.percentage == 75.0
+        # 75% is below 80% threshold
+        assert filtered.passed is False
+
+    def test_filter_returns_new_instance(self, tmp_path: Path) -> None:
+        """Test that filter returns a new CoverageResult instance."""
+        result = CoverageResult(
+            total_lines=100,
+            covered_lines=80,
+            threshold=80.0,
+            files={
+                "src/app.py": FileCoverage(
+                    file_path=Path("src/app.py"),
+                    total_lines=100,
+                    covered_lines=80,
+                ),
+            },
+        )
+
+        changed_files = [tmp_path / "src" / "app.py"]
+        filtered = result.filter_to_changed_files(changed_files, tmp_path)
+
+        # Should be a new instance
+        assert filtered is not result
+        assert filtered.files is not result.files


### PR DESCRIPTION
## Summary

- Fixed multiple bugs in incremental scanning implementation
- Added comprehensive documentation for incremental scanning feature
- Updated README with incremental scanning section

## Bug Fixes

### Coverage Path Matching (BUG)
- **Issue:** Used `.endswith()` for path matching, causing false positives (`"myfoo.py".endswith("foo.py")` = True)
- **Fix:** Now uses `Path.parts` comparison for proper path suffix matching

### Duplication files_analyzed Inconsistency (BUG)
- **Issue:** Filtered result had mismatched `files_analyzed` vs `total_lines`
- **Fix:** Now preserves original `files_analyzed` for semantic consistency

### scope=both with threshold=any (BUG)
- **Issue:** When `scope="both"` and no issues in changed files but issues in full project, the code didn't fail
- **Fix:** Restructured logic to check both changed files AND full project independently

### Empty Files List Fallback (BUG)
- **Issue:** `--files foo.py bar.py` with non-existent files fell back to full project scan
- **Fix:** Now returns empty list (consistent with "no changed files" behavior)

### Filter Issues None Handling
- **Issue:** `filter_issues_by_changed_files` could crash if `changed_files` was `None`
- **Fix:** Now handles `None` gracefully, returning original issues

### Threshold Scope Fallback Warning
- **Issue:** When scope="project" or "both" but full result unavailable, silently fell back to "changed"
- **Fix:** Now logs a warning when falling back

## Documentation

- Added `docs/incremental-scanning.md` with:
  - Two modes explained: Default (uncommitted) vs Branch Comparison (--base-branch)
  - Quick start examples for local dev, PR/CI, and MCP
  - Domain-specific behavior (display vs threshold checking)
  - CI platform integration (GitHub Actions, GitLab CI, Bitbucket, Azure DevOps)
  - Known behaviors and FAQ

- Updated `docs/help.md`:
  - Added missing `threshold_scope` config options for all domains
  - Added duplication `baseline`, `cache`, `use_git` options
  - Clarified default mode vs `--base-branch` behavior

- Updated `README.md`:
  - Added "Incremental Scanning" section
  - Added link to incremental-scanning.md in Documentation section

## Test plan

- [x] All unit tests pass (2110 passed)
- [x] Linting passes
- [x] Type checking passes
- [x] Coverage above threshold
- [x] Duplication below threshold (4.3% < 5%)