### PR TITLE
chore: bump tool versions

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -850,14 +850,14 @@ LucidShark pins versions for tools it downloads directly (security scanners and 
 [tool.lucidshark.tools]
 # Security scanners
 trivy = "0.69.3"
-opengrep = "1.16.3"
-checkov = "3.2.508"
+opengrep = "1.16.5"
+checkov = "3.2.513"
 # Java tools
-pmd = "7.22.0"
+pmd = "7.23.0"
 checkstyle = "13.3.0"
 spotbugs = "4.9.8"
 # Duplication detection
-duplo = "0.1.7"
+duplo = "0.2.0"
 ```
 
 **Language-specific tools** (ruff, eslint, biome, mypy, pyright, etc.) are **not** version-pinned by LucidShark. Install these via your package manager (pip, npm, cargo) to ensure compatibility with your project. PMD, Checkstyle, and SpotBugs are exceptions  -  they are managed (auto-downloaded) like security tools, since they are distributed as cross-platform JARs/zips.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,15 +130,15 @@ markers = [
 [tool.lucidshark.tools]
 # Security scanners
 trivy = "0.69.3"
-opengrep = "1.16.4"
-checkov = "3.2.508"
-gosec = "2.24.7"
+opengrep = "1.16.5"
+checkov = "3.2.513"
+gosec = "2.25.0"
 # Java tools
-pmd = "7.22.0"
+pmd = "7.23.0"
 checkstyle = "13.3.0"
 spotbugs = "4.9.8"
 # Kotlin tools
-ktlint = "1.5.0"
-detekt = "1.23.7"
+ktlint = "1.8.0"
+detekt = "1.23.8"
 # Duplication detection
-duplo = "0.1.7"
+duplo = "0.2.0"

--- a/src/lucidshark/__init__.py
+++ b/src/lucidshark/__init__.py
@@ -7,4 +7,4 @@ subpackages such as `core`, `schema`, and `scanners`.
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.19"
+__version__ = "0.7.0"

--- a/src/lucidshark/bootstrap/versions.py
+++ b/src/lucidshark/bootstrap/versions.py
@@ -22,18 +22,18 @@ _tomllib = get_tomllib()
 _FALLBACK_VERSIONS: Dict[str, str] = {
     # Security scanners
     "trivy": "0.69.3",
-    "opengrep": "1.16.4",
-    "checkov": "3.2.508",
-    "gosec": "2.24.7",
+    "opengrep": "1.16.5",
+    "checkov": "3.2.513",
+    "gosec": "2.25.0",
     # Java tools
-    "pmd": "7.22.0",
+    "pmd": "7.23.0",
     "checkstyle": "13.3.0",
     "spotbugs": "4.9.8",
     # Kotlin tools
-    "ktlint": "1.5.0",
-    "detekt": "1.23.7",
+    "ktlint": "1.8.0",
+    "detekt": "1.23.8",
     # Duplication detection
-    "duplo": "0.1.7",
+    "duplo": "0.2.0",
 }
 
 

--- a/tests/claude-manual/TEST_JAVA_E2E.md
+++ b/tests/claude-manual/TEST_JAVA_E2E.md
@@ -59,7 +59,7 @@ Your job is to **FIND BUGS**, not to confirm that things work. Approach every te
 | Domain | Tool | Version | Type |
 |--------|------|---------|------|
 | Linting | Checkstyle | 13.3.0 | Managed (auto-download JAR) |
-| Linting | PMD | 7.22.0 | Managed (auto-download JAR) |
+| Linting | PMD | 7.23.0 | Managed (auto-download JAR) |
 | Type Checking | SpotBugs | 4.9.8 | Managed (auto-download JAR) |
 | Testing | Maven / Gradle |  -  | System (build tool) |
 | Coverage | JaCoCo |  -  | Integrated (parses XML reports) |
@@ -1332,7 +1332,7 @@ for i in pmd_issues[:10]:
 ```
 
 **Verify:**
-- [ ] PMD JAR auto-downloaded to `.lucidshark/bin/pmd/7.22.0/`
+- [ ] PMD JAR auto-downloaded to `.lucidshark/bin/pmd/7.23.0/`
 - [ ] Finds empty if block in `Main.java` (`Do_Something` method)
 - [ ] Finds empty catch block in `Main.java` (`riskyOperation` method)
 - [ ] Finds string concatenation in loop (InefficientStringConcatenation) in `processData`
@@ -2007,7 +2007,7 @@ mcp__lucidshark__get_status()
 
 **Verify:**
 - [ ] Returns tool inventory including Java tools
-- [ ] Returns scanner versions (Checkstyle 13.3.0, PMD 7.22.0, SpotBugs 4.9.8)
+- [ ] Returns scanner versions (Checkstyle 13.3.0, PMD 7.23.0, SpotBugs 4.9.8)
 - [ ] Shows managed tool download status
 
 ### 5.6 `mcp__lucidshark__get_help()`
@@ -2486,7 +2486,7 @@ Write the report with this structure:
 **Java Version:** (from `java -version`)
 **Maven Version:** (from `mvn --version`)
 **Platform:** (from `uname -a`)
-**Tool Versions:** Checkstyle 13.3.0, PMD 7.22.0, SpotBugs 4.9.8, google-java-format X.Y.Z, Trivy X.Y.Z, OpenGrep X.Y.Z, Duplo X.Y.Z
+**Tool Versions:** Checkstyle 13.3.0, PMD 7.23.0, SpotBugs 4.9.8, google-java-format X.Y.Z, Trivy X.Y.Z, OpenGrep X.Y.Z, Duplo X.Y.Z
 
 ---
 

--- a/tests/unit/plugins/linters/test_ktlint.py
+++ b/tests/unit/plugins/linters/test_ktlint.py
@@ -109,8 +109,8 @@ class TestKtlintLinterProperties:
 
     def test_get_version(self) -> None:
         """Test get_version returns configured version."""
-        linter = KtlintLinter(version="1.5.0")
-        assert linter.get_version() == "1.5.0"
+        linter = KtlintLinter(version="1.8.0")
+        assert linter.get_version() == "1.8.0"
 
     def test_init_with_project_root(self) -> None:
         """Test initialization with project root."""
@@ -143,12 +143,12 @@ class TestKtlintEnsureBinary:
     def test_cached_jar_found(self) -> None:
         """Test finds cached JAR."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
 
             # Create fake cached JAR
-            jar_dir = Path(tmpdir) / ".lucidshark" / "bin" / "ktlint" / "1.5.0"
+            jar_dir = Path(tmpdir) / ".lucidshark" / "bin" / "ktlint" / "1.8.0"
             jar_dir.mkdir(parents=True)
-            jar_path = jar_dir / "ktlint-1.5.0.jar"
+            jar_path = jar_dir / "ktlint-1.8.0.jar"
             jar_path.touch()
 
             result = linter.ensure_binary()
@@ -157,25 +157,25 @@ class TestKtlintEnsureBinary:
     def test_download_triggered_when_not_cached(self) -> None:
         """Test download is triggered when JAR not cached."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
 
             with patch("shutil.which", return_value="/usr/bin/java"):
                 with patch.object(linter, "_download_binary") as mock_download:
                     # After download, create the JAR
                     def create_jar(dest_dir):
                         dest_dir.mkdir(parents=True, exist_ok=True)
-                        (dest_dir / "ktlint-1.5.0.jar").touch()
+                        (dest_dir / "ktlint-1.8.0.jar").touch()
 
                     mock_download.side_effect = create_jar
 
                     result = linter.ensure_binary()
                     mock_download.assert_called_once()
-                    assert result.name == "ktlint-1.5.0.jar"
+                    assert result.name == "ktlint-1.8.0.jar"
 
     def test_java_not_found_raises(self) -> None:
         """Test raises FileNotFoundError when Java not available."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
 
             with patch("shutil.which", return_value=None):
                 with pytest.raises(FileNotFoundError, match="Java is required"):
@@ -184,7 +184,7 @@ class TestKtlintEnsureBinary:
     def test_download_fails_raises_runtime_error(self) -> None:
         """Test raises RuntimeError when download fails."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
 
             with patch("shutil.which", return_value="/usr/bin/java"):
                 with patch.object(linter, "_download_binary"):
@@ -199,7 +199,7 @@ class TestKtlintDownloadBinary:
     def test_download_jar(self) -> None:
         """Test downloading JAR file."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             # Create mock JAR content
@@ -217,7 +217,7 @@ class TestKtlintDownloadBinary:
                 linter._download_binary(dest_dir)
 
             # Verify JAR was created
-            jar_path = dest_dir / "ktlint-1.5.0.jar"
+            jar_path = dest_dir / "ktlint-1.8.0.jar"
             assert jar_path.exists()
 
     def test_download_cleans_up_temp_on_network_error(self) -> None:
@@ -225,7 +225,7 @@ class TestKtlintDownloadBinary:
         from urllib.error import URLError
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             with patch(
@@ -238,7 +238,7 @@ class TestKtlintDownloadBinary:
     def test_download_validates_url_domain(self) -> None:
         """Verify URL domain validation."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = KtlintLinter(version="1.5.0", project_root=Path(tmpdir))
+            linter = KtlintLinter(version="1.8.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             mock_response = MagicMock()

--- a/tests/unit/plugins/linters/test_pmd.py
+++ b/tests/unit/plugins/linters/test_pmd.py
@@ -32,7 +32,7 @@ def make_completed_process(
 SAMPLE_PMD_OUTPUT = json.dumps(
     {
         "formatVersion": 0,
-        "pmdVersion": "7.22.0",
+        "pmdVersion": "7.23.0",
         "files": [
             {
                 "filename": "/project/src/Main.java",
@@ -46,7 +46,7 @@ SAMPLE_PMD_OUTPUT = json.dumps(
                         "ruleset": "Best Practices",
                         "priority": 3,
                         "description": "Avoid unused local variables such as 'x'.",
-                        "externalInfoUrl": "https://docs.pmd-code.org/pmd-doc-7.22.0/pmd_rules_java_bestpractices.html#unusedlocalvariable",
+                        "externalInfoUrl": "https://docs.pmd-code.org/pmd-doc-7.23.0/pmd_rules_java_bestpractices.html#unusedlocalvariable",
                     }
                 ],
             }
@@ -58,7 +58,7 @@ SAMPLE_PMD_OUTPUT = json.dumps(
 SAMPLE_PMD_MULTI_FILE = json.dumps(
     {
         "formatVersion": 0,
-        "pmdVersion": "7.22.0",
+        "pmdVersion": "7.23.0",
         "files": [
             {
                 "filename": "/project/src/A.java",
@@ -128,8 +128,8 @@ class TestPmdLinterProperties:
         assert linter.supports_fix is False
 
     def test_get_version(self) -> None:
-        linter = PmdLinter(version="7.22.0")
-        assert linter.get_version() == "7.22.0"
+        linter = PmdLinter(version="7.23.0")
+        assert linter.get_version() == "7.23.0"
 
     def test_init_with_project_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -170,7 +170,7 @@ class TestPmdEnsureBinary:
 
     def test_cached_binary_found(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
 
             # Create fake cached binary
             binary_dir = (
@@ -178,8 +178,8 @@ class TestPmdEnsureBinary:
                 / ".lucidshark"
                 / "bin"
                 / "pmd"
-                / "7.22.0"
-                / "pmd-bin-7.22.0"
+                / "7.23.0"
+                / "pmd-bin-7.23.0"
                 / "bin"
             )
             binary_dir.mkdir(parents=True)
@@ -192,13 +192,13 @@ class TestPmdEnsureBinary:
 
     def test_download_triggered_when_not_cached(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
 
             with patch("shutil.which", return_value="/usr/bin/java"):
                 with patch.object(linter, "_download_binary") as mock_download:
                     # After download, create the binary
                     def create_binary(dest_dir):
-                        binary_dir = dest_dir / "pmd-bin-7.22.0" / "bin"
+                        binary_dir = dest_dir / "pmd-bin-7.23.0" / "bin"
                         binary_dir.mkdir(parents=True)
                         (binary_dir / "pmd").touch()
 
@@ -210,7 +210,7 @@ class TestPmdEnsureBinary:
 
     def test_java_not_found_raises(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
 
             with patch("shutil.which", return_value=None):
                 with pytest.raises(FileNotFoundError, match="Java is required"):
@@ -218,7 +218,7 @@ class TestPmdEnsureBinary:
 
     def test_download_fails_raises_runtime_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
 
             with patch("shutil.which", return_value="/usr/bin/java"):
                 with patch.object(linter, "_download_binary"):
@@ -232,7 +232,7 @@ class TestPmdDownloadBinary:
 
     def test_download_and_extract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             # Create a mock zip file in memory
@@ -241,8 +241,8 @@ class TestPmdDownloadBinary:
 
             zip_buffer = io.BytesIO()
             with zipfile.ZipFile(zip_buffer, "w") as zf:
-                zf.writestr("pmd-bin-7.22.0/bin/pmd", "#!/bin/sh\necho pmd")
-                zf.writestr("pmd-bin-7.22.0/lib/pmd.jar", "fake jar")
+                zf.writestr("pmd-bin-7.23.0/bin/pmd", "#!/bin/sh\necho pmd")
+                zf.writestr("pmd-bin-7.23.0/lib/pmd.jar", "fake jar")
 
             zip_data = zip_buffer.getvalue()
 
@@ -258,7 +258,7 @@ class TestPmdDownloadBinary:
                 linter._download_binary(dest_dir)
 
             # Verify extraction
-            binary = dest_dir / "pmd-bin-7.22.0" / "bin" / "pmd"
+            binary = dest_dir / "pmd-bin-7.23.0" / "bin" / "pmd"
             assert binary.exists()
             # Verify executable
             import stat
@@ -267,7 +267,7 @@ class TestPmdDownloadBinary:
 
     def test_path_traversal_protection(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             # Create a malicious zip with path traversal
@@ -297,7 +297,7 @@ class TestPmdDownloadBinary:
         from urllib.error import URLError
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             with patch(
@@ -314,7 +314,7 @@ class TestPmdDownloadBinary:
     def test_download_cleans_up_temp_on_corrupt_zip(self) -> None:
         """Verify temp file is cleaned up when zip is corrupt."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             mock_response = MagicMock()
@@ -335,7 +335,7 @@ class TestPmdDownloadBinary:
         import zipfile
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            linter = PmdLinter(version="7.22.0", project_root=Path(tmpdir))
+            linter = PmdLinter(version="7.23.0", project_root=Path(tmpdir))
             dest_dir = Path(tmpdir) / "dest"
 
             # Zip without the expected binary structure
@@ -356,7 +356,7 @@ class TestPmdDownloadBinary:
                 linter._download_binary(dest_dir)
 
             # Binary should not exist
-            binary = dest_dir / "pmd-bin-7.22.0" / "bin" / "pmd"
+            binary = dest_dir / "pmd-bin-7.23.0" / "bin" / "pmd"
             assert not binary.exists()
 
 
@@ -1016,7 +1016,7 @@ class TestPmdParseOutput:
         output = json.dumps(
             {
                 "formatVersion": 0,
-                "pmdVersion": "7.22.0",
+                "pmdVersion": "7.23.0",
                 "files": [{"filename": "/project/Main.java", "violations": []}],
             }
         )
@@ -1044,14 +1044,14 @@ class TestPmdParseOutput:
 
     def test_parse_empty_files_list(self) -> None:
         linter = PmdLinter()
-        output = json.dumps({"formatVersion": 0, "pmdVersion": "7.22.0", "files": []})
+        output = json.dumps({"formatVersion": 0, "pmdVersion": "7.23.0", "files": []})
         issues = linter._parse_output(output, Path("/project"))
         assert issues == []
 
     def test_parse_missing_files_key(self) -> None:
         """Verify JSON without 'files' key returns empty list."""
         linter = PmdLinter()
-        output = json.dumps({"formatVersion": 0, "pmdVersion": "7.22.0"})
+        output = json.dumps({"formatVersion": 0, "pmdVersion": "7.23.0"})
         issues = linter._parse_output(output, Path("/project"))
         assert issues == []
 

--- a/tests/unit/plugins/type_checkers/test_detekt.py
+++ b/tests/unit/plugins/type_checkers/test_detekt.py
@@ -64,8 +64,8 @@ class TestDetektCheckerProperties:
 
     def test_get_version(self) -> None:
         """Test get_version returns configured version."""
-        checker = DetektChecker(version="1.23.7")
-        assert checker.get_version() == "1.23.7"
+        checker = DetektChecker(version="1.23.8")
+        assert checker.get_version() == "1.23.8"
 
     def test_get_version_default(self) -> None:
         """Test get_version returns default version when not overridden."""
@@ -83,7 +83,7 @@ class TestDetektEnsureBinary:
         """Test ensure_binary returns cached path when JAR already exists."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            version = "1.23.7"
+            version = "1.23.8"
 
             # Create the expected JAR file in the cache directory
             jar_dir = project_root / ".lucidshark" / "bin" / "detekt" / version
@@ -100,7 +100,7 @@ class TestDetektEnsureBinary:
         """Test ensure_binary downloads JAR when not found in cache."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            version = "1.23.7"
+            version = "1.23.8"
 
             checker = DetektChecker(version=version, project_root=project_root)
 
@@ -160,14 +160,14 @@ class TestDetektEnsureBinary:
     def test_different_versions_use_different_paths(self) -> None:
         """Test that different versions use different directories."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            checker1 = DetektChecker(version="1.23.7", project_root=Path(tmpdir))
+            checker1 = DetektChecker(version="1.23.8", project_root=Path(tmpdir))
             checker2 = DetektChecker(version="1.22.0", project_root=Path(tmpdir))
 
-            path1 = checker1._paths.plugin_bin_dir("detekt", "1.23.7")
+            path1 = checker1._paths.plugin_bin_dir("detekt", "1.23.8")
             path2 = checker2._paths.plugin_bin_dir("detekt", "1.22.0")
 
             assert path1 != path2
-            assert "1.23.7" in str(path1)
+            assert "1.23.8" in str(path1)
             assert "1.22.0" in str(path2)
 
 
@@ -178,7 +178,7 @@ class TestDetektDownloadBinary:
         """Test _download_binary downloads and saves the JAR file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            version = "1.23.7"
+            version = "1.23.8"
             dest_dir = project_root / "dest"
 
             checker = DetektChecker(version=version, project_root=project_root)
@@ -202,7 +202,7 @@ class TestDetektDownloadBinary:
         """Test that the download URL uses the github.com domain."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            version = "1.23.7"
+            version = "1.23.8"
 
             checker = DetektChecker(version=version, project_root=project_root)
 
@@ -223,7 +223,7 @@ class TestDetektDownloadBinary:
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            checker = DetektChecker(version="1.23.7", project_root=project_root)
+            checker = DetektChecker(version="1.23.8", project_root=project_root)
 
             # The URL is always correctly constructed internally, but the
             # guard ensures it starts with https://github.com/


### PR DESCRIPTION
## Summary
- Bump opengrep 1.16.4 → 1.16.5, checkov 3.2.508 → 3.2.513, gosec 2.24.7 → 2.25.0
- Bump pmd 7.22.0 → 7.23.0, ktlint 1.5.0 → 1.8.0, detekt 1.23.7 → 1.23.8
- Bump duplo 0.1.7 → 0.2.0
- Updated pyproject.toml, fallback versions, docs, and test fixtures

## Test plan
- [ ] Verify tools download correctly at new versions
- [ ] Run unit tests to confirm test fixtures match
- [ ] Run full scan to validate scanner integration