### PR TITLE
docs: add coverage configuration guidance to help and autoconfigure

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -2308,6 +2308,341 @@ pipeline:
     enabled: true
 ```
 
+### Configuring Test Runners to Produce Coverage Reports
+
+Coverage plugins **only parse existing data files** — they never run tests. Your test runner must be configured to produce coverage output in the format and location that the corresponding coverage plugin expects. LucidShark's built-in test runners handle this automatically for most languages, but if you use custom test commands or have non-default output paths, you must ensure the coverage data lands in the right place.
+
+#### Python (coverage_py)
+
+**Expected file:** `.coverage` (binary SQLite file at project root)
+
+LucidShark's pytest runner automatically wraps pytest with `coverage run -m pytest`, which produces the `.coverage` file. If you use a custom test command, you must ensure coverage data is generated:
+
+```yaml
+# Option A: Use the built-in pytest runner (recommended, automatic coverage)
+pipeline:
+  testing:
+    enabled: true
+    tools: [pytest]
+  coverage:
+    enabled: true
+    tools: [coverage_py]
+```
+
+If using a custom command, ensure it generates the `.coverage` file:
+
+```yaml
+# Option B: Custom test command that produces .coverage
+pipeline:
+  testing:
+    enabled: true
+    command: "coverage run -m pytest tests/"
+  coverage:
+    enabled: true
+    tools: [coverage_py]
+```
+
+**Test runner configuration (pyproject.toml):**
+
+```toml
+[tool.coverage.run]
+source = ["src"]          # IMPORTANT: Set this to your source directory
+omit = ["tests/*", "*/migrations/*"]
+
+[tool.coverage.report]
+fail_under = 80
+```
+
+Or via `.coveragerc`:
+
+```ini
+[run]
+source = src
+omit =
+    tests/*
+    */migrations/*
+```
+
+**Common pitfall:** If `source` is not configured in `.coveragerc` or `pyproject.toml`, coverage.py may measure coverage of test files and third-party packages instead of your source code. LucidShark auto-detects `src/` or the package directory, but explicit configuration is more reliable.
+
+#### JavaScript/TypeScript with Jest (istanbul)
+
+**Expected files:** `coverage/coverage-summary.json` or `coverage/coverage-final.json` (at project root)
+
+LucidShark's Jest runner automatically adds `--coverage`, which generates Istanbul-format reports in the `coverage/` directory.
+
+```yaml
+# Option A: Use the built-in Jest runner (recommended, automatic coverage)
+pipeline:
+  testing:
+    enabled: true
+    tools: [jest]
+  coverage:
+    enabled: true
+    tools: [istanbul]
+```
+
+**Jest configuration (jest.config.js or package.json):**
+
+```js
+// jest.config.js
+module.exports = {
+  coverageDirectory: "coverage",              // DEFAULT — must match what istanbul plugin expects
+  coverageReporters: ["json-summary", "text"], // REQUIRED: json-summary for LucidShark
+  collectCoverageFrom: [
+    "src/**/*.{js,ts,jsx,tsx}",
+    "!src/**/*.d.ts",
+    "!src/**/index.{js,ts}",
+  ],
+};
+```
+
+Or in `package.json`:
+
+```json
+{
+  "jest": {
+    "coverageDirectory": "coverage",
+    "coverageReporters": ["json-summary", "text"],
+    "collectCoverageFrom": ["src/**/*.{js,ts,jsx,tsx}"]
+  }
+}
+```
+
+**Common pitfall:** If `coverageDirectory` is set to a custom path (e.g., `reports/coverage/`), the istanbul plugin will not find the report. Either use the default `coverage/` directory, or use a custom test command that outputs to the expected location.
+
+**Fallback:** If no `coverage/` directory is found, the istanbul plugin falls back to `.nyc_output/` and runs `nyc report` to generate a summary. This requires `nyc` to be installed.
+
+#### JavaScript/TypeScript with Vitest (vitest_coverage)
+
+**Expected files:** `coverage/coverage-summary.json` or `coverage/coverage-final.json` (at project root)
+
+LucidShark's Vitest runner automatically adds `--coverage --coverage.reporter=json-summary`.
+
+```yaml
+# Option A: Use the built-in Vitest runner (recommended, automatic coverage)
+pipeline:
+  testing:
+    enabled: true
+    tools: [vitest]
+  coverage:
+    enabled: true
+    tools: [vitest_coverage]
+```
+
+**Vitest configuration (vitest.config.ts):**
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',                         // or 'istanbul'
+      reporter: ['json-summary', 'text'],      // REQUIRED: json-summary for LucidShark
+      reportsDirectory: './coverage',          // DEFAULT — must match what plugin expects
+      include: ['src/**/*.{js,ts,jsx,tsx}'],
+    },
+  },
+});
+```
+
+**Common pitfall:** You must install a coverage provider: `npm install @vitest/coverage-v8 --save-dev` (or `@vitest/coverage-istanbul`). Without it, `--coverage` silently produces no output.
+
+#### Java with Maven (jacoco)
+
+**Expected files (Maven):** `target/site/jacoco/jacoco.xml`, `target/jacoco.xml`, or `jacoco/jacoco.xml`
+**Expected files (Gradle):** `build/reports/jacoco/test/jacocoTestReport.xml`
+
+LucidShark's Maven runner automatically runs `mvn test jacoco:report` (or `gradle test jacocoTestReport`).
+
+```yaml
+# Option A: Use the built-in Maven runner (recommended)
+pipeline:
+  testing:
+    enabled: true
+    tools: [maven]
+  coverage:
+    enabled: true
+    tools: [jacoco]
+```
+
+**Maven configuration (pom.xml) — JaCoCo plugin must be present:**
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>0.8.12</version>
+      <executions>
+        <execution>
+          <goals><goal>prepare-agent</goal></goals>
+        </execution>
+        <execution>
+          <id>report</id>
+          <phase>test</phase>
+          <goals><goal>report</goal></goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+**Gradle configuration (build.gradle):**
+
+```groovy
+plugins {
+    id 'jacoco'
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true   // REQUIRED: LucidShark reads XML reports
+        html.required = true  // Optional: for human viewing
+    }
+}
+
+test {
+    finalizedBy jacocoTestReport  // Auto-generate report after tests
+}
+```
+
+**Common pitfall:** If the JaCoCo plugin is not configured in `pom.xml`/`build.gradle`, `mvn test` runs tests but produces no coverage data. The plugin must be declared in the build configuration.
+
+#### Go (go_cover)
+
+**Expected file:** `coverage.out` (at project root)
+
+LucidShark's go_test runner automatically adds `-coverprofile=coverage.out` when the coverage domain is enabled.
+
+```yaml
+# Option A: Use the built-in go_test runner (recommended, automatic coverage)
+pipeline:
+  testing:
+    enabled: true
+    tools: [go_test]
+  coverage:
+    enabled: true
+    tools: [go_cover]
+```
+
+If using a custom command:
+
+```yaml
+# Option B: Custom command — must write coverage.out at project root
+pipeline:
+  testing:
+    enabled: true
+    command: "go test -coverprofile=coverage.out ./..."
+  coverage:
+    enabled: true
+    tools: [go_cover]
+```
+
+**Common pitfall:** The `-coverprofile` flag must write to `coverage.out` at the project root. If your tests write to a different path (e.g., `build/coverage.out`), the go_cover plugin will not find it.
+
+#### Rust (tarpaulin)
+
+**Expected file:** `target/tarpaulin/tarpaulin-report.json`
+
+Tarpaulin is special: it both runs tests AND produces coverage data. LucidShark's cargo runner automatically uses `cargo tarpaulin` instead of `cargo test` when the coverage domain is enabled.
+
+```yaml
+# Option A: Use the built-in cargo runner (recommended, automatic coverage)
+pipeline:
+  testing:
+    enabled: true
+    tools: [cargo]
+  coverage:
+    enabled: true
+    tools: [tarpaulin]
+```
+
+If using a custom command:
+
+```yaml
+# Option B: Custom command — must write report to target/tarpaulin/
+pipeline:
+  testing:
+    enabled: true
+    command: "cargo tarpaulin --out json --output-dir target/tarpaulin"
+  coverage:
+    enabled: true
+    tools: [tarpaulin]
+```
+
+**Prerequisite:** Install tarpaulin: `cargo install cargo-tarpaulin`
+
+#### C (gcov)
+
+**Expected files:** `coverage.info` or `lcov.info` (at project root or build directory)
+
+```yaml
+pipeline:
+  testing:
+    enabled: true
+    tools: [ctest]
+  coverage:
+    enabled: true
+    tools: [gcov]
+```
+
+**CMake configuration for coverage:**
+
+```cmake
+# Add coverage flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+
+# Add a coverage target
+add_custom_target(coverage
+    COMMAND lcov --capture --directory . --output-file coverage.info
+    COMMAND lcov --remove coverage.info '/usr/*' --output-file coverage.info
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+```
+
+If using a custom command:
+
+```yaml
+pipeline:
+  testing:
+    enabled: true
+    command: "cmake --build build && ctest --test-dir build --output-on-failure"
+    post_command: "lcov --capture --directory build --output-file coverage.info && lcov --remove coverage.info '/usr/*' --output-file coverage.info"
+  coverage:
+    enabled: true
+    tools: [gcov]
+```
+
+### Coverage File Path Summary
+
+Each coverage plugin looks for files at specific paths relative to the project root. If your test runner writes coverage data to a non-default location, coverage analysis will fail with a `no_coverage_data` error.
+
+| Plugin | Expected Path(s) | Produced By |
+|--------|-------------------|-------------|
+| **coverage_py** | `.coverage` | `coverage run -m pytest` |
+| **istanbul** | `coverage/coverage-summary.json`, `coverage/coverage-final.json`, or `.nyc_output/` | `jest --coverage` or `nyc` |
+| **vitest_coverage** | `coverage/coverage-summary.json` or `coverage/coverage-final.json` | `vitest run --coverage` |
+| **jacoco** (Maven) | `target/site/jacoco/jacoco.xml`, `target/jacoco.xml` | `mvn test jacoco:report` |
+| **jacoco** (Gradle) | `build/reports/jacoco/test/jacocoTestReport.xml` | `gradle test jacocoTestReport` |
+| **tarpaulin** | `target/tarpaulin/tarpaulin-report.json` | `cargo tarpaulin --out json` |
+| **go_cover** | `coverage.out` | `go test -coverprofile=coverage.out` |
+| **gcov** | `coverage.info` or `lcov.info` (root or build dir) | `lcov --capture` after compile with `--coverage` |
+
+### Troubleshooting: "No coverage data found"
+
+If you see a `no_coverage_data` error:
+
+1. **Check that testing is enabled** — coverage requires the testing domain to run first
+2. **Verify the coverage file exists** — after running tests, check that the expected file (see table above) exists at the project root
+3. **Check your test runner configuration** — ensure it's configured to produce coverage output (see per-language sections above)
+4. **Check the output path** — if your test runner uses a custom output directory, it must match what the coverage plugin expects
+5. **Check reporter format** — for JS/TS, ensure `json-summary` is in the reporters list; for Java, ensure XML reports are enabled
+
 ### CLI Usage
 
 When running scans from the command line:

--- a/src/lucidshark/mcp/tools.py
+++ b/src/lucidshark/mcp/tools.py
@@ -765,6 +765,7 @@ class MCPToolExecutor:
                         ".coveragerc",
                         "jest.config.js",
                         "jest.config.ts",
+                        "vitest.config.ts",
                         "karma.conf.js",
                         "playwright.config.ts",
                         ".nycrc",
@@ -788,6 +789,174 @@ class MCPToolExecutor:
                         "MUST also enable testing in the generated config. The scan will fail if "
                         "coverage is enabled without testing."
                     ),
+                    "coverage_file_paths": (
+                        "CRITICAL: Coverage plugins look for data files at SPECIFIC paths relative to the "
+                        "project root. If the test runner writes coverage data to a non-default location, "
+                        "coverage analysis will fail with 'no_coverage_data'. Verify that the test runner "
+                        "configuration produces files at the expected locations:\n"
+                        "  - Python (coverage_py): .coverage (at project root)\n"
+                        "  - JS/TS Jest (istanbul): coverage/coverage-summary.json or coverage/coverage-final.json\n"
+                        "  - JS/TS Vitest (vitest_coverage): coverage/coverage-summary.json\n"
+                        "  - Java Maven (jacoco): target/site/jacoco/jacoco.xml\n"
+                        "  - Java Gradle (jacoco): build/reports/jacoco/test/jacocoTestReport.xml\n"
+                        "  - Rust (tarpaulin): target/tarpaulin/tarpaulin-report.json\n"
+                        "  - Go (go_cover): coverage.out (at project root)\n"
+                        "  - C (gcov): coverage.info or lcov.info (at project root or build dir)"
+                    ),
+                    "test_runner_coverage_setup": {
+                        "description": (
+                            "Each test runner must be configured to produce coverage data in the correct "
+                            "format. LucidShark's built-in test runners handle this automatically, but you "
+                            "must verify that any existing project-level configuration doesn't override the "
+                            "expected output paths."
+                        ),
+                        "python": {
+                            "auto_behavior": (
+                                "LucidShark's pytest runner wraps with 'coverage run -m pytest' automatically. "
+                                "If coverage binary is not found, pytest runs without coverage."
+                            ),
+                            "verify_config": (
+                                "Check pyproject.toml for [tool.coverage.run] source setting, or .coveragerc. "
+                                "If source is not set, LucidShark auto-detects src/ or the package directory. "
+                                "Explicit source config is recommended for reliable results."
+                            ),
+                            "example_pyproject_toml": (
+                                "[tool.coverage.run]\n"
+                                "source = [\"src\"]\n"
+                                "omit = [\"tests/*\", \"*/migrations/*\"]\n"
+                            ),
+                            "required_packages": "pip install coverage pytest-cov",
+                        },
+                        "javascript_jest": {
+                            "auto_behavior": (
+                                "LucidShark's Jest runner adds --coverage automatically, producing Istanbul "
+                                "reports in coverage/ directory."
+                            ),
+                            "verify_config": (
+                                "Check jest.config.js or package.json 'jest' section. "
+                                "CRITICAL: coverageDirectory must be 'coverage' (the default). "
+                                "CRITICAL: coverageReporters must include 'json-summary'. "
+                                "If coverageDirectory is set to a custom path, istanbul plugin won't find it."
+                            ),
+                            "example_jest_config": (
+                                "// jest.config.js\n"
+                                "module.exports = {\n"
+                                "  coverageDirectory: 'coverage',\n"
+                                "  coverageReporters: ['json-summary', 'text'],\n"
+                                "  collectCoverageFrom: ['src/**/*.{js,ts,jsx,tsx}', '!src/**/*.d.ts'],\n"
+                                "};"
+                            ),
+                        },
+                        "javascript_vitest": {
+                            "auto_behavior": (
+                                "LucidShark's Vitest runner adds --coverage --coverage.reporter=json-summary."
+                            ),
+                            "verify_config": (
+                                "Check vitest.config.ts coverage section. "
+                                "CRITICAL: reportsDirectory must be './coverage' (the default). "
+                                "CRITICAL: A coverage provider must be installed: "
+                                "@vitest/coverage-v8 or @vitest/coverage-istanbul."
+                            ),
+                            "example_vitest_config": (
+                                "// vitest.config.ts\n"
+                                "export default defineConfig({\n"
+                                "  test: {\n"
+                                "    coverage: {\n"
+                                "      provider: 'v8',\n"
+                                "      reporter: ['json-summary', 'text'],\n"
+                                "      reportsDirectory: './coverage',\n"
+                                "      include: ['src/**/*.{js,ts,jsx,tsx}'],\n"
+                                "    },\n"
+                                "  },\n"
+                                "});"
+                            ),
+                            "required_packages": "npm install @vitest/coverage-v8 --save-dev",
+                        },
+                        "java_maven": {
+                            "auto_behavior": (
+                                "LucidShark's Maven runner runs 'mvn test jacoco:report'. "
+                                "The JaCoCo Maven plugin MUST be configured in pom.xml."
+                            ),
+                            "verify_config": (
+                                "Check pom.xml for jacoco-maven-plugin. If not present, coverage will NOT "
+                                "be generated even though tests run. The plugin must declare both "
+                                "prepare-agent and report goals."
+                            ),
+                            "example_pom_xml": (
+                                "<plugin>\n"
+                                "  <groupId>org.jacoco</groupId>\n"
+                                "  <artifactId>jacoco-maven-plugin</artifactId>\n"
+                                "  <version>0.8.12</version>\n"
+                                "  <executions>\n"
+                                "    <execution><goals><goal>prepare-agent</goal></goals></execution>\n"
+                                "    <execution>\n"
+                                "      <id>report</id><phase>test</phase>\n"
+                                "      <goals><goal>report</goal></goals>\n"
+                                "    </execution>\n"
+                                "  </executions>\n"
+                                "</plugin>"
+                            ),
+                        },
+                        "java_gradle": {
+                            "auto_behavior": (
+                                "LucidShark's Gradle runner runs 'gradle test jacocoTestReport'."
+                            ),
+                            "verify_config": (
+                                "Check build.gradle for jacoco plugin and jacocoTestReport task. "
+                                "XML reports must be enabled (xml.required = true)."
+                            ),
+                            "example_build_gradle": (
+                                "plugins { id 'jacoco' }\n\n"
+                                "jacocoTestReport {\n"
+                                "  reports {\n"
+                                "    xml.required = true  // REQUIRED for LucidShark\n"
+                                "  }\n"
+                                "}\n\n"
+                                "test { finalizedBy jacocoTestReport }"
+                            ),
+                        },
+                        "go": {
+                            "auto_behavior": (
+                                "LucidShark's go_test runner adds -coverprofile=coverage.out when coverage "
+                                "domain is enabled. The file is written to the project root."
+                            ),
+                            "verify_config": (
+                                "If using a custom test command, ensure it includes "
+                                "-coverprofile=coverage.out and outputs to the project root."
+                            ),
+                        },
+                        "rust": {
+                            "auto_behavior": (
+                                "LucidShark's cargo runner uses 'cargo tarpaulin --out json --output-dir "
+                                "target/tarpaulin' when coverage domain is enabled. This replaces cargo test."
+                            ),
+                            "verify_config": (
+                                "Tarpaulin must be installed: cargo install cargo-tarpaulin. "
+                                "If using a custom command, ensure it writes to target/tarpaulin/tarpaulin-report.json."
+                            ),
+                        },
+                        "c": {
+                            "auto_behavior": (
+                                "LucidShark's ctest runner runs CTest. Coverage requires compiling with "
+                                "--coverage flag and generating lcov info files separately."
+                            ),
+                            "verify_config": (
+                                "Check CMakeLists.txt for --coverage flags. "
+                                "A post_command may be needed to run lcov --capture after tests."
+                            ),
+                            "example_config": (
+                                "pipeline:\n"
+                                "  testing:\n"
+                                "    enabled: true\n"
+                                "    tools: [ctest]\n"
+                                "    post_command: \"lcov --capture --directory build --output-file coverage.info "
+                                "&& lcov --remove coverage.info '/usr/*' --output-file coverage.info\"\n"
+                                "  coverage:\n"
+                                "    enabled: true\n"
+                                "    tools: [gcov]"
+                            ),
+                        },
+                    },
                 },
                 {
                     "step": 4,
@@ -1220,7 +1389,13 @@ class MCPToolExecutor:
                 "always_use_defaults": {
                     "security": "Always enable security scanning (trivy + opengrep). Fail on 'high' severity.",
                     "testing": "Enable if tests detected. Always fail on test failures. MUST be enabled if coverage is enabled.",
-                    "coverage": "Enable if coverage tool detected. REQUIRES testing to be enabled (testing produces coverage files).",
+                    "coverage": (
+                        "Enable if coverage tool detected. REQUIRES testing to be enabled (testing produces coverage files). "
+                        "IMPORTANT: Verify the test runner is configured to produce coverage data in the expected format and path. "
+                        "Check the 'test_runner_coverage_setup' guidance in step 3 for per-language details. "
+                        "Common issues: missing JaCoCo plugin in pom.xml, missing @vitest/coverage-v8 package, "
+                        "custom coverageDirectory in jest.config.js, missing [tool.coverage.run] source in pyproject.toml."
+                    ),
                     "linting": "Enable with detected tool. Use strictness setting for fail_on.",
                     "type_checking": "Enable if tool detected. Use strictness setting for fail_on.",
                     "duplication": "Always enable duplication detection (duplo). Threshold 5%, min_lines 7.",
@@ -1240,6 +1415,21 @@ class MCPToolExecutor:
                 "For legacy codebases: start with fail_on: none, fix issues gradually",
                 "Check current coverage with 'pytest --cov' before setting threshold",
                 "For Java with integration tests: use extra_args to skip tests requiring Docker",
+                (
+                    "COVERAGE: Verify the test runner is configured to produce coverage data. "
+                    "Coverage plugins only PARSE files — they never run tests. Common failures: "
+                    "(1) Python: coverage package not installed, so pytest runs without coverage instrumentation. "
+                    "(2) JS/TS Jest: coverageDirectory in jest.config.js set to non-default path — must be 'coverage'. "
+                    "(3) JS/TS Vitest: @vitest/coverage-v8 not installed — --coverage silently produces nothing. "
+                    "(4) Java: JaCoCo plugin not declared in pom.xml/build.gradle — tests run but no report generated. "
+                    "(5) Go: custom test script missing -coverprofile=coverage.out flag. "
+                    "(6) Rust: cargo-tarpaulin not installed."
+                ),
+                (
+                    "COVERAGE PATHS: Each coverage plugin expects data at a specific path relative to project root. "
+                    "If the test runner uses a non-default output directory, coverage analysis will fail with "
+                    "'no_coverage_data'. Check the 'coverage_file_paths' section in step 3 for expected paths."
+                ),
             ],
             "common_exclusions": {
                 "description": (


### PR DESCRIPTION
## Summary
- Add per-language coverage configuration examples to `docs/help.md` — concrete config snippets for Python, JS/TS (Jest + Vitest), Java (Maven + Gradle), Go, Rust, and C showing how to configure test runners to produce coverage data
- Add coverage file path summary table and "No coverage data found" troubleshooting checklist
- Enhance autoconfigure (`tools.py`) with `test_runner_coverage_setup` per-language guidance, `coverage_file_paths` reference, and coverage-specific common pitfalls

## Test plan
- [x] Python syntax check passes on `tools.py`
- [x] All 17 content checks pass on `help.md` (section headers, config keywords, tool names)
- [ ] Run `lucidshark autoconfigure` on a sample project and verify the new guidance appears in step 3
- [ ] Run `lucidshark get_help` and verify the new sections render correctly