### PR TITLE
docs: add missing tools for all 14 languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ By default, LucidShark scans only uncommitted changes (staged, unstaged, untrack
 
 See [Incremental Scanning](docs/incremental-scanning.md) for threshold scopes, CI integration, and advanced usage.
 
-**Note:** LucidShark runs in **strict mode** by default  -  all configured tools must run successfully. If a tool is missing, not applicable, or fails to execute, the scan fails with a HIGH severity issue and fix suggestions. Security tools (trivy, opengrep, gosec, checkov), duplo, PMD, Checkstyle, and SpotBugs are downloaded automatically.
+**Note:** LucidShark runs in **strict mode** by default  -  all configured tools must run successfully. If a tool is missing, not applicable, or fails to execute, the scan fails with a HIGH severity issue and fix suggestions. Security tools (trivy, opengrep, gosec, checkov), duplo, PMD, Checkstyle, SpotBugs, ktlint, and detekt are downloaded automatically.
 
 ### Example Output
 
@@ -138,13 +138,11 @@ Restart your AI tool after running `init` to activate.
 
 ## Supported Languages
 
-LucidShark supports 15 programming languages with varying levels of tool coverage:
+LucidShark supports 14 programming languages with full tool coverage:
 
-| Tier | Languages | What's Included |
-|------|-----------|-----------------|
-| **Full** | Python, TypeScript, JavaScript, Java, Rust, Go, C#, C, C++, Scala, Swift, Ruby | Linting, type checking, formatting, testing, coverage, security, duplication |
-| **Partial** | Kotlin | Testing, coverage, security (via shared Java tooling) |
-| **Minimal** | PHP | Security scanning |
+| Languages | What's Included |
+|-----------|-----------------|
+| Python, TypeScript, JavaScript, Java, Kotlin, Rust, Go, C#, C, C++, Scala, Swift, Ruby, PHP | Linting, type checking, formatting, testing, coverage, security, duplication |
 
 For detailed per-language tool coverage, configuration examples, and detection info, see the [Language Reference](docs/languages/README.md).
 
@@ -152,15 +150,15 @@ For detailed per-language tool coverage, configuration examples, and detection i
 
 | Domain | Tools | What It Catches |
 |--------|-------|-----------------|
-| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD, golangci-lint, dotnet format, clang-tidy, Scalafix, SwiftLint, RuboCop | Style issues, code smells, bug detection |
-| **Formatting** | Ruff Format, Prettier, rustfmt, gofmt, dotnet format, clang-format, Scalafmt, SwiftFormat, RuboCop Format | Code formatting, whitespace style |
-| **Type Checking** | mypy, Pyright, TypeScript (tsc), SpotBugs (managed), cargo check, go vet, dotnet build, cppcheck, scalac, Swift compiler, Sorbet | Type errors, static analysis bugs |
+| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD, ktlint, golangci-lint, dotnet format, clang-tidy, Scalafix, SwiftLint, RuboCop, phpcs | Style issues, code smells, bug detection |
+| **Formatting** | Ruff Format, Prettier, ktlint, rustfmt, gofmt, dotnet format, clang-format, Scalafmt, SwiftFormat, RuboCop Format, PHP-CS-Fixer | Code formatting, whitespace style |
+| **Type Checking** | mypy, Pyright, TypeScript (tsc), SpotBugs (managed), detekt, cargo check, go vet, dotnet build, cppcheck, scalac, Swift compiler, Sorbet, PHPStan | Type errors, static analysis bugs |
 | **Security (SAST)** | OpenGrep, gosec (Go) | Code vulnerabilities |
 | **Security (SCA)** | Trivy | Dependency vulnerabilities |
 | **Security (IaC)** | Checkov | Infrastructure misconfigurations |
 | **Security (Container)** | Trivy | Container image vulnerabilities |
-| **Testing** | pytest, Jest, Vitest, Mocha, Karma (Angular), Playwright (E2E), Maven/Gradle (JUnit), cargo test, go test, dotnet test, CTest, sbt test, swift test, RSpec | Test failures |
-| **Coverage** | coverage.py, Istanbul, Vitest, JaCoCo, Tarpaulin, go cover, dotnet coverage, gcov/lcov, Scoverage, llvm-cov, SimpleCov | Coverage gaps |
+| **Testing** | pytest, Jest, Vitest, Mocha, Karma (Angular), Playwright (E2E), Maven/Gradle (JUnit), cargo test, go test, dotnet test, CTest, sbt test, swift test, RSpec, PHPUnit | Test failures |
+| **Coverage** | coverage.py, Istanbul, Vitest, JaCoCo, Tarpaulin, go cover, dotnet coverage, gcov/lcov, Scoverage, llvm-cov, SimpleCov, PHPUnit Clover | Coverage gaps |
 | **Duplication** | Duplo | Code clones, duplicate blocks |
 
 All results are normalized to a common format.

--- a/docs/help.md
+++ b/docs/help.md
@@ -112,15 +112,15 @@ Run the quality/security pipeline. By default, scans only changed files (uncommi
 
 | Flag | Domain | Description |
 |------|--------|-------------|
-| `--linting` | linting | Code style and linting (Ruff, ESLint, Biome, Clippy, Checkstyle, PMD, golangci-lint) |
-| `--type-checking` | type_checking | Static type analysis (mypy, pyright, TypeScript, SpotBugs, cargo check, go vet) |
-| `--formatting` | formatting | Code formatting (Ruff Format, Prettier, rustfmt, gofmt) |
+| `--linting` | linting | Code style and linting (Ruff, ESLint, Biome, Clippy, Checkstyle, PMD, ktlint, golangci-lint, dotnet format, clang-tidy, Scalafix, SwiftLint, RuboCop, phpcs) |
+| `--type-checking` | type_checking | Static type analysis (mypy, pyright, TypeScript, SpotBugs, detekt, cargo check, go vet, dotnet build, cppcheck, scalac, Swift compiler, Sorbet, PHPStan) |
+| `--formatting` | formatting | Code formatting (Ruff Format, Prettier, ktlint, rustfmt, gofmt, dotnet format, clang-format, Scalafmt, SwiftFormat, RuboCop Format, PHP-CS-Fixer) |
 | `--sca` | sca | Dependency vulnerability scanning (Trivy) |
 | `--sast` | sast | Code security patterns (OpenGrep, gosec for Go) |
 | `--iac` | iac | Infrastructure-as-Code scanning (Checkov) |
 | `--container` | container | Container image scanning (Trivy) |
-| `--testing` | testing | Run test suite (pytest, Jest, Vitest, Mocha, Karma, Playwright, Maven, cargo test, go test) |
-| `--coverage` | coverage | Coverage analysis (coverage.py, Istanbul, Vitest, JaCoCo, Tarpaulin, go cover). **Requires `--testing`** |
+| `--testing` | testing | Run test suite (pytest, Jest, Vitest, Mocha, Karma, Playwright, Maven, cargo test, go test, dotnet test, CTest, sbt test, swift test, RSpec, PHPUnit) |
+| `--coverage` | coverage | Coverage analysis (coverage.py, Istanbul, Vitest, JaCoCo, Tarpaulin, go cover, dotnet coverage, gcov/lcov, Scoverage, llvm-cov, SimpleCov, PHPUnit Clover). **Requires `--testing`** |
 | `--duplication` | duplication | Code duplication detection (Duplo) |
 | `--all` | all | Enable all domains |
 
@@ -578,13 +578,13 @@ Run quality checks on the codebase or specific files. Supports partial scanning 
 
 | Domain | Partial Scan Support | Behavior |
 |--------|---------------------|----------|
-| `linting` | ⚠️ Partial support | Ruff/ESLint/Biome/golangci-lint support file args; Clippy is workspace-wide |
-| `type_checking` | ⚠️ Partial support | mypy/pyright support file args; tsc/SpotBugs/cargo check/go vet scan full project |
-| `formatting` | ⚠️ Partial support | Ruff Format/Prettier/gofmt support file args; rustfmt takes individual files only |
+| `linting` | ⚠️ Partial support | Ruff/ESLint/Biome/golangci-lint/ktlint/dotnet format/clang-tidy/Scalafix/SwiftLint/RuboCop/phpcs support file args; Clippy is workspace-wide |
+| `type_checking` | ⚠️ Partial support | mypy/pyright/cppcheck/Sorbet/PHPStan support file args; tsc/SpotBugs/detekt/cargo check/go vet/dotnet build/scala compile/swift compiler scan full project |
+| `formatting` | ⚠️ Partial support | Ruff Format/Prettier/ktlint/gofmt/dotnet format/clang-format/Scalafmt/SwiftFormat/RuboCop Format/PHP-CS-Fixer support file args; rustfmt project-wide |
 | `sast` | ✅ Full support | OpenGrep and gosec scan only specified/changed files |
 | `sca` | ❌ Project-wide only | Trivy dependency scan is inherently project-wide |
 | `iac` | ❌ Project-wide only | Checkov scans entire project |
-| `testing` | ⚠️ Partial support | pytest/Jest/Vitest/Mocha/Playwright support file args; Karma/Maven/cargo test/go test are project-wide |
+| `testing` | ⚠️ Partial support | pytest/Jest/Vitest/Mocha/Playwright/RSpec/PHPUnit support file args; Karma/Maven/cargo test/go test/dotnet test/CTest/sbt/swift test are project-wide |
 | `coverage` | ⚠️ Parse data, filter output | Coverage reads existing data files; output can be filtered to changed files; Tarpaulin/JaCoCo/go cover always project-wide |
 | `duplication` | ❌ Project-wide only | Duplo scans entire project to detect cross-file duplicates |
 
@@ -1127,14 +1127,28 @@ LucidShark validates that all configured tools are installed before running scan
 - ✅ `golangci_lint` - Go linter (manual install: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`)
 - ✅ `checkstyle` - Java linter (auto-downloaded)
 - ✅ `pmd` - Java linter (auto-downloaded)
+- ✅ `ktlint` - Kotlin linter (auto-downloaded)
+- ✅ `dotnet_format` - C# linter (included with .NET SDK)
+- ✅ `clang_tidy` - C/C++ linter (manual install: `brew install llvm` or `apt install clang-tidy`)
+- ✅ `scalafix` - Scala linter (manual install: `cs install scalafix`)
+- ✅ `swiftlint` - Swift linter (manual install: `brew install swiftlint`)
+- ✅ `rubocop` - Ruby linter (manual install: `gem install rubocop`)
+- ✅ `phpcs` - PHP linter (manual install: `composer require --dev squizlabs/php_codesniffer`)
 
 **TYPE_CHECKING (lucidshark.type_checkers):**
 - ✅ `mypy` - Python type checker (manual install: `pip install mypy`)
 - ✅ `pyright` - Python type checker (manual install: `pip install pyright`)
 - ✅ `typescript` - TypeScript type checker (manual install: `npm install -g typescript`)
 - ✅ `spotbugs` - Java type checker (auto-downloaded)
+- ✅ `detekt` - Kotlin static analyzer (auto-downloaded)
 - ✅ `cargo_check` - Rust type checker (included with rustup)
 - ✅ `go_vet` - Go type checker (included with Go toolchain)
+- ✅ `dotnet_build` - C# type checker (included with .NET SDK)
+- ✅ `cppcheck` - C/C++ static analyzer (manual install: `brew install cppcheck` or `apt install cppcheck`)
+- ✅ `scala_compile` - Scala type checker (via sbt/mvn/gradle)
+- ✅ `swift_compiler` - Swift type checker (included with Xcode / swift.org toolchain)
+- ✅ `sorbet` - Ruby type checker (manual install: `gem install sorbet`)
+- ✅ `phpstan` - PHP type checker (manual install: `composer require --dev phpstan/phpstan`)
 
 **TESTING (lucidshark.test_runners):**
 - ✅ `pytest` - Python test runner (manual install: `pip install pytest`)
@@ -1143,23 +1157,43 @@ LucidShark validates that all configured tools are installed before running scan
 - ✅ `mocha` - JavaScript/TypeScript test runner (manual install: `npm install mocha`)
 - ✅ `karma` - JavaScript/TypeScript test runner (manual install: `npm install karma`)
 - ✅ `playwright` - JavaScript/TypeScript E2E test runner (manual install: `npm install @playwright/test`)
-- ✅ `maven` - Java test runner (manual install: `brew install maven` or download)
+- ✅ `maven` - Java/Kotlin test runner (manual install: `brew install maven` or download)
 - ✅ `cargo` - Rust test runner (included with rustup)
 - ✅ `go_test` - Go test runner (included with Go toolchain)
+- ✅ `dotnet_test` - C# test runner (included with .NET SDK)
+- ✅ `ctest` - C/C++ test runner (included with CMake)
+- ✅ `sbt` - Scala test runner (manual install: `cs install sbt`)
+- ✅ `swift_test` - Swift test runner (included with Xcode / swift.org toolchain)
+- ✅ `rspec` - Ruby test runner (manual install: `gem install rspec`)
+- ✅ `phpunit` - PHP test runner (manual install: `composer require --dev phpunit/phpunit`)
 
 **COVERAGE (lucidshark.coverage):**
 - ✅ `coverage_py` - Python coverage (manual install: `pip install coverage pytest-cov`)
 - ✅ `istanbul` - JavaScript/TypeScript coverage (manual install: `npm install nyc`)
 - ✅ `vitest_coverage` - JavaScript/TypeScript coverage (manual install: `npm install @vitest/coverage-v8`)
-- ✅ `jacoco` - Java coverage (Maven/Gradle plugin in pom.xml/build.gradle)
+- ✅ `jacoco` - Java/Kotlin coverage (Maven/Gradle plugin in pom.xml/build.gradle)
 - ✅ `tarpaulin` - Rust coverage (manual install: `cargo install cargo-tarpaulin`)
 - ✅ `go_cover` - Go coverage (included with Go toolchain)
+- ✅ `dotnet_coverage` - C# coverage (included with .NET SDK)
+- ✅ `gcov` - C coverage (included with GCC)
+- ✅ `lcov` - C++ coverage (manual install: `brew install lcov` or `apt install lcov`)
+- ✅ `scoverage` - Scala coverage (sbt/Maven plugin)
+- ✅ `swift_coverage` - Swift coverage (included with Xcode / swift.org toolchain)
+- ✅ `simplecov` - Ruby coverage (manual install: `gem install simplecov`)
+- ✅ `phpunit_coverage` - PHP coverage (via PHPUnit with Xdebug/PCOV)
 
 **FORMATTING (lucidshark.formatters):**
 - ✅ `ruff_format` - Python formatter (manual install: `pip install ruff`)
 - ✅ `prettier` - JavaScript/TypeScript formatter (manual install: `npm install -g prettier`)
 - ✅ `rustfmt` - Rust formatter (manual install: `rustup component add rustfmt`)
 - ✅ `gofmt` - Go formatter (included with Go toolchain)
+- ✅ `ktlint_format` - Kotlin formatter (auto-downloaded)
+- ✅ `dotnet_format_whitespace` - C# formatter (included with .NET SDK)
+- ✅ `clang_format` - C/C++ formatter (manual install: `brew install clang-format` or `apt install clang-format`)
+- ✅ `scalafmt` - Scala formatter (manual install: `cs install scalafmt`)
+- ✅ `swiftformat` - Swift formatter (manual install: `brew install swiftformat`)
+- ✅ `rubocop_format` - Ruby formatter (manual install: `gem install rubocop`)
+- ✅ `php_cs_fixer` - PHP formatter (manual install: `composer require --dev friendsofphp/php-cs-fixer`)
 
 **SECURITY SCANNERS (lucidshark.scanners):**
 - ✅ `trivy` - SCA/Container scanner (auto-downloaded)
@@ -1184,6 +1218,8 @@ The following tools are **automatically downloaded** by LucidShark:
 | `pmd` | Linting (Java) | Bug detection, design issues, complexity analysis |
 | `checkstyle` | Linting (Java) | Style checking with Google or custom checks |
 | `spotbugs` | Type Checking (Java) | Static analysis for bugs in compiled Java bytecode |
+| `ktlint` | Linting/Formatting (Kotlin) | Kotlin linter and formatter |
+| `detekt` | Type Checking (Kotlin) | Static analysis for code smells and complexity |
 
 #### Manually Installed Tools
 
@@ -1198,6 +1234,12 @@ All other tools must be installed manually before use. If you configure a tool t
 | `biome` | JavaScript, TypeScript | `npm install -g @biomejs/biome` |
 | `clippy` | Rust | `rustup component add clippy` |
 | `golangci_lint` | Go | `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest` |
+| `dotnet_format` | C# | Included with .NET SDK |
+| `clang_tidy` | C, C++ | `brew install llvm` (macOS) or `apt install clang-tidy` |
+| `scalafix` | Scala | `cs install scalafix` |
+| `swiftlint` | Swift | `brew install swiftlint` |
+| `rubocop` | Ruby | `gem install rubocop` |
+| `phpcs` | PHP | `composer require --dev squizlabs/php_codesniffer` |
 
 **Type Checkers:**
 
@@ -1208,6 +1250,12 @@ All other tools must be installed manually before use. If you configure a tool t
 | `typescript` | TypeScript | `npm install -g typescript` |
 | `cargo_check` | Rust | Included with Rust toolchain (`rustup`) |
 | `go_vet` | Go | Included with Go toolchain |
+| `dotnet_build` | C# | Included with .NET SDK |
+| `cppcheck` | C, C++ | `brew install cppcheck` (macOS) or `apt install cppcheck` |
+| `scala_compile` | Scala | Via sbt / Maven / Gradle |
+| `swift_compiler` | Swift | Included with Xcode / swift.org toolchain |
+| `sorbet` | Ruby | `gem install sorbet` |
+| `phpstan` | PHP | `composer require --dev phpstan/phpstan` |
 
 **Test Runners:**
 
@@ -1219,9 +1267,15 @@ All other tools must be installed manually before use. If you configure a tool t
 | `mocha` | JavaScript, TypeScript | `npm install mocha` |
 | `karma` | JavaScript, TypeScript | `npm install karma` |
 | `playwright` | JavaScript, TypeScript | `npm install @playwright/test` |
-| `maven` | Java | `brew install maven` (macOS) or download from maven.apache.org |
+| `maven` | Java, Kotlin | `brew install maven` (macOS) or download from maven.apache.org |
 | `cargo` | Rust | Included with Rust toolchain (`rustup`) |
 | `go_test` | Go | Included with Go toolchain |
+| `dotnet_test` | C# | Included with .NET SDK |
+| `ctest` | C, C++ | Included with CMake |
+| `sbt` | Scala | `cs install sbt` |
+| `swift_test` | Swift | Included with Xcode / swift.org toolchain |
+| `rspec` | Ruby | `gem install rspec` |
+| `phpunit` | PHP | `composer require --dev phpunit/phpunit` |
 
 **Coverage Tools:**
 
@@ -1230,9 +1284,16 @@ All other tools must be installed manually before use. If you configure a tool t
 | `coverage_py` | Python | `pip install coverage pytest-cov` |
 | `istanbul` | JavaScript, TypeScript | `npm install nyc` |
 | `vitest_coverage` | JavaScript, TypeScript | `npm install @vitest/coverage-v8` or `@vitest/coverage-istanbul` |
-| `jacoco` | Java | Maven/Gradle plugin (configured in pom.xml/build.gradle) |
+| `jacoco` | Java, Kotlin | Maven/Gradle plugin (configured in pom.xml/build.gradle) |
 | `tarpaulin` | Rust | `cargo install cargo-tarpaulin` |
 | `go_cover` | Go | Included with Go toolchain |
+| `dotnet_coverage` | C# | Included with .NET SDK |
+| `gcov` | C | Included with GCC |
+| `lcov` | C++ | `brew install lcov` (macOS) or `apt install lcov` |
+| `scoverage` | Scala | sbt/Maven plugin |
+| `swift_coverage` | Swift | Included with Xcode / swift.org toolchain |
+| `simplecov` | Ruby | `gem install simplecov` |
+| `phpunit_coverage` | PHP | Via PHPUnit with Xdebug or PCOV |
 
 **Formatters:**
 
@@ -1242,6 +1303,12 @@ All other tools must be installed manually before use. If you configure a tool t
 | `prettier` | JavaScript, TypeScript | `npm install -g prettier` |
 | `rustfmt` | Rust | `rustup component add rustfmt` |
 | `gofmt` | Go | Included with Go toolchain |
+| `dotnet_format_whitespace` | C# | Included with .NET SDK |
+| `clang_format` | C, C++ | `brew install clang-format` (macOS) or `apt install clang-format` |
+| `scalafmt` | Scala | `cs install scalafmt` |
+| `swiftformat` | Swift | `brew install swiftformat` |
+| `rubocop_format` | Ruby | `gem install rubocop` (same as rubocop linter) |
+| `php_cs_fixer` | PHP | `composer require --dev friendsofphp/php-cs-fixer` |
 
 #### Validation Behavior
 
@@ -2141,8 +2208,15 @@ For detailed per-language tool coverage, detection, and configuration examples, 
 | Biome | JavaScript, TypeScript, JSON | ✅ Yes |
 | Checkstyle | Java | ✅ Yes |
 | PMD | Java | ✅ Yes |
+| ktlint | Kotlin | ✅ Yes |
 | Clippy | Rust | ❌ No (Cargo workspace) |
 | golangci-lint | Go | ✅ Yes |
+| dotnet format | C# | ✅ Yes |
+| clang-tidy | C, C++ | ✅ Yes |
+| Scalafix | Scala | ✅ Yes |
+| SwiftLint | Swift | ✅ Yes |
+| RuboCop | Ruby | ✅ Yes |
+| phpcs | PHP | ✅ Yes |
 
 All linting tools support the `files` parameter for partial scanning, except Clippy which operates on the full Cargo workspace.
 
@@ -2154,10 +2228,17 @@ All linting tools support the `files` parameter for partial scanning, except Cli
 | pyright | Python | ✅ Yes |
 | TypeScript (tsc) | TypeScript | ❌ No (project-wide only) |
 | SpotBugs (managed) | Java | ❌ No (requires compiled classes) |
+| detekt (managed) | Kotlin | ❌ No (project-wide) |
 | cargo check | Rust | ❌ No (Cargo workspace) |
 | go vet | Go | ❌ No (package-wide) |
+| dotnet build | C# | ❌ No (project-wide) |
+| cppcheck | C, C++ | ✅ Yes |
+| scala compile | Scala | ❌ No (project-wide) |
+| Swift compiler | Swift | ❌ No (project-wide) |
+| Sorbet | Ruby | ✅ Yes |
+| PHPStan | PHP | ✅ Yes |
 
-**Note:** TypeScript (tsc) does not support file-level scanning - it always analyzes the full project based on `tsconfig.json`. SpotBugs requires compiled Java classes (run `mvn compile` or `gradle build` first). cargo check operates on the full Cargo workspace. go vet operates on Go packages.
+**Note:** TypeScript (tsc) does not support file-level scanning - it always analyzes the full project based on `tsconfig.json`. SpotBugs requires compiled Java classes (run `mvn compile` or `gradle build` first). cargo check operates on the full Cargo workspace. go vet operates on Go packages. dotnet build, detekt, scala compile, and Swift compiler operate on full projects/packages.
 
 ### Security Scanning
 
@@ -2177,13 +2258,20 @@ All linting tools support the `files` parameter for partial scanning, except Cli
 | pytest | Python | ✅ Yes |
 | Jest | JavaScript, TypeScript | ✅ Yes |
 | Vitest | JavaScript, TypeScript | ✅ Yes |
+| Mocha | JavaScript, TypeScript | ✅ Yes |
 | Karma | JavaScript, TypeScript (Angular) | ❌ No (config-based) |
 | Playwright | JavaScript, TypeScript (E2E) | ✅ Yes |
-| Maven | Java (JUnit/TestNG) | ❌ No (project-wide) |
+| Maven | Java, Kotlin (JUnit/TestNG) | ❌ No (project-wide) |
 | cargo test | Rust | ❌ No (Cargo workspace) |
 | go test | Go | ⚠️ Partial (package-level) |
+| dotnet test | C# | ❌ No (project-wide) |
+| CTest | C, C++ | ❌ No (project-wide) |
+| sbt test | Scala | ❌ No (project-wide) |
+| swift test | Swift | ❌ No (project-wide) |
+| RSpec | Ruby | ✅ Yes |
+| PHPUnit | PHP | ✅ Yes |
 
-**Note:** Most test runners (pytest, jest, vitest, maven, go test) include coverage instrumentation automatically. Others (cargo test, karma, playwright) do not  -  their coverage is handled by separate tools (tarpaulin) or project config (karma). While test runners support running specific test files, it's recommended to run the full test suite before commits to catch regressions.
+**Note:** Most test runners (pytest, jest, vitest, mocha, maven, go test, dotnet test, swift test) include coverage instrumentation automatically. Others (cargo test, karma, playwright) do not  -  their coverage is handled by separate tools (tarpaulin) or project config (karma). While test runners support running specific test files, it's recommended to run the full test suite before commits to catch regressions.
 
 ### Coverage
 
@@ -2192,9 +2280,16 @@ All linting tools support the `files` parameter for partial scanning, except Cli
 | coverage.py | Python | ⚠️ Partial (filter output) |
 | Istanbul/nyc | JavaScript, TypeScript | ⚠️ Partial (filter output) |
 | Vitest coverage | JavaScript, TypeScript | ⚠️ Partial (filter output) |
-| JaCoCo | Java | ❌ No (project-wide) |
+| JaCoCo | Java, Kotlin | ❌ No (project-wide) |
 | Tarpaulin | Rust | ❌ No (Cargo workspace) |
 | go cover | Go | ❌ No (project-wide) |
+| dotnet coverage | C# | ❌ No (project-wide) |
+| gcov | C | ❌ No (project-wide) |
+| lcov | C++ | ❌ No (project-wide) |
+| Scoverage | Scala | ❌ No (project-wide) |
+| swift coverage (llvm-cov) | Swift | ❌ No (project-wide) |
+| SimpleCov | Ruby | ⚠️ Partial (filter output) |
+| PHPUnit Clover | PHP | ⚠️ Partial (filter output) |
 
 **Note:** Coverage plugins only parse existing coverage data files  -  they never run tests. The testing domain produces coverage files, and the coverage domain reads them. If no coverage data is found, coverage returns a `no_coverage_data` error. Coverage output can be filtered to show only changed files.
 
@@ -2212,7 +2307,7 @@ pipeline:
 
 | Tool | Languages | Partial Scan |
 |------|-----------|--------------|
-| Duplo | Python, Rust, Java, JavaScript, TypeScript, C, C++, C#, Go, Ruby, Erlang, VB, HTML, CSS | ❌ No (project-wide) |
+| Duplo | Python, Rust, Java, Kotlin, JavaScript, TypeScript, C, C++, C#, Go, Scala, Swift, Ruby, PHP, Erlang, VB, HTML, CSS | ❌ No (project-wide) |
 
 **Note:** Duplication detection always scans the entire project to find cross-file duplicates. This means missing exclusions in either the global `exclude` list or the domain-specific `exclude` will cause it to scan build artifacts, caches, vendored code, and generated files  -  producing noisy false positives. Always ensure comprehensive exclusions are in place. Examine your project's directory structure and exclude any directories that contain non-source-code files.
 

--- a/docs/languages/README.md
+++ b/docs/languages/README.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-LucidShark supports 15 programming languages with varying levels of tool coverage. Languages with full support have dedicated tools across most quality domains. All detected languages benefit from security scanning and many from duplication detection.
+LucidShark supports 14 programming languages with varying levels of tool coverage. Languages with full support have dedicated tools across most quality domains. All detected languages benefit from security scanning and many from duplication detection.
 
 ## Support Tiers
 

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -186,5 +186,5 @@ pipeline:
 ## See Also
 
 - [Java](java.md) -- related JVM language with full support
-- [Kotlin](kotlin.md) -- related JVM language with partial support
+- [Kotlin](kotlin.md) -- related JVM language with full support
 - [Supported Languages Overview](README.md)

--- a/docs/main.md
+++ b/docs/main.md
@@ -89,12 +89,12 @@ A single configuration file controls:
 
 | Domain | Tools | What It Catches |
 |--------|-------|-----------------|
-| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD, golangci-lint | Style, code smells, bug detection |
-| **Formatting** | Ruff Format, Prettier, rustfmt, gofmt | Code formatting, whitespace style |
-| **Type Checking** | mypy, TypeScript, Pyright, SpotBugs (managed), cargo check, go vet | Type errors, static analysis bugs |
+| **Linting** | Ruff, ESLint, Biome, Clippy, Checkstyle, PMD, ktlint, golangci-lint, dotnet format, clang-tidy, Scalafix, SwiftLint, RuboCop, phpcs | Style, code smells, bug detection |
+| **Formatting** | Ruff Format, Prettier, ktlint, rustfmt, gofmt, dotnet format, clang-format, Scalafmt, SwiftFormat, RuboCop Format, PHP-CS-Fixer | Code formatting, whitespace style |
+| **Type Checking** | mypy, TypeScript, Pyright, SpotBugs, detekt, cargo check, go vet, dotnet build, cppcheck, scalac, Swift compiler, Sorbet, PHPStan | Type errors, static analysis bugs |
 | **Security** | Trivy, OpenGrep, gosec (Go), Checkov | Vulnerabilities, misconfigurations |
-| **Testing** | pytest, Jest, Vitest, Mocha, Maven/Gradle, cargo test, go test | Test failures |
-| **Coverage** | coverage.py, Istanbul, Vitest, JaCoCo, Tarpaulin, go cover | Coverage gaps |
+| **Testing** | pytest, Jest, Vitest, Mocha, Karma, Playwright, Maven/Gradle, cargo test, go test, dotnet test, CTest, sbt test, swift test, RSpec, PHPUnit | Test failures |
+| **Coverage** | coverage.py, Istanbul, Vitest, JaCoCo, Tarpaulin, go cover, dotnet coverage, gcov/lcov, Scoverage, llvm-cov, SimpleCov, PHPUnit Clover | Coverage gaps |
 | **Duplication** | Duplo | Code clones, duplicate blocks |
 
 All results normalized to a common schema. One exit code for automation.
@@ -363,14 +363,14 @@ LucidShark scans only changed files (uncommitted changes) by default. Use `--all
 
 | Domain | Partial Scan Support | Behavior |
 |--------|---------------------|----------|
-| **Linting** | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle/PMD support file args; Clippy is workspace-wide; golangci-lint runs workspace-wide (`./...`) |
-| **Formatting** | ⚠️ Partial | Ruff Format/Prettier support file args; rustfmt project-wide; gofmt supports file args |
-| **Type Checking** | ⚠️ Partial | mypy/pyright yes; tsc/SpotBugs/cargo check always full; go vet runs package-wide (`./...`) |
+| **Linting** | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle/PMD/ktlint/dotnet format/clang-tidy/Scalafix/SwiftLint/RuboCop/phpcs support file args; Clippy is workspace-wide; golangci-lint runs workspace-wide (`./...`) |
+| **Formatting** | ⚠️ Partial | Ruff Format/Prettier/ktlint/gofmt/dotnet format/clang-format/Scalafmt/SwiftFormat/RuboCop Format/PHP-CS-Fixer support file args; rustfmt project-wide |
+| **Type Checking** | ⚠️ Partial | mypy/pyright yes; tsc/SpotBugs/detekt/cargo check/dotnet build/scala compile/swift compiler always full; go vet runs package-wide (`./...`); cppcheck/Sorbet/PHPStan support file args |
 | **SAST** | ✅ Full | OpenGrep and gosec scan only changed/specified files |
 | **SCA** | ❌ None | Trivy dependency scan always project-wide |
 | **IaC** | ❌ None | Checkov always project-wide |
-| **Testing** | ⚠️ Partial | pytest/Jest/Vitest/Mocha/Playwright yes; Karma/Maven/cargo test project-wide; go test runs package-wide (`./...`) |
-| **Coverage** | ⚠️ Partial | Parses existing data, filter output; Tarpaulin/JaCoCo always project-wide; go cover parses project-wide coverprofile |
+| **Testing** | ⚠️ Partial | pytest/Jest/Vitest/Mocha/Playwright/RSpec/PHPUnit yes; Karma/Maven/cargo test/dotnet test/CTest/sbt/swift test project-wide; go test runs package-wide (`./...`) |
+| **Coverage** | ⚠️ Partial | Parses existing data, filter output; Tarpaulin/JaCoCo/dotnet coverage/Scoverage/swift coverage always project-wide; go cover parses project-wide coverprofile |
 
 **Default workflow (partial scans):**
 - After modifying files - scans changed files automatically
@@ -912,20 +912,40 @@ Binaries are cached in `{project_root}/.lucidshark/` by default. The `LUCIDSHARK
 ├─────────────────────────────────────────────────────────────────┤
 │  Tool Plugins                                                   │
 │  ├── Linting:     RuffLinter, ESLintLinter, BiomeLinter,        │
-│  │                ClippyLinter                                  │
+│  │                ClippyLinter, CheckstyleLinter, PmdLinter,    │
+│  │                KtlintLinter, GoLangCILintLinter,             │
+│  │                DotnetFormatLinter, ClangTidyLinter,          │
+│  │                ScalafixLinter, SwiftLintLinter,              │
+│  │                RubocopLinter, PhpcsLinter                    │
 │  ├── TypeCheck:   MypyChecker, PyrightChecker,                  │
 │  │                TypeScriptChecker, SpotBugsChecker,           │
-│  │                CargoCheckChecker                             │
+│  │                DetektChecker, CargoCheckChecker,              │
+│  │                GoVetChecker, DotnetBuildChecker,              │
+│  │                CppcheckChecker, ScalaCompileChecker,          │
+│  │                SwiftCompilerChecker, SorbetChecker,           │
+│  │                PhpstanChecker                                │
 │  ├── Security:    TrivyScanner, OpenGrepScanner,                │
-│  │                CheckovScanner                                │
+│  │                CheckovScanner, GosecScanner                  │
 │  ├── Testing:     PytestRunner, JestRunner, VitestRunner,       │
-│  │                MavenTestRunner, KarmaRunner,                 │
-│  │                PlaywrightRunner, CargoTestRunner              │
+│  │                MochaRunner, KarmaRunner, PlaywrightRunner,   │
+│  │                MavenTestRunner, CargoTestRunner,              │
+│  │                GoTestRunner, DotnetTestRunner,               │
+│  │                CTestRunner, SbtTestRunner,                   │
+│  │                SwiftTestRunner, RspecRunner,                  │
+│  │                PhpunitRunner                                 │
 │  ├── Coverage:    CoveragePyPlugin, IstanbulPlugin,             │
 │  │                VitestCoveragePlugin, JaCoCoPlugin,            │
-│  │                TarpaulinPlugin                               │
+│  │                TarpaulinPlugin, GoCoverPlugin,               │
+│  │                DotnetCoveragePlugin, GcovPlugin,             │
+│  │                LcovPlugin, ScoveragePlugin,                  │
+│  │                SwiftCoveragePlugin, SimpleCovPlugin,          │
+│  │                PhpunitCoveragePlugin                         │
 │  ├── Formatting:  RuffFormatter, PrettierFormatter,             │
-│  │                RustfmtFormatter                              │
+│  │                RustfmtFormatter, GofmtFormatter,             │
+│  │                KtlintFormatter, DotnetFormatFormatter,       │
+│  │                ClangFormatFormatter, ScalafmtFormatter,      │
+│  │                SwiftFormatFormatter, RubocopFormatter,       │
+│  │                PhpCsFixerFormatter                           │
 │  ├── Duplication: DuploPlugin                                   │
 │  └── Enrichers:   (post-processing pipeline)                    │
 ├─────────────────────────────────────────────────────────────────┤
@@ -1195,14 +1215,14 @@ The MCP server sends progress notifications during scans, reporting domain start
 
 | Domain | Partial Scan | Notes |
 |--------|--------------|-------|
-| Linting | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle/PMD support file-level; Clippy is workspace-wide; golangci-lint runs workspace-wide (`./...`) |
-| Formatting | ⚠️ Partial | Ruff Format/Prettier support file-level; rustfmt project-wide; gofmt supports file args |
-| Type Checking | ⚠️ Partial | mypy/pyright yes; tsc/SpotBugs/cargo check no; go vet runs package-wide (`./...`) |
+| Linting | ⚠️ Partial | Ruff/ESLint/Biome/Checkstyle/PMD/ktlint/dotnet format/clang-tidy/Scalafix/SwiftLint/RuboCop/phpcs support file-level; Clippy is workspace-wide; golangci-lint runs workspace-wide (`./...`) |
+| Formatting | ⚠️ Partial | Ruff Format/Prettier/ktlint/gofmt/dotnet format/clang-format/Scalafmt/SwiftFormat/RuboCop Format/PHP-CS-Fixer support file-level; rustfmt project-wide |
+| Type Checking | ⚠️ Partial | mypy/pyright/cppcheck/Sorbet/PHPStan yes; tsc/SpotBugs/detekt/cargo check/dotnet build/scala compile/swift compiler no; go vet runs package-wide (`./...`) |
 | SAST | ✅ Yes | OpenGrep supports file-level scanning |
 | SCA | ❌ No | Trivy dependency scan always project-wide |
 | IaC | ❌ No | Checkov always project-wide |
-| Testing | ⚠️ Partial | pytest/Jest/Vitest/Mocha/Playwright yes; Karma/Maven/cargo test no; go test runs package-wide (`./...`) |
-| Coverage | ⚠️ Partial | Parses existing data, filter output; Tarpaulin/JaCoCo always project-wide; go cover parses project-wide coverprofile |
+| Testing | ⚠️ Partial | pytest/Jest/Vitest/Mocha/Playwright/RSpec/PHPUnit yes; Karma/Maven/cargo test/dotnet test/CTest/sbt/swift test no; go test runs package-wide (`./...`) |
+| Coverage | ⚠️ Partial | Parses existing data, filter output; Tarpaulin/JaCoCo/dotnet coverage/Scoverage/swift coverage always project-wide; go cover parses project-wide coverprofile |
 | Duplication | ❌ No | Duplo always scans project-wide for cross-file duplicates |
 
 ### 6.5 Unified Issue Schema
@@ -1418,23 +1438,22 @@ LucidShark scans only changed files by default, enabling fast feedback loops:
 
 | Tool Category | Tools | Partial Scan Support |
 |---------------|-------|---------------------|
-| **Linting** | Ruff, ESLint, Biome, Checkstyle, PMD | ✅ All support file args |
+| **Linting** | Ruff, ESLint, Biome, Checkstyle, PMD, ktlint, dotnet format, clang-tidy, Scalafix, SwiftLint, RuboCop, phpcs | ✅ All support file args |
 | **Linting** | Clippy | ❌ Cargo workspace only |
 | **Linting** | golangci-lint | ✅ Yes (via file/package args) |
-| **Formatting** | Ruff Format, Prettier | ✅ Support file args |
+| **Formatting** | Ruff Format, Prettier, ktlint, gofmt, dotnet format, clang-format, Scalafmt, SwiftFormat, RuboCop Format, PHP-CS-Fixer | ✅ Support file args |
 | **Formatting** | rustfmt | ❌ Project-wide only |
-| **Formatting** | gofmt | ✅ Yes (explicit file list) |
-| **Type Checking** | mypy, pyright | ✅ Support file args |
-| **Type Checking** | TypeScript (tsc), SpotBugs (managed), cargo check | ❌ Project-wide only |
+| **Type Checking** | mypy, pyright, cppcheck, Sorbet, PHPStan | ✅ Support file args |
+| **Type Checking** | TypeScript (tsc), SpotBugs, detekt, cargo check, dotnet build, scala compile, swift compiler | ❌ Project-wide only |
 | **Type Checking** | go vet | ❌ No (package-wide) |
-| **SAST** | OpenGrep | ✅ Supports file args |
+| **SAST** | OpenGrep, gosec | ✅ Supports file args |
 | **SCA** | Trivy | ❌ Project-wide by design |
 | **IaC** | Checkov | ❌ Project-wide by design |
-| **Testing** | pytest, Jest, Vitest, Mocha, Playwright | ✅ Support file args |
-| **Testing** | Karma, Maven/Gradle, cargo test | ❌ Config-based / project-wide |
+| **Testing** | pytest, Jest, Vitest, Mocha, Playwright, RSpec, PHPUnit | ✅ Support file args |
+| **Testing** | Karma, Maven/Gradle, cargo test, dotnet test, CTest, sbt, swift test | ❌ Config-based / project-wide |
 | **Testing** | go test | ❌ No (package-wide) |
-| **Coverage** | coverage.py, Istanbul, Vitest coverage | ⚠️ Parse data, filter output |
-| **Coverage** | JaCoCo, Tarpaulin | ❌ Project-wide |
+| **Coverage** | coverage.py, Istanbul, Vitest coverage, SimpleCov, PHPUnit Clover | ⚠️ Parse data, filter output |
+| **Coverage** | JaCoCo, Tarpaulin, dotnet coverage, Scoverage, swift coverage | ❌ Project-wide |
 | **Coverage** | go cover | ❌ No (project-wide coverprofile) |
 | **Duplication** | Duplo | ❌ Project-wide by design |
 
@@ -1665,10 +1684,17 @@ Examples:
 | Ruff | Python | pip / binary | ✅ Yes |
 | ESLint | JavaScript, TypeScript | npm | ✅ Yes |
 | Biome | JavaScript, TypeScript, JSON | npm / binary | ✅ Yes |
-| Checkstyle | Java | binary (jar) | ✅ Yes |
+| Checkstyle | Java | managed (auto-download) | ✅ Yes |
 | PMD | Java | managed (auto-download) | ✅ Yes |
+| ktlint | Kotlin | managed (auto-download) | ✅ Yes |
 | Clippy | Rust | system (rustup) | ❌ No (Cargo workspace) |
 | golangci-lint | Go | go install | ✅ Yes |
+| dotnet format | C# | system (.NET SDK) | ✅ Yes |
+| clang-tidy | C, C++ | system (LLVM) | ✅ Yes |
+| Scalafix | Scala | cs install / sbt plugin | ✅ Yes |
+| SwiftLint | Swift | brew / system | ✅ Yes |
+| RuboCop | Ruby | gem | ✅ Yes |
+| phpcs | PHP | composer | ✅ Yes |
 
 All linting tools support partial scanning via the `files` parameter, except Clippy which operates on the full Cargo workspace.
 
@@ -1678,10 +1704,17 @@ All linting tools support partial scanning via the `files` parameter, except Cli
 |------|-----------|----------------|--------------|
 | Ruff Format | Python | pip / binary | ✅ Yes |
 | Prettier | JavaScript, TypeScript, CSS, HTML, JSON | npm | ✅ Yes |
+| ktlint (format) | Kotlin | managed (auto-download) | ✅ Yes |
 | rustfmt | Rust | system (rustup) | ❌ No (Cargo workspace) |
 | gofmt | Go | system (ships with Go) | ✅ Yes |
+| dotnet format whitespace | C# | system (.NET SDK) | ✅ Yes |
+| clang-format | C, C++ | system (LLVM) | ✅ Yes |
+| Scalafmt | Scala | cs install / sbt plugin | ✅ Yes |
+| SwiftFormat | Swift | brew / system | ✅ Yes |
+| RuboCop Format | Ruby | gem | ✅ Yes |
+| PHP-CS-Fixer | PHP | composer | ✅ Yes |
 
-Formatting tools check code style and whitespace conventions. Ruff Format, Prettier, and gofmt support partial scanning via the `files` parameter.
+Formatting tools check code style and whitespace conventions. Most formatters support partial scanning via the `files` parameter. rustfmt operates on the full Cargo workspace.
 
 ### 9.3 Type Checking
 
@@ -1691,20 +1724,28 @@ Formatting tools check code style and whitespace conventions. Ruff Format, Prett
 | Pyright | Python | pip / npm / binary | ✅ Yes |
 | TypeScript (tsc) | TypeScript | npm | ❌ No |
 | SpotBugs | Java | managed (auto-download) | ❌ No |
+| detekt | Kotlin | managed (auto-download) | ❌ No |
 | cargo check | Rust | system (rustup) | ❌ No (Cargo workspace) |
 | go vet | Go | system (ships with Go) | ❌ No (package-wide) |
+| dotnet build | C# | system (.NET SDK) | ❌ No |
+| cppcheck | C, C++ | system | ✅ Yes |
+| scala compile | Scala | sbt / mvn / gradle | ❌ No |
+| Swift compiler | Swift | system (Xcode / swift.org) | ❌ No |
+| Sorbet | Ruby | gem | ✅ Yes |
+| PHPStan | PHP | composer | ✅ Yes |
 
-**Note:** TypeScript (tsc) does not support file-level CLI arguments - it uses `tsconfig.json` to determine what to check. SpotBugs requires compiled Java classes (run `mvn compile` or `gradle build` first). cargo check operates on the full Cargo workspace. go vet operates on Go packages.
+**Note:** TypeScript (tsc) does not support file-level CLI arguments - it uses `tsconfig.json` to determine what to check. SpotBugs requires compiled Java classes (run `mvn compile` or `gradle build` first). cargo check operates on the full Cargo workspace. go vet operates on Go packages. dotnet build, scala compile, and Swift compiler operate on full projects/packages.
 
 ### 9.4 Security
 
 | Tool | Domains | Install Method | Partial Scan |
 |------|---------|----------------|--------------|
-| Trivy | SCA, Container | binary | ❌ No |
-| OpenGrep | SAST | binary | ✅ Yes |
-| Checkov | IaC | pip / binary | ❌ No |
+| Trivy | SCA, Container | managed (auto-download) | ❌ No |
+| OpenGrep | SAST | managed (auto-download) | ✅ Yes |
+| gosec | SAST (Go) | managed (auto-download) | ✅ Yes |
+| Checkov | IaC | managed (auto-download) | ❌ No |
 
-**Note:** OpenGrep (SAST) supports partial scanning and scans only changed files by default. Trivy (SCA) always scans the entire project - dependency analysis requires full project context. Checkov (IaC) also scans project-wide.
+**Note:** OpenGrep (SAST) and gosec (Go SAST) support partial scanning and scan only changed files by default. Trivy (SCA) always scans the entire project - dependency analysis requires full project context. Checkov (IaC) also scans project-wide.
 
 ### 9.5 Testing
 
@@ -1713,13 +1754,20 @@ Formatting tools check code style and whitespace conventions. Ruff Format, Prett
 | pytest | Python | pip | ✅ Yes |
 | Jest | JavaScript, TypeScript | npm | ✅ Yes |
 | Vitest | JavaScript, TypeScript | npm | ✅ Yes |
+| Mocha | JavaScript, TypeScript | npm | ✅ Yes |
 | Karma | JavaScript, TypeScript (Angular) | npm | ❌ No |
 | Playwright | JavaScript, TypeScript (E2E) | npm | ✅ Yes |
 | Maven/Gradle | Java, Kotlin (JUnit/TestNG) | system | ❌ No |
 | cargo test | Rust | system (rustup) | ❌ No (Cargo workspace) |
 | go test | Go | system (ships with Go) | ⚠️ Partial (package-level) |
+| dotnet test | C# | system (.NET SDK) | ❌ No |
+| CTest | C, C++ | system (CMake) | ❌ No |
+| sbt test | Scala | system / cs install | ❌ No |
+| swift test | Swift | system (Xcode / swift.org) | ❌ No |
+| RSpec | Ruby | gem | ✅ Yes |
+| PHPUnit | PHP | composer | ✅ Yes |
 
-**Note:** While most test runners support running specific test files, running the full test suite is recommended before commits to catch regressions. Maven and Gradle run the full test suite by default. cargo test runs all unit tests, integration tests, and doc tests in the Cargo workspace. go test runs all tests in the specified packages.
+**Note:** While most test runners support running specific test files, running the full test suite is recommended before commits to catch regressions. Maven, Gradle, dotnet test, CTest, sbt, and swift test run the full test suite by default. cargo test runs all unit tests, integration tests, and doc tests in the Cargo workspace. go test runs all tests in the specified packages.
 
 ### 9.6 Coverage
 
@@ -1731,8 +1779,15 @@ Formatting tools check code style and whitespace conventions. Ruff Format, Prett
 | JaCoCo | Java, Kotlin | Maven/Gradle plugin | ❌ No (project-wide) |
 | Tarpaulin | Rust | cargo install | ❌ No (Cargo workspace) |
 | go cover | Go | system (ships with Go) | ❌ No (project-wide) |
+| dotnet coverage | C# | system (.NET SDK) | ❌ No (project-wide) |
+| gcov | C | system (GCC) | ❌ No (project-wide) |
+| lcov | C++ | system | ❌ No (project-wide) |
+| Scoverage | Scala | sbt / Maven plugin | ❌ No (project-wide) |
+| swift coverage (llvm-cov) | Swift | system (Xcode / swift.org) | ❌ No (project-wide) |
+| SimpleCov | Ruby | gem | ⚠️ Partial (filter output) |
+| PHPUnit Clover | PHP | composer | ⚠️ Partial (filter output) |
 
-**Note:** Coverage plugins only parse existing coverage data files  -  they never run tests. Most test runners (pytest, jest, vitest, maven, go test) include coverage instrumentation automatically. Mocha wraps with NYC when available. Others (cargo test, karma, playwright) require separate coverage tools or config. If no coverage data is found, a `no_coverage_data` error is returned. For partial scanning, coverage output can be filtered to show only changed files.
+**Note:** Coverage plugins only parse existing coverage data files  -  they never run tests. Most test runners (pytest, jest, vitest, mocha, maven, go test, dotnet test, swift test) include coverage instrumentation automatically. Others (cargo test, karma, playwright) require separate coverage tools or config. If no coverage data is found, a `no_coverage_data` error is returned. For partial scanning, coverage output can be filtered to show only changed files.
 
 **Java Coverage (JaCoCo):** For Java projects with integration tests that require Docker or external services, use `extra_args` to skip them:
 ```yaml
@@ -1748,7 +1803,7 @@ pipeline:
 
 | Tool | Languages | Install Method | Partial Scan |
 |------|-----------|----------------|--------------|
-| Duplo | Python, Rust, Java, JavaScript, TypeScript, C, C++, C#, Go, Ruby, Erlang, VB, HTML, CSS | binary | ❌ No |
+| Duplo | Python, Rust, Java, Kotlin, JavaScript, TypeScript, C, C++, C#, Go, Scala, Swift, Ruby, PHP, Erlang, VB, HTML, CSS | managed (auto-download) | ❌ No |
 
 **Note:** Duplication detection always scans the entire project to find cross-file duplicates. Use the `pipeline.duplication.exclude` configuration or the global `exclude` list to skip generated or vendor files (e.g., `htmlcov/**`, `generated/**`).
 
@@ -1783,6 +1838,36 @@ pipeline:
   - [x] Checkov (IaC)
   - [x] Checkstyle (Java linting)
   - [x] PMD (Java static analysis - managed)
+  - [x] ktlint (Kotlin linting - managed)
+  - [x] detekt (Kotlin static analysis - managed)
+  - [x] dotnet format (C# linting/formatting)
+  - [x] dotnet build (C# type checking)
+  - [x] dotnet test (C# testing)
+  - [x] dotnet coverage (C# coverage)
+  - [x] clang-tidy (C/C++ linting)
+  - [x] clang-format (C/C++ formatting)
+  - [x] cppcheck (C/C++ type checking)
+  - [x] CTest (C/C++ testing)
+  - [x] gcov/lcov (C/C++ coverage)
+  - [x] Scalafix (Scala linting)
+  - [x] Scalafmt (Scala formatting)
+  - [x] scala compile (Scala type checking)
+  - [x] sbt test (Scala testing)
+  - [x] Scoverage (Scala coverage)
+  - [x] SwiftLint (Swift linting)
+  - [x] SwiftFormat (Swift formatting)
+  - [x] swift compiler (Swift type checking)
+  - [x] swift test (Swift testing)
+  - [x] swift coverage (Swift coverage)
+  - [x] RuboCop (Ruby linting/formatting)
+  - [x] Sorbet (Ruby type checking)
+  - [x] RSpec (Ruby testing)
+  - [x] SimpleCov (Ruby coverage)
+  - [x] phpcs (PHP linting)
+  - [x] PHP-CS-Fixer (PHP formatting)
+  - [x] PHPStan (PHP type checking)
+  - [x] PHPUnit (PHP testing)
+  - [x] PHPUnit Clover (PHP coverage)
   - [x] Jest (JS/TS testing)
   - [x] Karma (Angular testing)
   - [x] Playwright (E2E testing)


### PR DESCRIPTION
## Summary

- Updates all documentation to reflect the full set of 60+ plugins across all 14 supported languages
- Fixes language count from 15 → 14 and promotes Kotlin and PHP from Partial/Minimal to Full support tier (matching their actual implementation)
- Adds missing tools for C#, C/C++, Scala, Swift, Ruby, Kotlin, and PHP to every tool table in README.md, docs/main.md, and docs/help.md
- Updates scan-domain descriptions, partial-scanning matrices, ASCII architecture diagram, auto-downloaded tool lists, and manually-installed tool tables

## Files changed

- **README.md** — language tier table, "What It Checks" table, auto-downloaded tools note
- **docs/main.md** — unified pipeline table, 3 partial scanning tables, ASCII diagram, sections 9.1–9.7, dev phases checklist
- **docs/help.md** — scan domain flags, partial scanning table, complete tool lists, auto-downloaded table, manually installed tables, supported tools reference tables
- **docs/languages/README.md** — language count fix
- **docs/languages/scala.md** — Kotlin cross-reference tier fix

## Test plan

- [ ] Verify all 14 language docs still render correctly
- [ ] Spot-check tool names in tables against `pyproject.toml` entry points
- [ ] Confirm no broken markdown table formatting