### PR TITLE
feat: add PMD as managed Java linting tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to LucidShark are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **PMD linter plugin** for Java static analysis — complements Checkstyle with bug detection, design issues, performance, and complexity checks (296 rules across 8 categories)
+  - Managed binary: auto-downloaded on first use from GitHub releases, cached at `.lucidshark/bin/pmd/{version}/`
+  - Default ruleset: `rulesets/java/quickstart.xml` (118 rules); auto-detects custom configs (`pmd-ruleset.xml`, `pmd.xml`, `config/pmd/pmd.xml`, etc.)
+  - JSON output parsing with PMD priority-to-severity mapping (1=Critical, 2=High, 3=Medium, 4=Low, 5=Info)
+  - Uses `--file-list` for precise file targeting (respects gitignore patterns)
+  - Requires Java runtime (any Java project already has one)
+- PMD tool detection for existing project configurations
+
 ## [0.5.50] - 2026-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ lucidshark scan --all --base-branch origin/main
 
 See [Incremental Scanning](docs/incremental-scanning.md) for threshold scopes, CI integration, and advanced usage.
 
-**Note:** LucidShark validates that all configured tools are installed before running. If a tool is missing, the scan fails immediately with install instructions. Security tools (trivy, opengrep, checkov) and duplo are downloaded automatically.
+**Note:** LucidShark validates that all configured tools are installed before running. If a tool is missing, the scan fails immediately with install instructions. Security tools (trivy, opengrep, checkov), duplo, and PMD are downloaded automatically.
 
 ### Example Output
 
@@ -160,7 +160,7 @@ For detailed per-language tool coverage, configuration examples, and detection i
 
 | Domain | Tools | What It Catches |
 |--------|-------|-----------------|
-| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle | Style issues, code smells |
+| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD | Style issues, code smells, bug detection |
 | **Formatting** | Ruff Format, Prettier, rustfmt, google-java-format | Code formatting, whitespace style |
 | **Type Checking** | mypy, Pyright, TypeScript (tsc), SpotBugs, cargo check | Type errors, static analysis bugs |
 | **Security (SAST)** | OpenGrep | Code vulnerabilities |

--- a/docs/exclude-patterns.md
+++ b/docs/exclude-patterns.md
@@ -71,6 +71,7 @@ LucidShark applies exclude patterns in two layers:
 | Linting | ESLint | `--ignore-pattern` |
 | Linting | Biome | Relies on `biome.json` config; LucidShark does not pass patterns to CLI |
 | Linting | Checkstyle | Pre-filtered by LucidShark via `ignore_patterns.matches()` per file |
+| Linting | PMD | Pre-filtered by LucidShark via `--file-list` (only matched files are passed) |
 | Type Checking | mypy | `--exclude` (glob patterns are converted to regex) |
 | Type Checking | Pyright | Relies on `pyrightconfig.json` / `pyproject.toml`; no CLI exclude flags |
 | Type Checking | TypeScript (tsc) | Relies on `tsconfig.json` `exclude` field |
@@ -586,6 +587,7 @@ Some tools have their own configuration files that LucidShark respects:
 | ESLint | `.eslintignore`, `eslint.config.js`, `eslint.config.mjs` |
 | Biome | `biome.json`, `biome.jsonc` |
 | Checkstyle | `checkstyle.xml`, `.checkstyle.xml`, `config/checkstyle/checkstyle.xml` |
+| PMD | `pmd-ruleset.xml`, `pmd.xml`, `ruleset.xml`, `.pmd/rulesets.xml`, `config/pmd/pmd.xml` |
 | mypy | `mypy.ini`, `setup.cfg`, `pyproject.toml` (mypy section) |
 | Pyright | `pyrightconfig.json`, `pyproject.toml` (pyright section) |
 | TypeScript | `tsconfig.json` (exclude field) |

--- a/docs/help.md
+++ b/docs/help.md
@@ -86,7 +86,7 @@ Run the quality/security pipeline. By default, scans only changed files (uncommi
 
 | Flag | Domain | Description |
 |------|--------|-------------|
-| `--linting` | linting | Code style and linting (Ruff, ESLint, Biome, Clippy, Checkstyle) |
+| `--linting` | linting | Code style and linting (Ruff, ESLint, Biome, Clippy, Checkstyle, PMD) |
 | `--type-checking` | type_checking | Static type analysis (mypy, pyright, TypeScript, SpotBugs, cargo check) |
 | `--formatting` | formatting | Code formatting (Ruff Format, Prettier, rustfmt, google-java-format) |
 | `--sca` | sca | Dependency vulnerability scanning (Trivy) |
@@ -455,7 +455,7 @@ Get current LucidShark status and configuration.
   "project_root": "/path/to/project",
   "available_tools": {
     "scanners": ["trivy", "opengrep", "checkov"],
-    "linters": ["ruff", "eslint", "biome", "clippy"],
+    "linters": ["ruff", "eslint", "biome", "clippy", "pmd"],
     "formatters": ["ruff_format", "prettier", "rustfmt", "google_java_format"],
     "type_checkers": ["mypy", "pyright", "typescript", "spotbugs", "cargo_check"],
     "test_runners": ["pytest", "jest", "vitest", "karma", "playwright", "maven", "cargo"],
@@ -511,7 +511,7 @@ autoconfigure()
 |----------|--------|-----------|-------------|-------------|----------|
 | Python | ruff | ruff_format | mypy or pyright | pytest | coverage_py |
 | JavaScript/TypeScript | eslint or biome | prettier | typescript (tsc) | jest, vitest, karma, or playwright | istanbul or vitest_coverage |
-| Java | checkstyle | google_java_format | spotbugs | maven (JUnit) | jacoco |
+| Java | checkstyle, pmd | google_java_format | spotbugs | maven (JUnit) | jacoco |
 | Kotlin | -- | -- | -- | maven (JUnit) | jacoco |
 | Rust | clippy | rustfmt | cargo_check | cargo | tarpaulin |
 
@@ -626,7 +626,8 @@ pipeline:
       - name: eslint
       - name: biome
       - name: clippy      # For Rust projects
-      - name: checkstyle  # For Java projects
+      - name: checkstyle  # For Java projects (style checking)
+      - name: pmd         # For Java projects (bug detection, managed)
 
   type_checking:
     enabled: true
@@ -805,6 +806,7 @@ All other tools must be installed manually before use. If you configure a tool t
 | `eslint` | JavaScript, TypeScript | `npm install -g eslint` |
 | `biome` | JavaScript, TypeScript | `npm install -g @biomejs/biome` |
 | `checkstyle` | Java | `brew install checkstyle` (macOS) or download from checkstyle.org |
+| `pmd` | Java | **Managed** — auto-downloaded on first use (requires Java) |
 | `clippy` | Rust | `rustup component add clippy` |
 
 **Type Checkers:**
@@ -1058,7 +1060,7 @@ exclude:
 
 #### Java Project
 
-Checkstyle for linting, google-java-format for formatting, SpotBugs for type/bug analysis, Maven for testing, and JaCoCo for coverage.
+Checkstyle and PMD for linting, google-java-format for formatting, SpotBugs for type/bug analysis, Maven for testing, and JaCoCo for coverage. Checkstyle enforces coding style, while PMD detects bugs, design issues, and complexity problems.
 
 ```yaml
 version: 1
@@ -1070,6 +1072,7 @@ pipeline:
     enabled: true
     tools:
       - name: checkstyle
+      - name: pmd
   formatting:
     enabled: true
     tools:
@@ -1476,6 +1479,7 @@ For detailed per-language tool coverage, detection, and configuration examples, 
 | ESLint | JavaScript, TypeScript | ✅ Yes |
 | Biome | JavaScript, TypeScript, JSON | ✅ Yes |
 | Checkstyle | Java | ✅ Yes |
+| PMD | Java | ✅ Yes |
 | Clippy | Rust | ❌ No (Cargo workspace) |
 
 All linting tools support the `files` parameter for partial scanning, except Clippy which operates on the full Cargo workspace.

--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -15,7 +15,7 @@ LucidShark supports 15 programming languages with varying levels of tool coverag
 
 | Domain | Tools | Languages |
 |--------|-------|-----------|
-| **Linting** | [Ruff](python.md#linting), [ESLint](typescript.md#linting), [Biome](javascript.md#linting), [Clippy](rust.md#linting), [Checkstyle](java.md#linting) | Python, JS/TS, Rust, Java |
+| **Linting** | [Ruff](python.md#linting), [ESLint](typescript.md#linting), [Biome](javascript.md#linting), [Clippy](rust.md#linting), [Checkstyle](java.md#linting), [PMD](java.md#pmd) | Python, JS/TS, Rust, Java |
 | **Formatting** | [Ruff Format](python.md#formatting), [Prettier](javascript.md#formatting), [google-java-format](java.md#formatting), [rustfmt](rust.md#formatting) | Python, JS/TS, Java, Rust |
 | **Type Checking** | [mypy](python.md#type-checking), [Pyright](python.md#type-checking), [tsc](typescript.md#type-checking), [SpotBugs](java.md#type-checking), [cargo check](rust.md#type-checking) | Python, TypeScript, Java, Rust |
 | **Security (SAST)** | OpenGrep | All languages |

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -17,6 +17,7 @@ Java has full tool coverage in LucidShark across all six quality domains, with s
 | Domain | Tool | Auto-Fix | Notes |
 |--------|------|----------|-------|
 | **Linting** | Checkstyle | No | Style checking with Google or custom checks |
+| **Linting** | PMD | No | Bug detection, design issues, complexity (managed, auto-downloaded) |
 | **Formatting** | google-java-format | Yes | Google's opinionated Java formatter |
 | **Type Checking** | SpotBugs | -- | Static analysis for bugs, requires compiled classes |
 | **Security (SAST)** | OpenGrep | -- | Java-specific vulnerability rules |
@@ -27,6 +28,10 @@ Java has full tool coverage in LucidShark across all six quality domains, with s
 
 ## Linting
 
+Java has two complementary linters. **Checkstyle** enforces coding style and conventions, while **PMD** detects bugs, design issues, and complexity problems. Using both together provides comprehensive coverage.
+
+### Checkstyle
+
 **Tool: [Checkstyle](https://checkstyle.org/)**
 
 Java style checker distributed as a JAR file. Requires Java runtime.
@@ -34,13 +39,28 @@ Java style checker distributed as a JAR file. Requires Java runtime.
 - Default configuration: Google Java Style (`google_checks.xml`)
 - Custom config detection: `checkstyle.xml`, `.checkstyle.xml`, `config/checkstyle/checkstyle.xml`
 - Does not support auto-fix
+- Must be installed manually (`brew install checkstyle` on macOS)
+
+### PMD
+
+**Tool: [PMD](https://pmd.github.io/)**
+
+Source code analyzer that finds common programming flaws — unused variables, empty catch blocks, unnecessary object creation, God classes, and more.
+
+- **Managed tool** — auto-downloaded on first use, cached at `.lucidshark/bin/pmd/{version}/`
+- Default ruleset: `rulesets/java/quickstart.xml` (118 rules)
+- Custom config detection: `pmd-ruleset.xml`, `pmd.xml`, `ruleset.xml`, `.pmd/rulesets.xml`, `config/pmd/pmd.xml`, `config/pmd/ruleset.xml`
+- Does not support auto-fix
+- Only requires Java (which any Java project already has)
+- PMD priority mapping: 1→Critical, 2→High, 3→Medium, 4→Low, 5→Info
 
 ```yaml
 pipeline:
   linting:
     enabled: true
     tools:
-      - name: checkstyle
+      - name: checkstyle   # Style checking
+      - name: pmd          # Bug detection and design analysis
 ```
 
 ## Formatting
@@ -146,6 +166,7 @@ pipeline:
     enabled: true
     tools:
       - { name: checkstyle }
+      - { name: pmd }
   formatting:
     enabled: true
     tools:

--- a/docs/main.md
+++ b/docs/main.md
@@ -85,7 +85,7 @@ A single configuration file controls:
 
 | Domain | Tools | What It Catches |
 |--------|-------|-----------------|
-| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle | Style, code smells |
+| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD | Style, code smells, bug detection |
 | **Formatting** | Ruff Format, Prettier, rustfmt, google-java-format | Code formatting, whitespace style |
 | **Type Checking** | mypy, TypeScript, Pyright, SpotBugs, cargo check | Type errors, static analysis bugs |
 | **Security** | Trivy, OpenGrep, Checkov | Vulnerabilities, misconfigurations |
@@ -358,7 +358,7 @@ LucidShark scans only changed files (uncommitted changes) by default. Use `--all
 
 | Domain | Partial Scan Support | Behavior |
 |--------|---------------------|----------|
-| **Linting** | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle support file args; Clippy is workspace-wide |
+| **Linting** | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle/PMD support file args; Clippy is workspace-wide |
 | **Formatting** | ⚠️ Partial | Ruff Format/Prettier support file args; rustfmt/google-java-format project-wide |
 | **Type Checking** | ⚠️ Partial | mypy/pyright yes; tsc/SpotBugs/cargo check always full |
 | **SAST** | ✅ Full | OpenGrep scans only changed/specified files |
@@ -717,7 +717,7 @@ checkov = "3.2.506"
 duplo = "0.1.6"
 ```
 
-**Language-specific tools** (ruff, eslint, biome, mypy, pyright, checkstyle, google-java-format, spotbugs, etc.) are **not** version-pinned by LucidShark. Install these via your package manager (pip, npm, cargo) to ensure compatibility with your project.
+**Language-specific tools** (ruff, eslint, biome, mypy, pyright, checkstyle, google-java-format, spotbugs, etc.) are **not** version-pinned by LucidShark. Install these via your package manager (pip, npm, cargo) to ensure compatibility with your project. PMD is an exception — it is managed (auto-downloaded) like security tools, since it is distributed as a cross-platform zip.
 
 When installed as a package, LucidShark uses hardcoded fallback versions from `src/lucidshark/bootstrap/versions.py`.
 
@@ -1049,7 +1049,7 @@ The MCP server sends progress notifications during scans, reporting domain start
 
 | Domain | Partial Scan | Notes |
 |--------|--------------|-------|
-| Linting | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle support file-level; Clippy is workspace-wide |
+| Linting | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle/PMD support file-level; Clippy is workspace-wide |
 | Formatting | ⚠️ Partial | Ruff Format/Prettier support file-level; rustfmt/google-java-format project-wide |
 | Type Checking | ⚠️ Partial | mypy/pyright yes; tsc/SpotBugs/cargo check no |
 | SAST | ✅ Yes | OpenGrep supports file-level scanning |
@@ -1272,7 +1272,7 @@ LucidShark scans only changed files by default, enabling fast feedback loops:
 
 | Tool Category | Tools | Partial Scan Support |
 |---------------|-------|---------------------|
-| **Linting** | Ruff, ESLint, Biome, Checkstyle | ✅ All support file args |
+| **Linting** | Ruff, ESLint, Biome, Checkstyle, PMD | ✅ All support file args |
 | **Linting** | Clippy | ❌ Cargo workspace only |
 | **Formatting** | Ruff Format, Prettier | ✅ Support file args |
 | **Formatting** | rustfmt, google-java-format | ❌ Project-wide only |
@@ -1471,6 +1471,7 @@ MCP tools, and configuration reference.
 | ESLint | JavaScript, TypeScript | npm | ✅ Yes |
 | Biome | JavaScript, TypeScript, JSON | npm / binary | ✅ Yes |
 | Checkstyle | Java | binary (jar) | ✅ Yes |
+| PMD | Java | managed (auto-download) | ✅ Yes |
 | Clippy | Rust | system (rustup) | ❌ No (Cargo workspace) |
 
 All linting tools support partial scanning via the `files` parameter, except Clippy which operates on the full Cargo workspace.
@@ -1582,6 +1583,7 @@ pipeline:
   - [x] Biome (JS/TS)
   - [x] Checkov (IaC)
   - [x] Checkstyle (Java linting)
+  - [x] PMD (Java static analysis - managed)
   - [x] Jest (JS/TS testing)
   - [x] Karma (Angular testing)
   - [x] Playwright (E2E testing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ eslint = "lucidshark.plugins.linters.eslint:ESLintLinter"
 biome = "lucidshark.plugins.linters.biome:BiomeLinter"
 clippy = "lucidshark.plugins.linters.clippy:ClippyLinter"
 checkstyle = "lucidshark.plugins.linters.checkstyle:CheckstyleLinter"
+pmd = "lucidshark.plugins.linters.pmd:PmdLinter"
 
 [project.entry-points."lucidshark.scanners"]
 trivy = "lucidshark.plugins.scanners.trivy:TrivyScanner"
@@ -158,5 +159,7 @@ markers = [
 trivy = "0.69.3"
 opengrep = "1.16.3"
 checkov = "3.2.506"
+# Linters
+pmd = "7.22.0"
 # Duplication detection
 duplo = "0.1.6"

--- a/src/lucidshark/bootstrap/versions.py
+++ b/src/lucidshark/bootstrap/versions.py
@@ -24,6 +24,8 @@ _FALLBACK_VERSIONS: Dict[str, str] = {
     "trivy": "0.69.3",
     "opengrep": "1.16.3",
     "checkov": "3.2.506",
+    # Linters
+    "pmd": "7.22.0",
     # Duplication detection
     "duplo": "0.1.6",
 }

--- a/src/lucidshark/cli/arguments.py
+++ b/src/lucidshark/cli/arguments.py
@@ -108,7 +108,7 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
     domain_group.add_argument(
         "--linting",
         action="store_true",
-        help="Run linting checks (Ruff for Python, ESLint for JS/TS, Checkstyle for Java).",
+        help="Run linting checks (Ruff for Python, ESLint for JS/TS, Checkstyle/PMD for Java).",
     )
     domain_group.add_argument(
         "--type-checking",

--- a/src/lucidshark/cli/commands/init.py
+++ b/src/lucidshark/cli/commands/init.py
@@ -39,7 +39,7 @@ Run scans proactively after code changes. Don't wait for user to ask.
 
 | Domain | What It Does | Tools |
 |--------|--------------|-------|
-| **linting** | Style issues, code smells, auto-fix | Ruff, ESLint, Biome, Clippy, Checkstyle |
+| **linting** | Style issues, code smells, auto-fix | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD |
 | **type_checking** | Type errors, static analysis | mypy, Pyright, tsc, SpotBugs, cargo check |
 | **sast** | Security vulnerabilities in code | OpenGrep |
 | **sca** | Dependency vulnerabilities | Trivy |

--- a/src/lucidshark/core/domain_runner.py
+++ b/src/lucidshark/core/domain_runner.py
@@ -27,6 +27,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
     "biome": ["javascript", "typescript"],
     "clippy": ["rust"],
     "checkstyle": ["java"],
+    "pmd": ["java"],
     # Type checkers
     "mypy": ["python"],
     "pyright": ["python"],

--- a/src/lucidshark/core/tool_validation.py
+++ b/src/lucidshark/core/tool_validation.py
@@ -32,6 +32,7 @@ AUTO_DOWNLOADABLE_TOOLS = frozenset(
         "opengrep",
         "checkov",
         "duplo",
+        "pmd",
     }
 )
 
@@ -240,7 +241,7 @@ def format_validation_errors(errors: List[ToolValidationError]) -> str:
 
     lines.append("Please install the missing tools and try again.")
     lines.append("")
-    lines.append("Note: Security tools (trivy, opengrep, checkov) and duplo are")
+    lines.append("Note: Security tools (trivy, opengrep, checkov), duplo, and pmd are")
     lines.append("downloaded automatically - no manual installation required.")
 
     return "\n".join(lines)

--- a/src/lucidshark/detection/tools.py
+++ b/src/lucidshark/detection/tools.py
@@ -71,6 +71,20 @@ TOOL_CONFIGS: Dict[str, Dict[str, Any]] = {
         "files": [".coveragerc"],
         "pyproject_section": "tool.coverage",
     },
+    # Java linters
+    "checkstyle": {
+        "files": ["checkstyle.xml", ".checkstyle.xml", "config/checkstyle/checkstyle.xml"],
+    },
+    "pmd": {
+        "files": [
+            "pmd-ruleset.xml",
+            "pmd.xml",
+            "ruleset.xml",
+            ".pmd/rulesets.xml",
+            "config/pmd/pmd.xml",
+            "config/pmd/ruleset.xml",
+        ],
+    },
     # JavaScript/TypeScript linters
     "eslint": {
         "files": [

--- a/src/lucidshark/mcp/server.py
+++ b/src/lucidshark/mcp/server.py
@@ -46,7 +46,7 @@ class LucidSharkMCPServer:
                     name="scan",
                     description=(
                         "Run comprehensive code quality checks. LucidShark is a unified pipeline "
-                        "for: LINTING (Ruff, ESLint, Biome, Clippy, Checkstyle - style issues, code smells); "
+                        "for: LINTING (Ruff, ESLint, Biome, Clippy, Checkstyle, PMD - style issues, code smells); "
                         "FORMATTING (Ruff Format, Prettier, rustfmt, google-java-format - code formatting); "
                         "TYPE_CHECKING (mypy, Pyright, tsc, SpotBugs, cargo check - type errors); "
                         "SAST security (OpenGrep - code vulnerabilities); "

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -844,11 +844,13 @@ class MCPToolExecutor:
                         "java_kotlin": {
                             "tools": [
                                 "checkstyle",
+                                "pmd (managed - auto-downloaded)",
                                 "spotbugs",
                                 "jacoco (all via Maven/Gradle plugins)",
                             ],
                             "note": (
                                 "Java/Kotlin tools are configured via Maven/Gradle plugins, not installed separately. "
+                                "PMD is auto-downloaded by LucidShark. "
                                 "Verify pom.xml or build.gradle has the required plugins configured."
                             ),
                         },
@@ -1162,7 +1164,7 @@ class MCPToolExecutor:
                     "coverage": "istanbul/nyc (usually included with jest)",
                 },
                 "java_kotlin": {
-                    "linter": "checkstyle",
+                    "linter": "checkstyle (style) + pmd (bugs/design, managed)",
                     "formatter": "google_java_format",
                     "type_checker": "spotbugs (bug detection via static analysis)",
                     "test_runner": "maven (runs JUnit/TestNG tests)",
@@ -1326,7 +1328,7 @@ project:
 pipeline:
   linting:
     enabled: true
-    tools: [checkstyle]
+    tools: [checkstyle, pmd]
   security:
     enabled: true
     tools:

--- a/src/lucidshark/plugins/linters/pmd.py
+++ b/src/lucidshark/plugins/linters/pmd.py
@@ -1,0 +1,433 @@
+"""PMD linter plugin.
+
+PMD is a source code analyzer for Java that finds common programming flaws
+like unused variables, empty catch blocks, unnecessary object creation, etc.
+https://pmd.github.io/
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from lucidshark.bootstrap.download import secure_urlopen
+from lucidshark.bootstrap.paths import LucidsharkPaths
+from lucidshark.bootstrap.versions import get_tool_version
+from lucidshark.core.logging import get_logger
+from lucidshark.core.models import (
+    ScanContext,
+    Severity,
+    ToolDomain,
+    UnifiedIssue,
+)
+from lucidshark.core.subprocess_runner import run_with_streaming
+from lucidshark.plugins.linters.base import LinterPlugin
+
+LOGGER = get_logger(__name__)
+
+# Default version from pyproject.toml [tool.lucidshark.tools]
+DEFAULT_VERSION = get_tool_version("pmd")
+
+# PMD priority mapping to unified severity
+# PMD priorities: 1=highest, 5=lowest
+PRIORITY_SEVERITY_MAP: Dict[int, Severity] = {
+    1: Severity.CRITICAL,
+    2: Severity.HIGH,
+    3: Severity.MEDIUM,
+    4: Severity.LOW,
+    5: Severity.INFO,
+}
+
+
+class PmdLinter(LinterPlugin):
+    """PMD linter plugin for Java static analysis."""
+
+    def __init__(
+        self,
+        version: str = DEFAULT_VERSION,
+        project_root: Optional[Path] = None,
+    ) -> None:
+        """Initialize PmdLinter.
+
+        Args:
+            version: PMD version to use.
+            project_root: Optional project root for binary cache.
+        """
+        super().__init__(project_root=project_root)
+        self._version = version
+        if project_root:
+            self._paths = LucidsharkPaths.for_project(project_root)
+        else:
+            self._paths = LucidsharkPaths.default()
+
+    @property
+    def name(self) -> str:
+        """Plugin identifier."""
+        return "pmd"
+
+    @property
+    def languages(self) -> List[str]:
+        """Supported languages."""
+        return ["java"]
+
+    @property
+    def supports_fix(self) -> bool:
+        """PMD does not support auto-fix."""
+        return False
+
+    def get_version(self) -> str:
+        """Get PMD version."""
+        return self._version
+
+    def ensure_binary(self) -> Path:
+        """Ensure PMD is available, downloading if needed.
+
+        Returns:
+            Path to the PMD binary script.
+
+        Raises:
+            FileNotFoundError: If Java is not available.
+            RuntimeError: If PMD cannot be downloaded.
+        """
+        binary_dir = self._paths.plugin_bin_dir(self.name, self._version)
+        binary_path = binary_dir / f"pmd-bin-{self._version}" / "bin" / "pmd"
+
+        if binary_path.exists():
+            LOGGER.debug(f"PMD binary found at {binary_path}")
+            return binary_path
+
+        # Verify Java is available before downloading
+        if not shutil.which("java"):
+            raise FileNotFoundError(
+                "Java is required to run PMD but was not found. "
+                "Install a JDK (e.g., OpenJDK 11+) and ensure 'java' is in PATH."
+            )
+
+        LOGGER.info(f"Downloading PMD v{self._version}...")
+        self._download_binary(binary_dir)
+
+        if not binary_path.exists():
+            raise RuntimeError(f"Failed to download PMD binary to {binary_path}")
+
+        return binary_path
+
+    def _download_binary(self, dest_dir: Path) -> None:
+        """Download and extract PMD for current platform.
+
+        Args:
+            dest_dir: Directory to extract PMD into.
+        """
+        # Construct download URL
+        url = (
+            f"https://github.com/pmd/pmd/releases/download/"
+            f"pmd_releases/{self._version}/pmd-dist-{self._version}-bin.zip"
+        )
+
+        LOGGER.debug(f"Downloading from {url}")
+
+        # Create destination directory
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        # Validate URL scheme and domain for security
+        if not url.startswith("https://github.com/"):
+            raise ValueError(f"Invalid download URL: {url}")
+
+        # Download and extract
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+        tmp_path = Path(tmp_file.name)
+        try:
+            with secure_urlopen(url) as response:  # nosec B310 nosemgrep
+                tmp_file.write(response.read())
+            tmp_file.close()
+
+            # Extract zip safely (prevent path traversal)
+            with zipfile.ZipFile(tmp_path, "r") as zf:
+                for zip_info in zf.infolist():
+                    # Validate each member path to prevent traversal attacks
+                    member_path = (dest_dir / zip_info.filename).resolve()
+                    if not member_path.is_relative_to(dest_dir.resolve()):
+                        raise ValueError(
+                            f"Path traversal detected: {zip_info.filename}"
+                        )
+                    zf.extract(zip_info, path=dest_dir)
+
+            # Make bin/pmd executable
+            binary_path = dest_dir / f"pmd-bin-{self._version}" / "bin" / "pmd"
+            if binary_path.exists():
+                binary_path.chmod(0o755)
+            LOGGER.info(f"PMD v{self._version} installed to {binary_path}")
+
+        finally:
+            # Ensure file is closed before attempting to delete
+            if not tmp_file.closed:
+                tmp_file.close()
+            tmp_path.unlink(missing_ok=True)
+
+    def lint(self, context: ScanContext) -> List[UnifiedIssue]:
+        """Run PMD linting checks.
+
+        Args:
+            context: Scan context with paths and configuration.
+
+        Returns:
+            List of linting issues.
+        """
+        try:
+            binary = self.ensure_binary()
+        except (FileNotFoundError, RuntimeError) as e:
+            LOGGER.warning(str(e))
+            return []
+
+        # Find Java source files
+        java_files = self._find_java_files(context)
+        if not java_files:
+            LOGGER.info("No Java files found to check with PMD")
+            return []
+
+        # Determine ruleset
+        ruleset = self._find_ruleset_config(context.project_root)
+
+        # Write file list to temp file for precise targeting.
+        # Using --file-list instead of -d (directories) ensures PMD only
+        # scans the exact files that passed our gitignore filtering.
+        file_list_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        )
+        file_list_path = Path(file_list_file.name)
+        try:
+            for f in java_files:
+                file_list_file.write(f + "\n")
+            file_list_file.close()
+
+            # Build command
+            cmd = [
+                str(binary),
+                "check",
+                "--file-list",
+                str(file_list_path),
+                "-R",
+                ruleset,
+                "-f",
+                "json",
+                "--no-fail-on-violation",
+            ]
+
+            LOGGER.debug(f"Running: {' '.join(cmd[:10])}...")
+
+            try:
+                result = run_with_streaming(
+                    cmd=cmd,
+                    cwd=context.project_root,
+                    tool_name="pmd",
+                    stream_handler=context.stream_handler,
+                    timeout=120,
+                )
+            except subprocess.TimeoutExpired:
+                LOGGER.warning("PMD timed out after 120 seconds")
+                return []
+            except Exception as e:
+                LOGGER.error(f"Failed to run PMD: {e}")
+                return []
+        finally:
+            file_list_path.unlink(missing_ok=True)
+
+        # Parse JSON output
+        issues = self._parse_output(result.stdout, context.project_root)
+
+        LOGGER.info(f"PMD found {len(issues)} issues")
+        return issues
+
+    def _find_ruleset_config(self, project_root: Path) -> str:
+        """Find PMD ruleset configuration file.
+
+        Args:
+            project_root: Project root directory.
+
+        Returns:
+            Path to ruleset file or built-in ruleset name.
+        """
+        custom_configs = [
+            "pmd-ruleset.xml",
+            "pmd.xml",
+            "ruleset.xml",
+            ".pmd/rulesets.xml",
+            "config/pmd/pmd.xml",
+            "config/pmd/ruleset.xml",
+        ]
+
+        for config in custom_configs:
+            config_path = project_root / config
+            if config_path.exists():
+                return str(config_path)
+
+        # Use PMD built-in quickstart ruleset (118 rules)
+        return "rulesets/java/quickstart.xml"
+
+    def _find_java_files(self, context: ScanContext) -> List[str]:
+        """Find Java source files to check.
+
+        Args:
+            context: Scan context.
+
+        Returns:
+            List of Java file paths.
+        """
+        java_files = []
+
+        # Search in specified paths or common Java directories
+        search_dirs = []
+        if context.paths:
+            search_dirs = list(context.paths)
+        else:
+            # Common Java source directories
+            for src_dir in ["src", "src/main/java", "src/test/java"]:
+                src_path = context.project_root / src_dir
+                if src_path.exists():
+                    search_dirs.append(src_path)
+
+        if not search_dirs:
+            search_dirs = [context.project_root]
+
+        for search_dir in search_dirs:
+            if not search_dir.exists():
+                continue
+
+            for java_file in search_dir.rglob("*.java"):
+                # Check if file should be excluded using proper gitignore matching
+                if (
+                    context.ignore_patterns is None
+                    or not context.ignore_patterns.matches(
+                        java_file, context.project_root
+                    )
+                ):
+                    java_files.append(str(java_file))
+
+        return java_files
+
+    def _parse_output(self, output: str, project_root: Path) -> List[UnifiedIssue]:
+        """Parse PMD JSON output.
+
+        Args:
+            output: JSON output from PMD.
+            project_root: Project root directory.
+
+        Returns:
+            List of UnifiedIssue objects.
+        """
+        if not output.strip():
+            return []
+
+        try:
+            data = json.loads(output)
+        except json.JSONDecodeError as e:
+            LOGGER.warning(f"Failed to parse PMD JSON output: {e}")
+            return []
+
+        issues = []
+
+        for file_entry in data.get("files", []):
+            file_path = file_entry.get("filename", "")
+
+            for violation in file_entry.get("violations", []):
+                issue = self._violation_to_issue(violation, file_path, project_root)
+                if issue:
+                    issues.append(issue)
+
+        return issues
+
+    def _violation_to_issue(
+        self,
+        violation: Dict[str, Any],
+        file_path: str,
+        project_root: Path,
+    ) -> Optional[UnifiedIssue]:
+        """Convert PMD violation to UnifiedIssue.
+
+        Args:
+            violation: PMD violation dictionary.
+            file_path: File path from parent file entry.
+            project_root: Project root directory.
+
+        Returns:
+            UnifiedIssue or None.
+        """
+        try:
+            rule = violation.get("rule", "")
+            ruleset = violation.get("ruleset", "")
+            priority = violation.get("priority", 3)
+            description = violation.get("description", "")
+            begin_line = violation.get("beginline")
+            begin_column = violation.get("begincolumn")
+            end_line = violation.get("endline")
+            external_info_url = violation.get("externalInfoUrl")
+
+            # Get severity from priority
+            severity = PRIORITY_SEVERITY_MAP.get(priority, Severity.MEDIUM)
+
+            # Build file path
+            path = Path(file_path)
+            if not path.is_absolute():
+                path = project_root / path
+
+            # Parse line/column
+            line_num = int(begin_line) if begin_line is not None else None
+            col_num = int(begin_column) if begin_column is not None else None
+            end_line_num = int(end_line) if end_line is not None else None
+
+            # Generate deterministic ID
+            issue_id = self._generate_issue_id(
+                rule, file_path, line_num, col_num, description
+            )
+
+            return UnifiedIssue(
+                id=issue_id,
+                domain=ToolDomain.LINTING,
+                source_tool="pmd",
+                severity=severity,
+                rule_id=rule or "unknown",
+                title=f"[{rule}] {description}" if rule else description,
+                description=description,
+                documentation_url=external_info_url,
+                file_path=path,
+                line_start=line_num,
+                line_end=end_line_num,
+                column_start=col_num,
+                fixable=False,
+                metadata={
+                    "ruleset": ruleset,
+                    "priority": priority,
+                },
+            )
+        except Exception as e:
+            LOGGER.warning(f"Failed to parse PMD violation: {e}")
+            return None
+
+    def _generate_issue_id(
+        self,
+        rule: str,
+        file: str,
+        line: Optional[int],
+        column: Optional[int],
+        message: str,
+    ) -> str:
+        """Generate deterministic issue ID.
+
+        Args:
+            rule: Rule name.
+            file: File path.
+            line: Line number.
+            column: Column number.
+            message: Violation message.
+
+        Returns:
+            Unique issue ID.
+        """
+        content = f"{rule}:{file}:{line or 0}:{column or 0}:{message}"
+        hash_val = hashlib.sha256(content.encode()).hexdigest()[:12]
+        return f"pmd-{rule}-{hash_val}" if rule else f"pmd-{hash_val}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,7 @@ from lucidshark.plugins.linters.ruff import RuffLinter
 from lucidshark.plugins.linters.biome import BiomeLinter
 from lucidshark.plugins.linters.eslint import ESLintLinter
 from lucidshark.plugins.linters.checkstyle import CheckstyleLinter
+from lucidshark.plugins.linters.pmd import PmdLinter
 from lucidshark.plugins.type_checkers.mypy import MypyChecker
 from lucidshark.plugins.type_checkers.pyright import PyrightChecker
 from lucidshark.plugins.type_checkers.typescript import TypeScriptChecker
@@ -225,6 +226,17 @@ def _ensure_spotbugs_downloaded() -> bool:
         return False
 
 
+def _ensure_pmd_downloaded() -> bool:
+    """Ensure PMD binary is downloaded. Returns True if available."""
+    root = Path(__file__).parent.parent.parent
+    try:
+        linter = PmdLinter(project_root=root)
+        linter.ensure_binary()
+        return True
+    except Exception:
+        return False
+
+
 # =============================================================================
 # Type checker availability checks
 # =============================================================================
@@ -292,6 +304,7 @@ _mypy_available = _ensure_mypy_available()
 _pyright_available = _ensure_pyright_available()
 _tsc_available = _ensure_tsc_available()
 _spotbugs_available = _java_available and _ensure_spotbugs_downloaded()
+_pmd_available = _java_available and _ensure_pmd_downloaded()
 _maven_available = _java_available and _is_maven_available()
 
 
@@ -425,6 +438,10 @@ spotbugs_available = pytest.mark.skipif(
     not _spotbugs_available, reason="SpotBugs not available (requires Java)"
 )
 
+pmd_available = pytest.mark.skipif(
+    not _pmd_available, reason="PMD not available (requires Java and download)"
+)
+
 maven_available = pytest.mark.skipif(
     not _maven_available, reason="Maven not available (requires Java and mvn)"
 )
@@ -468,6 +485,12 @@ def eslint_linter(project_root: Path) -> ESLintLinter:
 def checkstyle_linter(project_root: Path) -> CheckstyleLinter:
     """Return a CheckstyleLinter instance."""
     return CheckstyleLinter(project_root=project_root)
+
+
+@pytest.fixture
+def pmd_linter(project_root: Path) -> PmdLinter:
+    """Return a PmdLinter instance."""
+    return PmdLinter(project_root=project_root)
 
 
 @pytest.fixture

--- a/tests/integration/linters/test_pmd_integration.py
+++ b/tests/integration/linters/test_pmd_integration.py
@@ -1,0 +1,100 @@
+"""Integration tests for PMD linter.
+
+These tests require Java to be installed. PMD will be auto-downloaded.
+
+Run with: pytest tests/integration/linters/test_pmd_integration.py -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from lucidshark.core.models import ScanContext
+from lucidshark.plugins.linters.pmd import PmdLinter
+from tests.integration.conftest import java_available, pmd_available
+
+
+class TestPmdResolution:
+    """Tests for PMD binary resolution."""
+
+    def test_ensure_binary_raises_when_java_not_available(self) -> None:
+        """Test that ensure_binary raises FileNotFoundError when Java is missing."""
+        import shutil
+        from unittest.mock import patch
+
+        linter = PmdLinter(project_root=Path("/nonexistent"))
+
+        with patch.object(shutil, "which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="Java is required"):
+                linter.ensure_binary()
+
+
+@java_available
+class TestPmdDownload:
+    """Integration tests for PMD binary download."""
+
+    @pytest.mark.slow
+    def test_download_pmd_binary(self) -> None:
+        """Test downloading and extracting PMD binary."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(project_root=Path(tmpdir))
+            binary = linter.ensure_binary()
+            assert binary.exists()
+            assert binary.name == "pmd"
+
+
+@pmd_available
+class TestPmdLinting:
+    """Integration tests for PMD linting checks."""
+
+    @pytest.mark.slow
+    def test_lint_java_file_with_issues(self) -> None:
+        """Test linting a Java file with known violations."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            # Create a Java file with a known PMD violation (empty catch block)
+            test_file = tmpdir_path / "Example.java"
+            test_file.write_text(
+                "public class Example {\n"
+                "    public void method() {\n"
+                "        try {\n"
+                "            int x = 1;\n"
+                "        } catch (Exception e) {\n"
+                "            // empty\n"
+                "        }\n"
+                "    }\n"
+                "}\n"
+            )
+
+            linter = PmdLinter(project_root=tmpdir_path)
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[tmpdir_path],
+                enabled_domains=[],
+            )
+
+            issues = linter.lint(context)
+            assert isinstance(issues, list)
+            for issue in issues:
+                assert issue.source_tool == "pmd"
+
+    @pytest.mark.slow
+    def test_lint_empty_directory(self) -> None:
+        """Test linting an empty directory returns no issues."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            linter = PmdLinter(project_root=tmpdir_path)
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[tmpdir_path],
+                enabled_domains=[],
+            )
+
+            issues = linter.lint(context)
+            assert isinstance(issues, list)
+            assert len(issues) == 0

--- a/tests/unit/plugins/linters/test_pmd.py
+++ b/tests/unit/plugins/linters/test_pmd.py
@@ -1,0 +1,1297 @@
+"""Unit tests for PMD linter plugin."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lucidshark.core.models import ScanContext, Severity, ToolDomain
+from lucidshark.plugins.linters.pmd import (
+    PRIORITY_SEVERITY_MAP,
+    PmdLinter,
+)
+
+
+def make_completed_process(
+    returncode: int, stdout: str, stderr: str = ""
+) -> subprocess.CompletedProcess:
+    """Create a CompletedProcess for testing."""
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+SAMPLE_PMD_OUTPUT = json.dumps(
+    {
+        "formatVersion": 0,
+        "pmdVersion": "7.22.0",
+        "files": [
+            {
+                "filename": "/project/src/Main.java",
+                "violations": [
+                    {
+                        "beginline": 5,
+                        "begincolumn": 1,
+                        "endline": 5,
+                        "endcolumn": 20,
+                        "rule": "UnusedLocalVariable",
+                        "ruleset": "Best Practices",
+                        "priority": 3,
+                        "description": "Avoid unused local variables such as 'x'.",
+                        "externalInfoUrl": "https://docs.pmd-code.org/pmd-doc-7.22.0/pmd_rules_java_bestpractices.html#unusedlocalvariable",
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+SAMPLE_PMD_MULTI_FILE = json.dumps(
+    {
+        "formatVersion": 0,
+        "pmdVersion": "7.22.0",
+        "files": [
+            {
+                "filename": "/project/src/A.java",
+                "violations": [
+                    {
+                        "beginline": 1,
+                        "begincolumn": 1,
+                        "endline": 1,
+                        "endcolumn": 10,
+                        "rule": "UnusedImports",
+                        "ruleset": "Best Practices",
+                        "priority": 4,
+                        "description": "Unused import",
+                        "externalInfoUrl": "https://example.com/unused-imports",
+                    }
+                ],
+            },
+            {
+                "filename": "/project/src/B.java",
+                "violations": [
+                    {
+                        "beginline": 10,
+                        "begincolumn": 5,
+                        "endline": 20,
+                        "endcolumn": 5,
+                        "rule": "GodClass",
+                        "ruleset": "Design",
+                        "priority": 2,
+                        "description": "Possible God Class",
+                        "externalInfoUrl": "https://example.com/god-class",
+                    },
+                    {
+                        "beginline": 50,
+                        "begincolumn": 1,
+                        "endline": 50,
+                        "endcolumn": 30,
+                        "rule": "EmptyCatchBlock",
+                        "ruleset": "Error Prone",
+                        "priority": 1,
+                        "description": "Avoid empty catch blocks",
+                        "externalInfoUrl": "https://example.com/empty-catch",
+                    },
+                ],
+            },
+        ],
+    }
+)
+
+
+class TestPmdLinterProperties:
+    """Tests for PmdLinter basic properties."""
+
+    def test_name(self) -> None:
+        linter = PmdLinter()
+        assert linter.name == "pmd"
+
+    def test_languages(self) -> None:
+        linter = PmdLinter()
+        assert linter.languages == ["java"]
+
+    def test_domain(self) -> None:
+        linter = PmdLinter()
+        assert linter.domain == ToolDomain.LINTING
+
+    def test_supports_fix(self) -> None:
+        linter = PmdLinter()
+        assert linter.supports_fix is False
+
+    def test_get_version(self) -> None:
+        linter = PmdLinter(version="7.22.0")
+        assert linter.get_version() == "7.22.0"
+
+    def test_init_with_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(project_root=Path(tmpdir))
+            assert linter._project_root == Path(tmpdir)
+
+    def test_init_default_version(self) -> None:
+        linter = PmdLinter()
+        # Should use DEFAULT_VERSION from get_tool_version("pmd")
+        assert linter._version is not None
+        assert isinstance(linter._version, str)
+
+
+class TestPmdSeverityMapping:
+    """Tests for PMD priority to severity mapping."""
+
+    def test_priority_1_maps_to_critical(self) -> None:
+        assert PRIORITY_SEVERITY_MAP[1] == Severity.CRITICAL
+
+    def test_priority_2_maps_to_high(self) -> None:
+        assert PRIORITY_SEVERITY_MAP[2] == Severity.HIGH
+
+    def test_priority_3_maps_to_medium(self) -> None:
+        assert PRIORITY_SEVERITY_MAP[3] == Severity.MEDIUM
+
+    def test_priority_4_maps_to_low(self) -> None:
+        assert PRIORITY_SEVERITY_MAP[4] == Severity.LOW
+
+    def test_priority_5_maps_to_info(self) -> None:
+        assert PRIORITY_SEVERITY_MAP[5] == Severity.INFO
+
+    def test_all_priorities_covered(self) -> None:
+        assert set(PRIORITY_SEVERITY_MAP.keys()) == {1, 2, 3, 4, 5}
+
+
+class TestPmdEnsureBinary:
+    """Tests for ensure_binary method."""
+
+    def test_cached_binary_found(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+
+            # Create fake cached binary
+            binary_dir = (
+                Path(tmpdir)
+                / ".lucidshark"
+                / "bin"
+                / "pmd"
+                / "7.22.0"
+                / "pmd-bin-7.22.0"
+                / "bin"
+            )
+            binary_dir.mkdir(parents=True)
+            binary_path = binary_dir / "pmd"
+            binary_path.touch()
+            binary_path.chmod(0o755)
+
+            result = linter.ensure_binary()
+            assert result == binary_path
+
+    def test_download_triggered_when_not_cached(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+
+            with patch("shutil.which", return_value="/usr/bin/java"):
+                with patch.object(linter, "_download_binary") as mock_download:
+                    # After download, create the binary
+                    def create_binary(dest_dir):
+                        binary_dir = dest_dir / "pmd-bin-7.22.0" / "bin"
+                        binary_dir.mkdir(parents=True)
+                        (binary_dir / "pmd").touch()
+
+                    mock_download.side_effect = create_binary
+
+                    result = linter.ensure_binary()
+                    mock_download.assert_called_once()
+                    assert result.name == "pmd"
+
+    def test_java_not_found_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+
+            with patch("shutil.which", return_value=None):
+                with pytest.raises(FileNotFoundError, match="Java is required"):
+                    linter.ensure_binary()
+
+    def test_download_fails_raises_runtime_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+
+            with patch("shutil.which", return_value="/usr/bin/java"):
+                with patch.object(linter, "_download_binary"):
+                    # Don't create the binary — simulate failed download
+                    with pytest.raises(RuntimeError, match="Failed to download"):
+                        linter.ensure_binary()
+
+
+class TestPmdDownloadBinary:
+    """Tests for _download_binary method."""
+
+    def test_download_and_extract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            dest_dir = Path(tmpdir) / "dest"
+
+            # Create a mock zip file in memory
+            import io
+            import zipfile
+
+            zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(zip_buffer, "w") as zf:
+                zf.writestr("pmd-bin-7.22.0/bin/pmd", "#!/bin/sh\necho pmd")
+                zf.writestr("pmd-bin-7.22.0/lib/pmd.jar", "fake jar")
+
+            zip_data = zip_buffer.getvalue()
+
+            mock_response = MagicMock()
+            mock_response.read.return_value = zip_data
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch(
+                "lucidshark.plugins.linters.pmd.secure_urlopen",
+                return_value=mock_response,
+            ):
+                linter._download_binary(dest_dir)
+
+            # Verify extraction
+            binary = dest_dir / "pmd-bin-7.22.0" / "bin" / "pmd"
+            assert binary.exists()
+            # Verify executable
+            import stat
+
+            assert binary.stat().st_mode & stat.S_IXUSR
+
+    def test_path_traversal_protection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            dest_dir = Path(tmpdir) / "dest"
+
+            # Create a malicious zip with path traversal
+            import io
+            import zipfile
+
+            zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(zip_buffer, "w") as zf:
+                zf.writestr("../../etc/passwd", "malicious content")
+
+            zip_data = zip_buffer.getvalue()
+
+            mock_response = MagicMock()
+            mock_response.read.return_value = zip_data
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch(
+                "lucidshark.plugins.linters.pmd.secure_urlopen",
+                return_value=mock_response,
+            ):
+                with pytest.raises(ValueError, match="Path traversal detected"):
+                    linter._download_binary(dest_dir)
+
+    def test_download_cleans_up_temp_on_network_error(self) -> None:
+        """Verify temp zip is cleaned up when secure_urlopen raises."""
+        from urllib.error import URLError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            dest_dir = Path(tmpdir) / "dest"
+
+            with patch(
+                "lucidshark.plugins.linters.pmd.secure_urlopen",
+                side_effect=URLError("connection refused"),
+            ):
+                with pytest.raises(URLError):
+                    linter._download_binary(dest_dir)
+
+            # The finally block in _download_binary should have cleaned up the temp file.
+            # We can't assert on specific temp files since we don't control the path,
+            # but the test verifies no exception was raised during cleanup.
+
+    def test_download_cleans_up_temp_on_corrupt_zip(self) -> None:
+        """Verify temp file is cleaned up when zip is corrupt."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            dest_dir = Path(tmpdir) / "dest"
+
+            mock_response = MagicMock()
+            mock_response.read.return_value = b"not a zip file at all"
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch(
+                "lucidshark.plugins.linters.pmd.secure_urlopen",
+                return_value=mock_response,
+            ):
+                with pytest.raises(Exception):
+                    linter._download_binary(dest_dir)
+
+    def test_download_missing_binary_in_zip(self) -> None:
+        """Verify no error when zip lacks expected bin/pmd path (caller handles it)."""
+        import io
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            dest_dir = Path(tmpdir) / "dest"
+
+            # Zip without the expected binary structure
+            zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(zip_buffer, "w") as zf:
+                zf.writestr("README.md", "just a readme")
+
+            mock_response = MagicMock()
+            mock_response.read.return_value = zip_buffer.getvalue()
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch(
+                "lucidshark.plugins.linters.pmd.secure_urlopen",
+                return_value=mock_response,
+            ):
+                # Should not raise — the caller (ensure_binary) checks for the path
+                linter._download_binary(dest_dir)
+
+            # Binary should not exist
+            binary = dest_dir / "pmd-bin-7.22.0" / "bin" / "pmd"
+            assert not binary.exists()
+
+
+class TestPmdFindRulesetConfig:
+    """Tests for _find_ruleset_config method."""
+
+    def test_finds_pmd_ruleset_xml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "pmd-ruleset.xml"
+            config_file.touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == str(config_file)
+
+    def test_finds_pmd_xml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "pmd.xml"
+            config_file.touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == str(config_file)
+
+    def test_finds_ruleset_xml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "ruleset.xml"
+            config_file.touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == str(config_file)
+
+    def test_finds_dot_pmd_rulesets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / ".pmd"
+            config_dir.mkdir()
+            config_file = config_dir / "rulesets.xml"
+            config_file.touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == str(config_file)
+
+    def test_finds_config_pmd_pmd_xml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "config" / "pmd"
+            config_dir.mkdir(parents=True)
+            config_file = config_dir / "pmd.xml"
+            config_file.touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == str(config_file)
+
+    def test_finds_config_pmd_ruleset_xml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "config" / "pmd"
+            config_dir.mkdir(parents=True)
+            config_file = config_dir / "ruleset.xml"
+            config_file.touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == str(config_file)
+
+    def test_defaults_to_quickstart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result == "rulesets/java/quickstart.xml"
+
+    def test_priority_ordering_with_multiple_configs(self) -> None:
+        """Verify pmd-ruleset.xml takes priority over pmd.xml."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "pmd-ruleset.xml").touch()
+            (Path(tmpdir) / "pmd.xml").touch()
+
+            linter = PmdLinter()
+            result = linter._find_ruleset_config(Path(tmpdir))
+            assert result.endswith("pmd-ruleset.xml")
+
+
+class TestPmdFindJavaFiles:
+    """Tests for _find_java_files method."""
+
+    def test_finds_java_files_in_context_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            java_file = src_dir / "Main.java"
+            java_file.touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert len(files) == 1
+            assert files[0].endswith("Main.java")
+
+    def test_finds_java_files_in_standard_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src" / "main" / "java"
+            src_dir.mkdir(parents=True)
+            java_file = src_dir / "App.java"
+            java_file.touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[],
+                enabled_domains=[],
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert len(files) >= 1
+            assert any("App.java" in f for f in files)
+
+    def test_no_java_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[],
+                enabled_domains=[],
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert files == []
+
+    def test_skips_nonexistent_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nonexistent = Path(tmpdir) / "nonexistent"
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[nonexistent],
+                enabled_domains=[],
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert files == []
+
+    def test_ignore_patterns_excludes_matching_files(self) -> None:
+        """Verify ignore_patterns filtering excludes matching files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+            build_dir = Path(tmpdir) / "build"
+            build_dir.mkdir()
+            (build_dir / "Generated.java").touch()
+
+            mock_patterns = MagicMock()
+            mock_patterns.matches = MagicMock(
+                side_effect=lambda f, root: "build" in str(f)
+            )
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir, build_dir],
+                enabled_domains=[],
+                ignore_patterns=mock_patterns,
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert len(files) == 1
+            assert files[0].endswith("Main.java")
+
+    def test_ignore_patterns_none_includes_all(self) -> None:
+        """Verify ignore_patterns=None includes all Java files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "A.java").touch()
+            (src_dir / "B.java").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+                ignore_patterns=None,
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert len(files) == 2
+
+    def test_fallback_to_project_root(self) -> None:
+        """Verify fallback to project_root when no paths and no standard dirs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[],
+                enabled_domains=[],
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert len(files) == 1
+            assert files[0].endswith("Main.java")
+
+    def test_excludes_non_java_files(self) -> None:
+        """Verify non-.java files are excluded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+            (src_dir / "Main.kt").touch()
+            (src_dir / "Main.py").touch()
+            (src_dir / "Main.class").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            linter = PmdLinter()
+            files = linter._find_java_files(context)
+            assert len(files) == 1
+            assert files[0].endswith("Main.java")
+
+
+class TestPmdLint:
+    """Tests for lint method."""
+
+    def test_lint_success(self) -> None:
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            src_dir = tmpdir_path / "src"
+            src_dir.mkdir()
+            java_file = src_dir / "Main.java"
+            java_file.touch()
+
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            mock_result = make_completed_process(0, SAMPLE_PMD_OUTPUT)
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    return_value=mock_result,
+                ):
+                    issues = linter.lint(context)
+
+                    assert len(issues) == 1
+                    assert issues[0].source_tool == "pmd"
+                    assert issues[0].domain == ToolDomain.LINTING
+                    assert issues[0].severity == Severity.MEDIUM
+                    assert issues[0].rule_id == "UnusedLocalVariable"
+                    assert issues[0].line_start == 5
+
+    def test_lint_uses_file_list_not_directory(self) -> None:
+        """Verify --file-list is used instead of -d to respect gitignore filtering."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            src_dir = tmpdir_path / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            mock_result = make_completed_process(0, '{"files": []}')
+            captured_cmd = []
+
+            def capture_cmd(**kwargs):
+                captured_cmd.extend(kwargs.get("cmd", []))
+                return mock_result
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=capture_cmd,
+                ):
+                    linter.lint(context)
+
+            assert "--file-list" in captured_cmd
+            assert "-d" not in captured_cmd
+            # Verify --file-list is followed by a path
+            idx = captured_cmd.index("--file-list")
+            file_list_path = captured_cmd[idx + 1]
+            assert file_list_path.endswith(".txt")
+
+    def test_lint_file_list_contains_correct_paths(self) -> None:
+        """Verify the temp file-list contains all discovered Java file paths."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            src_dir = tmpdir_path / "src"
+            src_dir.mkdir()
+            file_a = src_dir / "A.java"
+            file_b = src_dir / "B.java"
+            file_a.touch()
+            file_b.touch()
+
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            mock_result = make_completed_process(0, '{"files": []}')
+            captured_file_list_contents = []
+
+            def capture_file_list(**kwargs):
+                cmd = kwargs.get("cmd", [])
+                idx = cmd.index("--file-list")
+                file_list_path = Path(cmd[idx + 1])
+                captured_file_list_contents.append(file_list_path.read_text())
+                return mock_result
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=capture_file_list,
+                ):
+                    linter.lint(context)
+
+            assert len(captured_file_list_contents) == 1
+            contents = captured_file_list_contents[0]
+            file_lines = [line for line in contents.strip().split("\n") if line]
+            assert len(file_lines) == 2
+            assert any("A.java" in line for line in file_lines)
+            assert any("B.java" in line for line in file_lines)
+
+    def test_lint_file_list_cleaned_up_on_success(self) -> None:
+        """Verify temp file-list is deleted after successful lint."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            src_dir = tmpdir_path / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            mock_result = make_completed_process(0, '{"files": []}')
+            captured_paths = []
+
+            def capture_path(**kwargs):
+                cmd = kwargs.get("cmd", [])
+                idx = cmd.index("--file-list")
+                captured_paths.append(Path(cmd[idx + 1]))
+                return mock_result
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=capture_path,
+                ):
+                    linter.lint(context)
+
+            assert len(captured_paths) == 1
+            assert not captured_paths[0].exists(), "Temp file-list should be cleaned up"
+
+    def test_lint_file_list_cleaned_up_on_timeout(self) -> None:
+        """Verify temp file-list is deleted when run_with_streaming times out."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            created_files = []
+            original_named_temp = tempfile.NamedTemporaryFile
+
+            def tracking_temp(*args, **kwargs):
+                f = original_named_temp(*args, **kwargs)
+                created_files.append(Path(f.name))
+                return f
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=subprocess.TimeoutExpired("pmd", 120),
+                ):
+                    with patch(
+                        "lucidshark.plugins.linters.pmd.tempfile.NamedTemporaryFile",
+                        side_effect=tracking_temp,
+                    ):
+                        issues = linter.lint(context)
+
+            assert issues == []
+            for f in created_files:
+                assert not f.exists(), f"Temp file {f} should be cleaned up"
+
+    def test_lint_file_list_cleaned_up_on_unexpected_exception(self) -> None:
+        """Verify temp file-list is deleted when run_with_streaming raises unexpected error."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            created_files = []
+            original_named_temp = tempfile.NamedTemporaryFile
+
+            def tracking_temp(*args, **kwargs):
+                f = original_named_temp(*args, **kwargs)
+                created_files.append(Path(f.name))
+                return f
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=RuntimeError("unexpected crash"),
+                ):
+                    with patch(
+                        "lucidshark.plugins.linters.pmd.tempfile.NamedTemporaryFile",
+                        side_effect=tracking_temp,
+                    ):
+                        issues = linter.lint(context)
+
+            assert issues == []
+            for f in created_files:
+                assert not f.exists(), f"Temp file {f} should be cleaned up"
+
+    def test_lint_passes_correct_kwargs_to_runner(self) -> None:
+        """Verify correct cwd, tool_name, timeout passed to run_with_streaming."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            src_dir = tmpdir_path / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            mock_result = make_completed_process(0, '{"files": []}')
+            captured_kwargs = {}
+
+            def capture_kwargs(**kwargs):
+                captured_kwargs.update(kwargs)
+                return mock_result
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=capture_kwargs,
+                ):
+                    linter.lint(context)
+
+            assert captured_kwargs["cwd"] == tmpdir_path
+            assert captured_kwargs["tool_name"] == "pmd"
+            assert captured_kwargs["timeout"] == 120
+
+    def test_lint_no_binary(self) -> None:
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[Path(tmpdir)],
+                enabled_domains=[],
+            )
+
+            with patch.object(
+                linter,
+                "ensure_binary",
+                side_effect=FileNotFoundError("Java not found"),
+            ):
+                issues = linter.lint(context)
+                assert issues == []
+
+    def test_lint_runtime_error_from_ensure_binary(self) -> None:
+        """Verify RuntimeError from ensure_binary is caught and returns []."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[Path(tmpdir)],
+                enabled_domains=[],
+            )
+
+            with patch.object(
+                linter,
+                "ensure_binary",
+                side_effect=RuntimeError("Failed to download PMD"),
+            ):
+                issues = linter.lint(context)
+                assert issues == []
+
+    def test_lint_no_files(self) -> None:
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[Path(tmpdir)],
+                enabled_domains=[],
+            )
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                issues = linter.lint(context)
+                assert issues == []
+
+    def test_lint_timeout(self) -> None:
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=subprocess.TimeoutExpired("pmd", 120),
+                ):
+                    issues = linter.lint(context)
+                    assert issues == []
+
+    def test_lint_subprocess_error(self) -> None:
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    side_effect=OSError("command failed"),
+                ):
+                    issues = linter.lint(context)
+                    assert issues == []
+
+    def test_lint_nonzero_exit_code_with_valid_json(self) -> None:
+        """Verify issues are parsed even when PMD returns non-zero exit code."""
+        linter = PmdLinter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            src_dir = tmpdir_path / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.java").touch()
+
+            context = ScanContext(
+                project_root=tmpdir_path,
+                paths=[src_dir],
+                enabled_domains=[],
+            )
+
+            # PMD returns exit code 4 when violations are found
+            mock_result = make_completed_process(4, SAMPLE_PMD_OUTPUT)
+
+            with patch.object(
+                linter, "ensure_binary", return_value=Path("/opt/pmd/bin/pmd")
+            ):
+                with patch(
+                    "lucidshark.plugins.linters.pmd.run_with_streaming",
+                    return_value=mock_result,
+                ):
+                    issues = linter.lint(context)
+                    assert len(issues) == 1
+                    assert issues[0].rule_id == "UnusedLocalVariable"
+
+
+class TestPmdParseOutput:
+    """Tests for _parse_output method."""
+
+    def test_parse_empty_output(self) -> None:
+        linter = PmdLinter()
+        issues = linter._parse_output("", Path("/project"))
+        assert issues == []
+
+    def test_parse_invalid_json(self) -> None:
+        linter = PmdLinter()
+        issues = linter._parse_output("not json at all", Path("/project"))
+        assert issues == []
+
+    def test_parse_no_violations(self) -> None:
+        linter = PmdLinter()
+        output = json.dumps(
+            {
+                "formatVersion": 0,
+                "pmdVersion": "7.22.0",
+                "files": [{"filename": "/project/Main.java", "violations": []}],
+            }
+        )
+        issues = linter._parse_output(output, Path("/project"))
+        assert issues == []
+
+    def test_parse_single_violation(self) -> None:
+        linter = PmdLinter()
+        issues = linter._parse_output(SAMPLE_PMD_OUTPUT, Path("/project"))
+        assert len(issues) == 1
+        assert issues[0].rule_id == "UnusedLocalVariable"
+        assert issues[0].severity == Severity.MEDIUM
+        assert issues[0].line_start == 5
+
+    def test_parse_multiple_files_and_violations(self) -> None:
+        linter = PmdLinter()
+        issues = linter._parse_output(SAMPLE_PMD_MULTI_FILE, Path("/project"))
+        assert len(issues) == 3
+        assert issues[0].rule_id == "UnusedImports"
+        assert issues[0].severity == Severity.LOW
+        assert issues[1].rule_id == "GodClass"
+        assert issues[1].severity == Severity.HIGH
+        assert issues[2].rule_id == "EmptyCatchBlock"
+        assert issues[2].severity == Severity.CRITICAL
+
+    def test_parse_empty_files_list(self) -> None:
+        linter = PmdLinter()
+        output = json.dumps({"formatVersion": 0, "pmdVersion": "7.22.0", "files": []})
+        issues = linter._parse_output(output, Path("/project"))
+        assert issues == []
+
+    def test_parse_missing_files_key(self) -> None:
+        """Verify JSON without 'files' key returns empty list."""
+        linter = PmdLinter()
+        output = json.dumps({"formatVersion": 0, "pmdVersion": "7.22.0"})
+        issues = linter._parse_output(output, Path("/project"))
+        assert issues == []
+
+    def test_parse_file_without_violations_key(self) -> None:
+        """Verify file entry without 'violations' key is handled."""
+        linter = PmdLinter()
+        output = json.dumps({"files": [{"filename": "/project/Main.java"}]})
+        issues = linter._parse_output(output, Path("/project"))
+        assert issues == []
+
+    def test_parse_file_without_filename_key(self) -> None:
+        """Verify file entry without 'filename' key is handled."""
+        linter = PmdLinter()
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "violations": [
+                            {
+                                "rule": "X",
+                                "priority": 3,
+                                "description": "test",
+                                "beginline": 1,
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+        issues = linter._parse_output(output, Path("/project"))
+        assert len(issues) == 1
+
+    def test_parse_whitespace_only_output(self) -> None:
+        """Verify whitespace-only output returns empty list."""
+        linter = PmdLinter()
+        issues = linter._parse_output("   \n\t  ", Path("/project"))
+        assert issues == []
+
+    def test_parse_skips_bad_violations(self) -> None:
+        """Verify a bad violation is skipped while good ones are parsed."""
+        linter = PmdLinter()
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "filename": "/project/Main.java",
+                        "violations": [
+                            {
+                                "rule": "Good",
+                                "priority": 3,
+                                "description": "good issue",
+                                "beginline": 1,
+                            },
+                            {
+                                "rule": "Bad",
+                                "priority": 3,
+                                "description": "bad issue",
+                                "beginline": "not-a-number",
+                            },
+                        ],
+                    }
+                ]
+            }
+        )
+        issues = linter._parse_output(output, Path("/project"))
+        assert len(issues) == 1
+        assert issues[0].rule_id == "Good"
+
+
+class TestPmdViolationToIssue:
+    """Tests for _violation_to_issue method."""
+
+    def test_full_conversion(self) -> None:
+        linter = PmdLinter()
+        violation = {
+            "beginline": 15,
+            "begincolumn": 3,
+            "endline": 20,
+            "endcolumn": 10,
+            "rule": "UnusedLocalVariable",
+            "ruleset": "Best Practices",
+            "priority": 3,
+            "description": "Avoid unused local variables such as 'x'.",
+            "externalInfoUrl": "https://docs.pmd-code.org/unused",
+        }
+
+        issue = linter._violation_to_issue(
+            violation, "/project/Main.java", Path("/project")
+        )
+
+        assert issue is not None
+        assert issue.source_tool == "pmd"
+        assert issue.severity == Severity.MEDIUM
+        assert issue.rule_id == "UnusedLocalVariable"
+        assert issue.line_start == 15
+        assert issue.line_end == 20
+        assert issue.column_start == 3
+        assert "UnusedLocalVariable" in issue.title
+        assert issue.documentation_url == "https://docs.pmd-code.org/unused"
+        assert issue.metadata["ruleset"] == "Best Practices"
+        assert issue.metadata["priority"] == 3
+        assert issue.fixable is False
+
+    def test_missing_fields(self) -> None:
+        linter = PmdLinter()
+        violation = {
+            "description": "Some issue",
+            "priority": 3,
+        }
+
+        issue = linter._violation_to_issue(
+            violation, "/project/Main.java", Path("/project")
+        )
+
+        assert issue is not None
+        assert issue.rule_id == "unknown"
+        assert issue.line_start is None
+        assert issue.column_start is None
+        assert issue.documentation_url is None
+
+    def test_relative_path(self) -> None:
+        linter = PmdLinter()
+        violation = {
+            "beginline": 1,
+            "rule": "Test",
+            "priority": 3,
+            "description": "test",
+        }
+
+        issue = linter._violation_to_issue(violation, "src/Main.java", Path("/project"))
+
+        assert issue is not None
+        assert issue.file_path == Path("/project/src/Main.java")
+
+    def test_absolute_path(self) -> None:
+        linter = PmdLinter()
+        violation = {
+            "beginline": 1,
+            "rule": "Test",
+            "priority": 3,
+            "description": "test",
+        }
+
+        issue = linter._violation_to_issue(
+            violation, "/abs/path/Main.java", Path("/project")
+        )
+
+        assert issue is not None
+        assert issue.file_path == Path("/abs/path/Main.java")
+
+    def test_unknown_priority_defaults_to_medium(self) -> None:
+        linter = PmdLinter()
+        violation = {
+            "beginline": 1,
+            "rule": "Test",
+            "priority": 99,
+            "description": "test",
+        }
+
+        issue = linter._violation_to_issue(violation, "Main.java", Path("/project"))
+
+        assert issue is not None
+        assert issue.severity == Severity.MEDIUM
+
+    def test_empty_violation_dict(self) -> None:
+        """Verify empty violation dict produces an issue with defaults."""
+        linter = PmdLinter()
+        issue = linter._violation_to_issue({}, "/project/Main.java", Path("/project"))
+        assert issue is not None
+        assert issue.rule_id == "unknown"
+        assert issue.severity == Severity.MEDIUM
+        assert issue.line_start is None
+
+    def test_non_numeric_beginline_returns_none(self) -> None:
+        """Verify non-numeric beginline causes violation to be skipped."""
+        linter = PmdLinter()
+        violation = {
+            "beginline": "abc",
+            "rule": "Test",
+            "priority": 3,
+            "description": "test",
+        }
+        issue = linter._violation_to_issue(violation, "Main.java", Path("/project"))
+        assert issue is None
+
+    def test_string_priority_defaults_to_medium(self) -> None:
+        """Verify string priority (not int) falls back to MEDIUM."""
+        linter = PmdLinter()
+        violation = {
+            "beginline": 1,
+            "rule": "Test",
+            "priority": "3",
+            "description": "test",
+        }
+        issue = linter._violation_to_issue(violation, "Main.java", Path("/project"))
+        assert issue is not None
+        # String "3" does not match int key 3 in PRIORITY_SEVERITY_MAP
+        assert issue.severity == Severity.MEDIUM
+
+    def test_title_format_without_rule(self) -> None:
+        """Verify title is just description when rule is empty."""
+        linter = PmdLinter()
+        violation = {
+            "beginline": 1,
+            "rule": "",
+            "priority": 3,
+            "description": "Some message",
+        }
+        issue = linter._violation_to_issue(violation, "Main.java", Path("/project"))
+        assert issue is not None
+        assert issue.title == "Some message"
+        assert "[]" not in issue.title
+
+
+class TestPmdIssueIdGeneration:
+    """Tests for deterministic issue ID generation."""
+
+    def test_deterministic_ids(self) -> None:
+        linter = PmdLinter()
+        id1 = linter._generate_issue_id("Rule", "file.java", 10, 5, "msg")
+        id2 = linter._generate_issue_id("Rule", "file.java", 10, 5, "msg")
+        assert id1 == id2
+
+    def test_different_inputs_different_ids(self) -> None:
+        linter = PmdLinter()
+        id1 = linter._generate_issue_id("Rule1", "file.java", 10, 5, "msg")
+        id2 = linter._generate_issue_id("Rule2", "file.java", 10, 5, "msg")
+        assert id1 != id2
+
+    def test_id_format_with_rule(self) -> None:
+        linter = PmdLinter()
+        issue_id = linter._generate_issue_id(
+            "UnusedLocalVariable", "f.java", 1, 1, "msg"
+        )
+        assert issue_id.startswith("pmd-UnusedLocalVariable-")
+
+    def test_id_format_without_rule(self) -> None:
+        linter = PmdLinter()
+        issue_id = linter._generate_issue_id("", "f.java", 1, 1, "msg")
+        assert issue_id.startswith("pmd-")
+        assert "pmd--" not in issue_id
+
+    def test_id_handles_none_values(self) -> None:
+        linter = PmdLinter()
+        issue_id = linter._generate_issue_id("Rule", "file.java", None, None, "msg")
+        assert issue_id.startswith("pmd-Rule-")


### PR DESCRIPTION
## Summary

- **New PMD linter plugin** (`PmdLinter`) — auto-downloaded and cached like Trivy/OpenGrep, zero user setup required
- **Complements Checkstyle** — PMD covers bug detection, design issues, performance, and complexity (296 rules); Checkstyle covers style/formatting
- **Uses `--file-list`** for precise file targeting that respects gitignore filtering
- **76 unit tests + integration tests** with comprehensive coverage of download, parsing, edge cases, and temp file lifecycle
- **Documentation updated** across 13+ files: README, CHANGELOG, help, main spec, java.md, exclude-patterns, MCP tools, CLI arguments, etc.

## Changes

### New files
- `src/lucidshark/plugins/linters/pmd.py` — Main plugin: managed binary download/caching, JSON output parsing, severity mapping (priority 1-5 → CRITICAL/HIGH/MEDIUM/LOW/INFO)
- `tests/unit/plugins/linters/test_pmd.py` — 76 unit tests across 10 test classes
- `tests/integration/linters/test_pmd_integration.py` — Integration tests (skip if Java unavailable)

### Modified files
- `pyproject.toml` — Entry point + version pin (7.22.0)
- `src/lucidshark/bootstrap/versions.py` — Fallback version
- `src/lucidshark/core/domain_runner.py` — PLUGIN_LANGUAGES mapping
- `src/lucidshark/core/tool_validation.py` — AUTO_DOWNLOADABLE_TOOLS
- `src/lucidshark/detection/tools.py` — PMD config detection
- `tests/integration/conftest.py` — PMD fixtures and markers
- Plus docs and UI-facing text updates in 10 files

## Test plan

- [ ] `python -m pytest tests/unit/plugins/linters/test_pmd.py -v` — all 76 unit tests pass
- [ ] `python -m pytest tests/integration/linters/test_pmd_integration.py -v` — integration tests (requires Java)
- [ ] `lucidshark scan --linting` on a Java project — PMD runs alongside Checkstyle
- [ ] `lucidshark scan --linting --fix` — PMD issues reported (no auto-fix, as expected)
- [ ] Verify PMD binary auto-downloads on first use and is cached for subsequent runs