### PR TITLE
fix: repair Rust plugin severity mapping and error handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==2.0.0
 charset-normalizer==3.4.4
 click==8.3.1
 coverage==7.13.4
-cryptography==46.0.5
+cryptography==46.0.6
 defusedxml==0.7.1
 distro==1.9.0
 docstring_parser==0.17.0
@@ -25,7 +25,7 @@ jsonpointer==3.0.0
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 langchain-anthropic==1.3.3
-langchain-core==1.2.14
+langchain-core==1.2.22
 langchain-ollama==1.0.1
 langchain-openai==1.1.10
 langsmith==0.7.6
@@ -46,8 +46,8 @@ pycparser==3.0
 pydantic==2.12.5
 pydantic-settings==2.13.1
 pydantic_core==2.41.5
-Pygments==2.19.2
-PyJWT==2.11.0
+Pygments==2.20.0
+PyJWT==2.12.0
 pyproject_hooks==1.2.0
 pyright==1.1.408
 pytest==9.0.2
@@ -61,7 +61,7 @@ types-defusedxml==0.7.0.20250822
 questionary==2.1.1
 referencing==0.37.0
 regex==2026.2.19
-requests==2.32.5
+requests==2.33.0
 requests-toolbelt==1.0.0
 rpds-py==0.30.0
 sniffio==1.3.1

--- a/src/lucidshark/plugins/linters/clippy.py
+++ b/src/lucidshark/plugins/linters/clippy.py
@@ -32,17 +32,64 @@ from lucidshark.plugins.rust_utils import (
 
 LOGGER = get_logger(__name__)
 
-# Clippy lint category to severity mapping
-CATEGORY_SEVERITY = {
-    "clippy::correctness": Severity.HIGH,
-    "clippy::suspicious": Severity.HIGH,
-    "clippy::complexity": Severity.MEDIUM,
-    "clippy::perf": Severity.MEDIUM,
-    "clippy::style": Severity.LOW,
-    "clippy::pedantic": Severity.LOW,
-    "clippy::nursery": Severity.LOW,
-    "clippy::restriction": Severity.LOW,
-    "clippy::cargo": Severity.LOW,
+# Clippy lint name to severity mapping.
+# Clippy lint codes (e.g., "clippy::needless_return") don't encode their
+# category, so we maintain a curated set of overrides for common lints where
+# the diagnostic-level fallback gives the wrong severity.
+# Correctness lints are deny-by-default (emitted as errors → HIGH via
+# LEVEL_SEVERITY), so they don't need overrides here.
+LINT_SEVERITY = {
+    # Suspicious lints — should be HIGH (warn-by-default → MEDIUM without override)
+    "clippy::almost_swapped": Severity.HIGH,
+    "clippy::arc_with_non_send_sync": Severity.HIGH,
+    "clippy::float_equality_without_abs": Severity.HIGH,
+    "clippy::iter_out_of_bounds": Severity.HIGH,
+    "clippy::multi_assignments": Severity.HIGH,
+    "clippy::mut_range_bound": Severity.HIGH,
+    "clippy::mutable_key_type": Severity.HIGH,
+    "clippy::non_canonical_clone_impl": Severity.HIGH,
+    "clippy::non_canonical_partial_ord_impl": Severity.HIGH,
+    "clippy::octal_escapes": Severity.HIGH,
+    "clippy::suspicious_arithmetic_impl": Severity.HIGH,
+    "clippy::suspicious_assignment_formatting": Severity.HIGH,
+    "clippy::suspicious_command_arg_space": Severity.HIGH,
+    "clippy::suspicious_doc_comments": Severity.HIGH,
+    "clippy::suspicious_else_formatting": Severity.HIGH,
+    "clippy::suspicious_map": Severity.HIGH,
+    "clippy::suspicious_op_assign_impl": Severity.HIGH,
+    "clippy::suspicious_open_options": Severity.HIGH,
+    "clippy::suspicious_to_owned": Severity.HIGH,
+    "clippy::suspicious_unary_op_formatting": Severity.HIGH,
+    "clippy::unconditional_recursion": Severity.HIGH,
+    # Style lints — should be LOW (warn-by-default → MEDIUM without override)
+    "clippy::bool_assert_comparison": Severity.LOW,
+    "clippy::collapsible_else_if": Severity.LOW,
+    "clippy::collapsible_if": Severity.LOW,
+    "clippy::comparison_to_empty": Severity.LOW,
+    "clippy::enum_variant_names": Severity.LOW,
+    "clippy::from_over_into": Severity.LOW,
+    "clippy::len_without_is_empty": Severity.LOW,
+    "clippy::len_zero": Severity.LOW,
+    "clippy::let_and_return": Severity.LOW,
+    "clippy::manual_map": Severity.LOW,
+    "clippy::match_bool": Severity.LOW,
+    "clippy::match_like_matches_macro": Severity.LOW,
+    "clippy::needless_borrow": Severity.LOW,
+    "clippy::needless_range_loop": Severity.LOW,
+    "clippy::needless_return": Severity.LOW,
+    "clippy::new_without_default": Severity.LOW,
+    "clippy::ptr_arg": Severity.LOW,
+    "clippy::question_mark": Severity.LOW,
+    "clippy::redundant_clone": Severity.LOW,
+    "clippy::redundant_closure": Severity.LOW,
+    "clippy::redundant_field_names": Severity.LOW,
+    "clippy::redundant_pattern": Severity.LOW,
+    "clippy::redundant_static_lifetimes": Severity.LOW,
+    "clippy::should_implement_trait": Severity.LOW,
+    "clippy::single_match": Severity.LOW,
+    "clippy::unnecessary_lazy_evaluations": Severity.LOW,
+    "clippy::upper_case_acronyms": Severity.LOW,
+    "clippy::wrong_self_convention": Severity.LOW,
 }
 
 # Compiler diagnostic level to severity mapping
@@ -215,19 +262,7 @@ class ClippyLinter(LinterPlugin):
         # Count remaining issues
         post_issues = self.lint(context)
 
-        files_modified = len(
-            set(
-                str(issue.file_path)
-                for issue in pre_issues
-                if str(issue.file_path) not in {str(i.file_path) for i in post_issues}
-            )
-        )
-
-        return FixResult(
-            files_modified=files_modified,
-            issues_fixed=len(pre_issues) - len(post_issues),
-            issues_remaining=len(post_issues),
-        )
+        return self._calculate_fix_stats(pre_issues, post_issues)
 
     def _parse_output(self, output: str, project_root: Path) -> List[UnifiedIssue]:
         """Parse Clippy JSON output.
@@ -357,10 +392,13 @@ class ClippyLinter(LinterPlugin):
         Returns:
             Severity level.
         """
-        # Check category-based severity first
-        for category, severity in CATEGORY_SEVERITY.items():
-            if code.startswith(category):
-                return severity
+        # Direct lint name lookup
+        if code in LINT_SEVERITY:
+            return LINT_SEVERITY[code]
+
+        # Catch-all for unlisted suspicious_ lints
+        if code.startswith("clippy::suspicious_"):
+            return Severity.HIGH
 
         # Fall back to level-based severity
         return LEVEL_SEVERITY.get(level, Severity.MEDIUM)

--- a/src/lucidshark/plugins/test_runners/cargo.py
+++ b/src/lucidshark/plugins/test_runners/cargo.py
@@ -70,8 +70,9 @@ class CargoTestRunner(TestRunnerPlugin):
             True if tarpaulin is installed and runnable.
         """
         try:
+            cargo = find_cargo()
             result = subprocess.run(
-                ["cargo", "tarpaulin", "--version"],
+                [str(cargo), "tarpaulin", "--version"],
                 capture_output=True,
                 timeout=10,
             )
@@ -160,10 +161,6 @@ class CargoTestRunner(TestRunnerPlugin):
                 message="cargo tarpaulin timed out after 600 seconds",
             )
             return None
-        except subprocess.CalledProcessError as e:
-            # Tarpaulin returns non-zero on test failures — that's normal.
-            stdout = getattr(e, "stdout", "") or ""
-            stderr = getattr(e, "stderr", "") or ""
         except Exception as e:
             LOGGER.warning(f"Tarpaulin failed to execute: {e}")
             context.record_skip(
@@ -217,8 +214,14 @@ class CargoTestRunner(TestRunnerPlugin):
             )
             return TestResult(tool="cargo")
         except Exception as e:
-            # cargo test returns non-zero on test failures
-            LOGGER.debug(f"cargo test completed with: {e}")
+            LOGGER.error(f"Failed to run cargo test: {e}")
+            context.record_skip(
+                tool_name=self.name,
+                domain=ToolDomain.TESTING,
+                reason=SkipReason.EXECUTION_FAILED,
+                message=f"Failed to run cargo test: {e}",
+            )
+            return TestResult(tool="cargo")
 
         # Combine stdout and stderr for parsing
         combined = stdout + "\n" + stderr

--- a/tests/unit/plugins/test_runners/test_cargo.py
+++ b/tests/unit/plugins/test_runners/test_cargo.py
@@ -30,17 +30,21 @@ class TestHasTarpaulin:
     """Tests for _has_tarpaulin method."""
 
     @patch("subprocess.run")
-    def test_returns_true_when_available(self, mock_run: MagicMock) -> None:
+    @patch("lucidshark.plugins.test_runners.cargo.find_cargo")
+    def test_returns_true_when_available(
+        self, mock_find: MagicMock, mock_run: MagicMock
+    ) -> None:
         """Test _has_tarpaulin returns True when tarpaulin is installed."""
+        mock_find.return_value = Path("/usr/bin/cargo")
         mock_run.return_value = subprocess.CompletedProcess(
-            args=["cargo", "tarpaulin", "--version"],
+            args=["/usr/bin/cargo", "tarpaulin", "--version"],
             returncode=0,
             stdout="cargo-tarpaulin 0.27.0",
         )
         runner = CargoTestRunner()
         assert runner._has_tarpaulin() is True
         mock_run.assert_called_once_with(
-            ["cargo", "tarpaulin", "--version"],
+            ["/usr/bin/cargo", "tarpaulin", "--version"],
             capture_output=True,
             timeout=10,
         )


### PR DESCRIPTION
## Summary

- **Clippy severity mapping was broken**: `CATEGORY_SEVERITY` matched on category prefixes (e.g., `clippy::style`) but clippy lint codes don't encode categories (e.g., `clippy::needless_return`). Replaced with `LINT_SEVERITY` direct lookup for ~50 common lints plus a `clippy::suspicious_` prefix catch-all. Correctness lints already map correctly via `LEVEL_SEVERITY` (deny-by-default → error → HIGH).
- **Clippy `fix()` undercounted `files_modified`**: manual logic only counted files going from "has issues" to "zero issues", missing partial fixes. Replaced with base class `_calculate_fix_stats()`.
- **`_run_cargo_test()` silently swallowed execution failures**: bare `except Exception` logged at DEBUG and returned empty `TestResult(0 passed, 0 failed)` with no skip recorded. Now properly logs at ERROR and records a skip.
- **Dead `CalledProcessError` catch in `_run_with_tarpaulin()`**: `run_with_streaming()` never raises `CalledProcessError` — removed unreachable handler.
- **`_has_tarpaulin()` hardcoded `"cargo"`**: inconsistent with all other methods that use `find_cargo()`. Fixed + updated test.

## Test plan

- [x] All 12 cargo unit tests pass (including previously-failing `test_returns_true_when_available`)
- [x] All 7 clippy integration tests pass
- [ ] Verify clippy severity on a real Rust project with style/suspicious lints