### PR TITLE
fix: C++ support bugs and resolve quality scan issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==2.0.0
 charset-normalizer==3.4.4
 click==8.3.1
 coverage==7.13.4
-cryptography==46.0.5
+cryptography==46.0.6
 defusedxml==0.7.1
 distro==1.9.0
 docstring_parser==0.17.0
@@ -25,7 +25,7 @@ jsonpointer==3.0.0
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 langchain-anthropic==1.3.3
-langchain-core==1.2.14
+langchain-core==1.2.22
 langchain-ollama==1.0.1
 langchain-openai==1.1.10
 langsmith==0.7.6
@@ -46,8 +46,8 @@ pycparser==3.0
 pydantic==2.12.5
 pydantic-settings==2.13.1
 pydantic_core==2.41.5
-Pygments==2.19.2
-PyJWT==2.11.0
+Pygments==2.20.0
+PyJWT==2.12.0
 pyproject_hooks==1.2.0
 pyright==1.1.408
 pytest==9.0.2
@@ -61,7 +61,7 @@ types-defusedxml==0.7.0.20250822
 questionary==2.1.1
 referencing==0.37.0
 regex==2026.2.19
-requests==2.32.5
+requests==2.33.0
 requests-toolbelt==1.0.0
 rpds-py==0.30.0
 sniffio==1.3.1

--- a/src/lucidshark/core/domain_runner.py
+++ b/src/lucidshark/core/domain_runner.py
@@ -119,6 +119,7 @@ EXTENSION_LANGUAGE: Dict[str, str] = {
     ".cc": "c++",
     ".cxx": "c++",
     ".hpp": "c++",
+    ".hh": "c++",
     ".hxx": "c++",
     ".rb": "ruby",
     ".cs": "csharp",

--- a/src/lucidshark/detection/languages.py
+++ b/src/lucidshark/detection/languages.py
@@ -65,10 +65,12 @@ EXTENSION_MAP = {
     ".swift": "swift",
     ".c": "c",
     ".h": "c",
-    ".cpp": "cpp",
-    ".cc": "cpp",
-    ".cxx": "cpp",
-    ".hpp": "cpp",
+    ".cpp": "c++",
+    ".cc": "c++",
+    ".cxx": "c++",
+    ".hpp": "c++",
+    ".hh": "c++",
+    ".hxx": "c++",
 }
 
 # Marker files that indicate a language
@@ -89,7 +91,7 @@ MARKER_FILES = {
     "ruby": ["Gemfile", "Rakefile"],
     "php": ["composer.json"],
     "c": ["CMakeLists.txt", "Makefile", "makefile", "GNUmakefile", "meson.build"],
-    "cpp": ["CMakeLists.txt"],
+    "c++": ["CMakeLists.txt"],
     "swift": ["Package.swift"],
 }
 

--- a/src/lucidshark/plugins/duplication/duplo.py
+++ b/src/lucidshark/plugins/duplication/duplo.py
@@ -58,6 +58,7 @@ SUPPORTED_EXTENSIONS = {
     ".cxx": "c++",
     ".cc": "c++",
     ".h": "c",
+    ".hh": "c++",
     ".hpp": "c++",
     ".hxx": "c++",
     ".kt": "kotlin",

--- a/src/lucidshark/plugins/linters/clang_tidy.py
+++ b/src/lucidshark/plugins/linters/clang_tidy.py
@@ -362,9 +362,12 @@ class ClangTidyLinter(LinterPlugin):
         """
         if check_name:
             # Extract the category prefix (e.g., "bugprone" from "bugprone-use-after-move")
-            category = check_name.split("-")[0]
-            if category in CATEGORY_SEVERITY:
-                return CATEGORY_SEVERITY[category]
+            # Handle multi-segment prefixes like "clang-analyzer" and "clang-diagnostic"
+            parts = check_name.split("-")
+            if len(parts) >= 2 and f"{parts[0]}-{parts[1]}" in CATEGORY_SEVERITY:
+                return CATEGORY_SEVERITY[f"{parts[0]}-{parts[1]}"]
+            if parts[0] in CATEGORY_SEVERITY:
+                return CATEGORY_SEVERITY[parts[0]]
 
         if diag_level in DIAG_SEVERITY:
             return DIAG_SEVERITY[diag_level]

--- a/src/lucidshark/plugins/test_runners/ctest.py
+++ b/src/lucidshark/plugins/test_runners/ctest.py
@@ -466,8 +466,8 @@ class CTestRunner(TestRunnerPlugin):
 
         # Match C/C++ file patterns like "test_main.cpp:42:" or "test_main.cpp(42):"
         patterns = [
-            re.compile(r"(\S+\.(?:cpp|cc|cxx|hpp|h|c)):(\d+):"),
-            re.compile(r"(\S+\.(?:cpp|cc|cxx|hpp|h|c))\((\d+)\)"),
+            re.compile(r"(\S+\.(?:cpp|cc|cxx|hpp|hh|hxx|h|c)):(\d+):"),
+            re.compile(r"(\S+\.(?:cpp|cc|cxx|hpp|hh|hxx|h|c))\((\d+)\)"),
         ]
 
         for line in output.splitlines():

--- a/tests/unit/detection/test_csharp_detection.py
+++ b/tests/unit/detection/test_csharp_detection.py
@@ -12,7 +12,6 @@ from lucidshark.detection.languages import (
     detect_languages,
 )
 from lucidshark.detection.frameworks import (
-    _get_csharp_dependencies,
     _parse_csproj_deps,
     detect_frameworks,
 )
@@ -60,9 +59,7 @@ class TestCSharpVersionDetection:
     def test_from_global_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            (project_root / "global.json").write_text(
-                '{"sdk": {"version": "8.0.100"}}'
-            )
+            (project_root / "global.json").write_text('{"sdk": {"version": "8.0.100"}}')
             version = _detect_csharp_version(project_root)
             assert version == "8.0"
 
@@ -101,9 +98,7 @@ class TestCSharpVersionDetection:
     def test_prefers_global_json_over_csproj(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            (project_root / "global.json").write_text(
-                '{"sdk": {"version": "9.0.100"}}'
-            )
+            (project_root / "global.json").write_text('{"sdk": {"version": "9.0.100"}}')
             (project_root / "MyApp.csproj").write_text(
                 "<Project>\n"
                 "  <PropertyGroup>\n"

--- a/tests/unit/detection/test_languages.py
+++ b/tests/unit/detection/test_languages.py
@@ -573,12 +573,12 @@ class TestDetectPhpVersion:
         """Test detecting PHP by composer.json marker file."""
         (tmp_path / "composer.json").write_text("{}")
         languages = detect_languages(tmp_path)
-        lang_names = [l.name for l in languages]
+        lang_names = [lang.name for lang in languages]
         assert "php" in lang_names
 
     def test_detect_php_by_extension(self, tmp_path: Path) -> None:
         """Test detecting PHP by .php file extension."""
         (tmp_path / "index.php").write_text("<?php echo 'hello'; ?>")
         languages = detect_languages(tmp_path)
-        lang_names = [l.name for l in languages]
+        lang_names = [lang.name for lang in languages]
         assert "php" in lang_names

--- a/tests/unit/plugins/coverage/test_gcov.py
+++ b/tests/unit/plugins/coverage/test_gcov.py
@@ -164,12 +164,7 @@ class TestGcovMeasureCoverage:
             project_root = Path(tmpdir)
 
             lcov_content = (
-                "SF:/project/src/lib.c\n"
-                "DA:1,1\n"
-                "DA:2,1\n"
-                "LF:2\n"
-                "LH:2\n"
-                "end_of_record\n"
+                "SF:/project/src/lib.c\nDA:1,1\nDA:2,1\nLF:2\nLH:2\nend_of_record\n"
             )
             (project_root / "lcov.info").write_text(lcov_content)
 
@@ -192,13 +187,7 @@ class TestGcovMeasureCoverage:
             build_dir.mkdir()
             (build_dir / "CMakeCache.txt").touch()
 
-            lcov_content = (
-                "SF:/project/src/main.c\n"
-                "DA:1,1\n"
-                "LF:1\n"
-                "LH:1\n"
-                "end_of_record\n"
-            )
+            lcov_content = "SF:/project/src/main.c\nDA:1,1\nLF:1\nLH:1\nend_of_record\n"
             (build_dir / "coverage.info").write_text(lcov_content)
 
             context = MagicMock()
@@ -217,12 +206,7 @@ class TestGcovMeasureCoverage:
 
             # Create coverage.info in both root and build dir
             root_content = (
-                "SF:/project/src/main.c\n"
-                "DA:1,1\n"
-                "DA:2,1\n"
-                "LF:2\n"
-                "LH:2\n"
-                "end_of_record\n"
+                "SF:/project/src/main.c\nDA:1,1\nDA:2,1\nLF:2\nLH:2\nend_of_record\n"
             )
             (project_root / "coverage.info").write_text(root_content)
 
@@ -230,11 +214,7 @@ class TestGcovMeasureCoverage:
             build_dir.mkdir()
             (build_dir / "CMakeCache.txt").touch()
             build_content = (
-                "SF:/project/src/main.c\n"
-                "DA:1,1\n"
-                "LF:1\n"
-                "LH:1\n"
-                "end_of_record\n"
+                "SF:/project/src/main.c\nDA:1,1\nLF:1\nLH:1\nend_of_record\n"
             )
             (build_dir / "coverage.info").write_text(build_content)
 
@@ -453,11 +433,7 @@ class TestParseLcovInfo:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             info_file = project_root / "coverage.info"
-            content = (
-                f"SF:{project_root}/src/main.c\n"
-                "DA:1,1\n"
-                "end_of_record\n"
-            )
+            content = f"SF:{project_root}/src/main.c\nDA:1,1\nend_of_record\n"
             info_file.write_text(content)
 
             result = plugin._parse_lcov_info(info_file, project_root, 80.0)
@@ -470,11 +446,7 @@ class TestParseLcovInfo:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             info_file = project_root / "coverage.info"
-            content = (
-                "SF:/external/path/lib.c\n"
-                "DA:1,1\n"
-                "end_of_record\n"
-            )
+            content = "SF:/external/path/lib.c\nDA:1,1\nend_of_record\n"
             info_file.write_text(content)
 
             result = plugin._parse_lcov_info(info_file, project_root, 80.0)

--- a/tests/unit/plugins/coverage/test_phpunit_coverage.py
+++ b/tests/unit/plugins/coverage/test_phpunit_coverage.py
@@ -10,7 +10,7 @@ import tempfile
 import textwrap
 from pathlib import Path
 
-from lucidshark.core.models import ScanContext, Severity, ToolDomain
+from lucidshark.core.models import ScanContext, ToolDomain
 from lucidshark.plugins.coverage.phpunit_coverage import (
     PhpunitCoveragePlugin,
     CLOVER_PATHS,

--- a/tests/unit/plugins/coverage/test_scoverage.py
+++ b/tests/unit/plugins/coverage/test_scoverage.py
@@ -373,7 +373,15 @@ class TestScoverageSourcePathResolution:
                 project_root, "com/example/Missing.scala"
             )
             # Should return best guess
-            expected = project_root / "src" / "main" / "scala" / "com" / "example" / "Missing.scala"
+            expected = (
+                project_root
+                / "src"
+                / "main"
+                / "scala"
+                / "com"
+                / "example"
+                / "Missing.scala"
+            )
             assert resolved == expected
 
 

--- a/tests/unit/plugins/coverage/test_simplecov.py
+++ b/tests/unit/plugins/coverage/test_simplecov.py
@@ -9,8 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lucidshark.core.models import Severity, ToolDomain
-from lucidshark.plugins.coverage.base import CoverageResult
+from lucidshark.core.models import ToolDomain
 from lucidshark.plugins.coverage.simplecov import SimpleCovPlugin
 
 
@@ -145,9 +144,7 @@ class TestSimpleCovParseResultset:
             resultset = Path(tmpdir) / "resultset.json"
             data = {
                 "RSpec": {
-                    "coverage": {
-                        f"{tmpdir}/lib/example.rb": [None, 1, 1, 0, None, 1]
-                    }
+                    "coverage": {f"{tmpdir}/lib/example.rb": [None, 1, 1, 0, None, 1]}
                 }
             }
             resultset.write_text(json.dumps(data))
@@ -165,16 +162,8 @@ class TestSimpleCovParseResultset:
             project_root = Path(tmpdir)
             resultset = Path(tmpdir) / "resultset.json"
             data = {
-                "RSpec": {
-                    "coverage": {
-                        f"{tmpdir}/lib/example.rb": [None, 1, 0, 0]
-                    }
-                },
-                "Minitest": {
-                    "coverage": {
-                        f"{tmpdir}/lib/example.rb": [None, 0, 1, 0]
-                    }
-                },
+                "RSpec": {"coverage": {f"{tmpdir}/lib/example.rb": [None, 1, 0, 0]}},
+                "Minitest": {"coverage": {f"{tmpdir}/lib/example.rb": [None, 0, 1, 0]}},
             }
             resultset.write_text(json.dumps(data))
 
@@ -192,9 +181,7 @@ class TestSimpleCovParseResultset:
             resultset.write_text("{}")
 
             plugin = SimpleCovPlugin()
-            result = plugin._parse_resultset(
-                resultset, Path(tmpdir), threshold=80.0
-            )
+            result = plugin._parse_resultset(resultset, Path(tmpdir), threshold=80.0)
             assert result.total_lines == 0
             assert result.covered_lines == 0
 
@@ -204,9 +191,7 @@ class TestSimpleCovParseResultset:
             resultset.write_text("not json")
 
             plugin = SimpleCovPlugin()
-            result = plugin._parse_resultset(
-                resultset, Path(tmpdir), threshold=80.0
-            )
+            result = plugin._parse_resultset(resultset, Path(tmpdir), threshold=80.0)
             assert result.total_lines == 0
 
 
@@ -219,11 +204,7 @@ class TestSimpleCovCoverageThreshold:
             resultset = Path(tmpdir) / "resultset.json"
             # 50% coverage (2 of 4 lines covered)
             data = {
-                "RSpec": {
-                    "coverage": {
-                        f"{tmpdir}/lib/example.rb": [None, 1, 1, 0, 0]
-                    }
-                }
+                "RSpec": {"coverage": {f"{tmpdir}/lib/example.rb": [None, 1, 1, 0, 0]}}
             }
             resultset.write_text(json.dumps(data))
 
@@ -240,11 +221,7 @@ class TestSimpleCovCoverageThreshold:
             resultset = Path(tmpdir) / "resultset.json"
             # 100% coverage
             data = {
-                "RSpec": {
-                    "coverage": {
-                        f"{tmpdir}/lib/example.rb": [None, 1, 1, 1, 1]
-                    }
-                }
+                "RSpec": {"coverage": {f"{tmpdir}/lib/example.rb": [None, 1, 1, 1, 1]}}
             }
             resultset.write_text(json.dumps(data))
 
@@ -264,9 +241,7 @@ class TestSimpleCovMissingLines:
             resultset = Path(tmpdir) / "resultset.json"
             data = {
                 "RSpec": {
-                    "coverage": {
-                        f"{tmpdir}/lib/example.rb": [None, 1, 0, 1, 0, None]
-                    }
+                    "coverage": {f"{tmpdir}/lib/example.rb": [None, 1, 0, 1, 0, None]}
                 }
             }
             resultset.write_text(json.dumps(data))

--- a/tests/unit/plugins/formatters/test_rubocop_format.py
+++ b/tests/unit/plugins/formatters/test_rubocop_format.py
@@ -63,10 +63,12 @@ class TestRubocopFormatterCheck:
                 enabled_domains=[ToolDomain.FORMATTING],
             )
 
-            output = json.dumps({
-                "files": [{"path": "test.rb", "offenses": []}],
-                "summary": {"offense_count": 0},
-            })
+            output = json.dumps(
+                {
+                    "files": [{"path": "test.rb", "offenses": []}],
+                    "summary": {"offense_count": 0},
+                }
+            )
             result = make_completed_process(0, output)
             with (
                 patch.object(
@@ -92,31 +94,33 @@ class TestRubocopFormatterCheck:
                 enabled_domains=[ToolDomain.FORMATTING],
             )
 
-            output = json.dumps({
-                "files": [
-                    {
-                        "path": "test.rb",
-                        "offenses": [
-                            {
-                                "severity": "convention",
-                                "message": "Surrounding space missing for operator `=`.",
-                                "cop_name": "Layout/SpaceAroundOperators",
-                                "corrected": False,
-                                "correctable": True,
-                                "location": {
-                                    "start_line": 1,
-                                    "start_column": 2,
-                                    "last_line": 1,
-                                    "last_column": 2,
-                                    "line": 1,
-                                    "column": 2,
-                                },
-                            }
-                        ],
-                    }
-                ],
-                "summary": {"offense_count": 1},
-            })
+            output = json.dumps(
+                {
+                    "files": [
+                        {
+                            "path": "test.rb",
+                            "offenses": [
+                                {
+                                    "severity": "convention",
+                                    "message": "Surrounding space missing for operator `=`.",
+                                    "cop_name": "Layout/SpaceAroundOperators",
+                                    "corrected": False,
+                                    "correctable": True,
+                                    "location": {
+                                        "start_line": 1,
+                                        "start_column": 2,
+                                        "last_line": 1,
+                                        "last_column": 2,
+                                        "line": 1,
+                                        "column": 2,
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                    "summary": {"offense_count": 1},
+                }
+            )
             result = make_completed_process(1, output)
             with (
                 patch.object(
@@ -150,32 +154,36 @@ class TestRubocopFormatterParseOutput:
 
     def test_parse_no_offenses(self) -> None:
         formatter = RubocopFormatter()
-        output = json.dumps({
-            "files": [{"path": "test.rb", "offenses": []}],
-            "summary": {"offense_count": 0},
-        })
+        output = json.dumps(
+            {
+                "files": [{"path": "test.rb", "offenses": []}],
+                "summary": {"offense_count": 0},
+            }
+        )
         issues = formatter._parse_output(output, Path("/project"))
         assert issues == []
 
     def test_parse_with_offenses(self) -> None:
         formatter = RubocopFormatter()
-        output = json.dumps({
-            "files": [
-                {
-                    "path": "test.rb",
-                    "offenses": [
-                        {
-                            "severity": "convention",
-                            "message": "Bad indentation",
-                            "cop_name": "Layout/IndentationWidth",
-                            "corrected": False,
-                            "correctable": True,
-                            "location": {"line": 5, "column": 1},
-                        }
-                    ],
-                }
-            ]
-        })
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "test.rb",
+                        "offenses": [
+                            {
+                                "severity": "convention",
+                                "message": "Bad indentation",
+                                "cop_name": "Layout/IndentationWidth",
+                                "corrected": False,
+                                "correctable": True,
+                                "location": {"line": 5, "column": 1},
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
         issues = formatter._parse_output(output, Path("/project"))
         assert len(issues) == 1
         assert issues[0].source_tool == "rubocop_format"
@@ -183,32 +191,34 @@ class TestRubocopFormatterParseOutput:
 
     def test_parse_multiple_files(self) -> None:
         formatter = RubocopFormatter()
-        output = json.dumps({
-            "files": [
-                {
-                    "path": "a.rb",
-                    "offenses": [
-                        {
-                            "cop_name": "Layout/A",
-                            "message": "a",
-                            "correctable": True,
-                            "location": {"line": 1},
-                        }
-                    ],
-                },
-                {
-                    "path": "b.rb",
-                    "offenses": [
-                        {
-                            "cop_name": "Layout/B",
-                            "message": "b",
-                            "correctable": False,
-                            "location": {"line": 2},
-                        }
-                    ],
-                },
-            ]
-        })
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "a.rb",
+                        "offenses": [
+                            {
+                                "cop_name": "Layout/A",
+                                "message": "a",
+                                "correctable": True,
+                                "location": {"line": 1},
+                            }
+                        ],
+                    },
+                    {
+                        "path": "b.rb",
+                        "offenses": [
+                            {
+                                "cop_name": "Layout/B",
+                                "message": "b",
+                                "correctable": False,
+                                "location": {"line": 2},
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
         issues = formatter._parse_output(output, Path("/project"))
         assert len(issues) == 2
 
@@ -228,22 +238,24 @@ class TestRubocopFormatterFix:
                 enabled_domains=[ToolDomain.FORMATTING],
             )
 
-            output = json.dumps({
-                "files": [
-                    {
-                        "path": "test.rb",
-                        "offenses": [
-                            {
-                                "cop_name": "Layout/SpaceAroundOperators",
-                                "message": "fixed",
-                                "corrected": True,
-                                "correctable": True,
-                                "location": {"line": 1, "column": 2},
-                            }
-                        ],
-                    }
-                ]
-            })
+            output = json.dumps(
+                {
+                    "files": [
+                        {
+                            "path": "test.rb",
+                            "offenses": [
+                                {
+                                    "cop_name": "Layout/SpaceAroundOperators",
+                                    "message": "fixed",
+                                    "corrected": True,
+                                    "correctable": True,
+                                    "location": {"line": 1, "column": 2},
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
             result = make_completed_process(0, output)
             with (
                 patch.object(

--- a/tests/unit/plugins/linters/test_dotnet_format.py
+++ b/tests/unit/plugins/linters/test_dotnet_format.py
@@ -166,7 +166,9 @@ class TestDotnetFormatLinterLint:
             linter = DotnetFormatLinter()
             context = _make_context(project_root)
 
-            stdout = "src/Broken.cs(5,10): error IDE0001: Simplify name [MyApp.csproj]\n"
+            stdout = (
+                "src/Broken.cs(5,10): error IDE0001: Simplify name [MyApp.csproj]\n"
+            )
             result = subprocess.CompletedProcess(
                 args=[], returncode=1, stdout=stdout, stderr=""
             )

--- a/tests/unit/plugins/linters/test_rubocop.py
+++ b/tests/unit/plugins/linters/test_rubocop.py
@@ -156,42 +156,44 @@ class TestRubocopParseOutput:
 
     def test_parse_no_offenses(self) -> None:
         linter = RubocopLinter()
-        output = json.dumps({
-            "files": [
-                {"path": "lib/example.rb", "offenses": []}
-            ],
-            "summary": {"offense_count": 0}
-        })
+        output = json.dumps(
+            {
+                "files": [{"path": "lib/example.rb", "offenses": []}],
+                "summary": {"offense_count": 0},
+            }
+        )
         issues = linter._parse_output(output, Path("/project"))
         assert issues == []
 
     def test_parse_with_offenses(self) -> None:
         linter = RubocopLinter()
-        output = json.dumps({
-            "files": [
-                {
-                    "path": "lib/example.rb",
-                    "offenses": [
-                        {
-                            "severity": "convention",
-                            "message": "Line is too long. [120/80]",
-                            "cop_name": "Layout/LineLength",
-                            "corrected": False,
-                            "correctable": True,
-                            "location": {
-                                "start_line": 10,
-                                "start_column": 1,
-                                "last_line": 10,
-                                "last_column": 120,
-                                "line": 10,
-                                "column": 1,
-                            },
-                        }
-                    ],
-                }
-            ],
-            "summary": {"offense_count": 1}
-        })
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "lib/example.rb",
+                        "offenses": [
+                            {
+                                "severity": "convention",
+                                "message": "Line is too long. [120/80]",
+                                "cop_name": "Layout/LineLength",
+                                "corrected": False,
+                                "correctable": True,
+                                "location": {
+                                    "start_line": 10,
+                                    "start_column": 1,
+                                    "last_line": 10,
+                                    "last_column": 120,
+                                    "line": 10,
+                                    "column": 1,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "summary": {"offense_count": 1},
+            }
+        )
         issues = linter._parse_output(output, Path("/project"))
         assert len(issues) == 1
         issue = issues[0]
@@ -204,37 +206,39 @@ class TestRubocopParseOutput:
 
     def test_parse_multiple_files_and_offenses(self) -> None:
         linter = RubocopLinter()
-        output = json.dumps({
-            "files": [
-                {
-                    "path": "lib/a.rb",
-                    "offenses": [
-                        {
-                            "severity": "warning",
-                            "message": "Unused variable",
-                            "cop_name": "Lint/UselessAssignment",
-                            "corrected": False,
-                            "correctable": False,
-                            "location": {"line": 5, "column": 1},
-                        }
-                    ],
-                },
-                {
-                    "path": "lib/b.rb",
-                    "offenses": [
-                        {
-                            "severity": "error",
-                            "message": "Syntax error",
-                            "cop_name": "Lint/Syntax",
-                            "corrected": False,
-                            "correctable": False,
-                            "location": {"line": 1, "column": 1},
-                        }
-                    ],
-                },
-            ],
-            "summary": {"offense_count": 2}
-        })
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "lib/a.rb",
+                        "offenses": [
+                            {
+                                "severity": "warning",
+                                "message": "Unused variable",
+                                "cop_name": "Lint/UselessAssignment",
+                                "corrected": False,
+                                "correctable": False,
+                                "location": {"line": 5, "column": 1},
+                            }
+                        ],
+                    },
+                    {
+                        "path": "lib/b.rb",
+                        "offenses": [
+                            {
+                                "severity": "error",
+                                "message": "Syntax error",
+                                "cop_name": "Lint/Syntax",
+                                "corrected": False,
+                                "correctable": False,
+                                "location": {"line": 1, "column": 1},
+                            }
+                        ],
+                    },
+                ],
+                "summary": {"offense_count": 2},
+            }
+        )
         issues = linter._parse_output(output, Path("/project"))
         assert len(issues) == 2
 
@@ -304,24 +308,26 @@ class TestRubocopLint:
             assert issues == []
 
     def test_lint_runs_rubocop(self) -> None:
-        output = json.dumps({
-            "files": [
-                {
-                    "path": "test.rb",
-                    "offenses": [
-                        {
-                            "severity": "convention",
-                            "message": "test offense",
-                            "cop_name": "Style/Test",
-                            "corrected": False,
-                            "correctable": True,
-                            "location": {"line": 1, "column": 1},
-                        }
-                    ],
-                }
-            ],
-            "summary": {"offense_count": 1}
-        })
+        output = json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "test.rb",
+                        "offenses": [
+                            {
+                                "severity": "convention",
+                                "message": "test offense",
+                                "cop_name": "Style/Test",
+                                "corrected": False,
+                                "correctable": True,
+                                "location": {"line": 1, "column": 1},
+                            }
+                        ],
+                    }
+                ],
+                "summary": {"offense_count": 1},
+            }
+        )
         linter = RubocopLinter()
         context = ScanContext(
             project_root=Path("/project"),
@@ -351,7 +357,12 @@ class TestRubocopPathFiltering:
             (root / "readme.md").touch()
             (root / "lib").mkdir()
 
-            paths = [root / "app.rb", root / "task.rake", root / "readme.md", root / "lib"]
+            paths = [
+                root / "app.rb",
+                root / "task.rake",
+                root / "readme.md",
+                root / "lib",
+            ]
             filtered = linter._filter_paths(paths)
             assert str(root / "app.rb") in filtered
             assert str(root / "task.rake") in filtered

--- a/tests/unit/plugins/test_runners/test_dotnet_test.py
+++ b/tests/unit/plugins/test_runners/test_dotnet_test.py
@@ -221,23 +221,22 @@ class TestRunTests:
 
     @patch("lucidshark.plugins.test_runners.dotnet_test.run_with_streaming")
     @patch.object(DotnetTestRunner, "ensure_binary")
-    def test_uses_trx_logger(
-        self, mock_binary: MagicMock, mock_run: MagicMock
-    ) -> None:
+    def test_uses_trx_logger(self, mock_binary: MagicMock, mock_run: MagicMock) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             (project_root / "MyApp.csproj").touch()
             mock_binary.return_value = FAKE_BINARY
 
             mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=0,
+                args=[],
+                returncode=0,
                 stdout="Passed! - Failed: 0, Passed: 3, Skipped: 0, Total: 3\n",
                 stderr="",
             )
 
             runner = DotnetTestRunner()
             context = _make_context(project_root)
-            result = runner.run_tests(context)
+            runner.run_tests(context)
 
             # Check that --logger trx was in the command
             call_args = mock_run.call_args
@@ -260,7 +259,8 @@ class TestRunTests:
             mock_binary.return_value = FAKE_BINARY
 
             mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=0,
+                args=[],
+                returncode=0,
                 stdout="Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1\n",
                 stderr="",
             )

--- a/tests/unit/plugins/test_runners/test_phpunit.py
+++ b/tests/unit/plugins/test_runners/test_phpunit.py
@@ -6,7 +6,6 @@ requiring actual PHPUnit installation.
 
 from __future__ import annotations
 
-import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/unit/plugins/test_runners/test_rspec.py
+++ b/tests/unit/plugins/test_runners/test_rspec.py
@@ -66,36 +66,38 @@ class TestRspecJsonParsing:
 
     def test_parse_all_passing(self) -> None:
         runner = RspecRunner()
-        output = json.dumps({
-            "version": "3.12.0",
-            "examples": [
-                {
-                    "id": "./spec/user_spec.rb[1:1]",
-                    "description": "is valid",
-                    "full_description": "User is valid",
-                    "status": "passed",
-                    "file_path": "./spec/user_spec.rb",
-                    "line_number": 5,
-                    "run_time": 0.012,
+        output = json.dumps(
+            {
+                "version": "3.12.0",
+                "examples": [
+                    {
+                        "id": "./spec/user_spec.rb[1:1]",
+                        "description": "is valid",
+                        "full_description": "User is valid",
+                        "status": "passed",
+                        "file_path": "./spec/user_spec.rb",
+                        "line_number": 5,
+                        "run_time": 0.012,
+                    },
+                    {
+                        "id": "./spec/user_spec.rb[1:2]",
+                        "description": "has a name",
+                        "full_description": "User has a name",
+                        "status": "passed",
+                        "file_path": "./spec/user_spec.rb",
+                        "line_number": 10,
+                        "run_time": 0.003,
+                    },
+                ],
+                "summary": {
+                    "duration": 0.015,
+                    "example_count": 2,
+                    "failure_count": 0,
+                    "pending_count": 0,
+                    "errors_outside_of_examples_count": 0,
                 },
-                {
-                    "id": "./spec/user_spec.rb[1:2]",
-                    "description": "has a name",
-                    "full_description": "User has a name",
-                    "status": "passed",
-                    "file_path": "./spec/user_spec.rb",
-                    "line_number": 10,
-                    "run_time": 0.003,
-                },
-            ],
-            "summary": {
-                "duration": 0.015,
-                "example_count": 2,
-                "failure_count": 0,
-                "pending_count": 0,
-                "errors_outside_of_examples_count": 0,
-            },
-        })
+            }
+        )
         result = runner._parse_json_output(output, Path("/project"))
         assert result.passed == 2
         assert result.failed == 0
@@ -104,43 +106,45 @@ class TestRspecJsonParsing:
 
     def test_parse_with_failures(self) -> None:
         runner = RspecRunner()
-        output = json.dumps({
-            "version": "3.12.0",
-            "examples": [
-                {
-                    "id": "./spec/user_spec.rb[1:1]",
-                    "description": "is valid",
-                    "full_description": "User is valid",
-                    "status": "passed",
-                    "file_path": "./spec/user_spec.rb",
-                    "line_number": 5,
-                    "run_time": 0.012,
-                },
-                {
-                    "id": "./spec/user_spec.rb[1:2]",
-                    "description": "validates name",
-                    "full_description": "User validates name",
-                    "status": "failed",
-                    "file_path": "./spec/user_spec.rb",
-                    "line_number": 10,
-                    "run_time": 0.005,
-                    "exception": {
-                        "class": "RSpec::Expectations::ExpectationNotMetError",
-                        "message": "expected true\n     got false",
-                        "backtrace": [
-                            "./spec/user_spec.rb:10:in `block (2 levels) in <top>'"
-                        ],
+        output = json.dumps(
+            {
+                "version": "3.12.0",
+                "examples": [
+                    {
+                        "id": "./spec/user_spec.rb[1:1]",
+                        "description": "is valid",
+                        "full_description": "User is valid",
+                        "status": "passed",
+                        "file_path": "./spec/user_spec.rb",
+                        "line_number": 5,
+                        "run_time": 0.012,
                     },
+                    {
+                        "id": "./spec/user_spec.rb[1:2]",
+                        "description": "validates name",
+                        "full_description": "User validates name",
+                        "status": "failed",
+                        "file_path": "./spec/user_spec.rb",
+                        "line_number": 10,
+                        "run_time": 0.005,
+                        "exception": {
+                            "class": "RSpec::Expectations::ExpectationNotMetError",
+                            "message": "expected true\n     got false",
+                            "backtrace": [
+                                "./spec/user_spec.rb:10:in `block (2 levels) in <top>'"
+                            ],
+                        },
+                    },
+                ],
+                "summary": {
+                    "duration": 0.017,
+                    "example_count": 2,
+                    "failure_count": 1,
+                    "pending_count": 0,
+                    "errors_outside_of_examples_count": 0,
                 },
-            ],
-            "summary": {
-                "duration": 0.017,
-                "example_count": 2,
-                "failure_count": 1,
-                "pending_count": 0,
-                "errors_outside_of_examples_count": 0,
-            },
-        })
+            }
+        )
         result = runner._parse_json_output(output, Path("/project"))
         assert result.passed == 1
         assert result.failed == 1
@@ -153,27 +157,29 @@ class TestRspecJsonParsing:
 
     def test_parse_with_pending(self) -> None:
         runner = RspecRunner()
-        output = json.dumps({
-            "examples": [
-                {
-                    "id": "./spec/a_spec.rb[1:1]",
-                    "description": "pending test",
-                    "full_description": "A pending test",
-                    "status": "pending",
-                    "file_path": "./spec/a_spec.rb",
-                    "line_number": 3,
-                    "run_time": 0.001,
-                    "pending_message": "Not yet implemented",
+        output = json.dumps(
+            {
+                "examples": [
+                    {
+                        "id": "./spec/a_spec.rb[1:1]",
+                        "description": "pending test",
+                        "full_description": "A pending test",
+                        "status": "pending",
+                        "file_path": "./spec/a_spec.rb",
+                        "line_number": 3,
+                        "run_time": 0.001,
+                        "pending_message": "Not yet implemented",
+                    },
+                ],
+                "summary": {
+                    "duration": 0.001,
+                    "example_count": 1,
+                    "failure_count": 0,
+                    "pending_count": 1,
+                    "errors_outside_of_examples_count": 0,
                 },
-            ],
-            "summary": {
-                "duration": 0.001,
-                "example_count": 1,
-                "failure_count": 0,
-                "pending_count": 1,
-                "errors_outside_of_examples_count": 0,
-            },
-        })
+            }
+        )
         result = runner._parse_json_output(output, Path("/project"))
         assert result.passed == 0
         assert result.skipped == 1

--- a/tests/unit/plugins/test_runners/test_sbt.py
+++ b/tests/unit/plugins/test_runners/test_sbt.py
@@ -217,8 +217,12 @@ class TestSbtTestcaseToIssue:
 
             import defusedxml.ElementTree as ET
 
-            testcase_xml = '<testcase classname="com.example.MySpec" name="test" time="0.1"/>'
-            failure_xml = '<failure type="TestFailed" message="oops">stacktrace</failure>'
+            testcase_xml = (
+                '<testcase classname="com.example.MySpec" name="test" time="0.1"/>'
+            )
+            failure_xml = (
+                '<failure type="TestFailed" message="oops">stacktrace</failure>'
+            )
             testcase = ET.fromstring(testcase_xml)
             failure = ET.fromstring(failure_xml)
 
@@ -254,8 +258,12 @@ class TestSbtMergeResults:
         from lucidshark.plugins.test_runners.base import TestResult
 
         plugin = SbtTestRunner()
-        r1 = TestResult(passed=5, failed=1, skipped=2, errors=0, duration_ms=100, tool="sbt")
-        r2 = TestResult(passed=3, failed=2, skipped=0, errors=1, duration_ms=200, tool="sbt")
+        r1 = TestResult(
+            passed=5, failed=1, skipped=2, errors=0, duration_ms=100, tool="sbt"
+        )
+        r2 = TestResult(
+            passed=3, failed=2, skipped=0, errors=1, duration_ms=200, tool="sbt"
+        )
 
         merged = plugin._merge_results(r1, r2)
         assert merged.passed == 8

--- a/tests/unit/plugins/type_checkers/test_dotnet_build.py
+++ b/tests/unit/plugins/type_checkers/test_dotnet_build.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/plugins/type_checkers/test_sorbet.py
+++ b/tests/unit/plugins/type_checkers/test_sorbet.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -129,10 +128,7 @@ class TestSorbetParseOutput:
 
     def test_skips_summary_lines(self) -> None:
         checker = SorbetChecker()
-        output = (
-            "lib/a.rb:5: Type error https://srb.help/7002\n"
-            "Errors: 1\n"
-        )
+        output = "lib/a.rb:5: Type error https://srb.help/7002\nErrors: 1\n"
         issues = checker._parse_output(output, Path("/project"))
         assert len(issues) == 1
 


### PR DESCRIPTION
## Summary

- **Fix critical C++ auto-detection bug**: Language detection used `"cpp"` while the entire plugin system expects `"c++"`, silently breaking C++ scanning when no languages are explicitly configured
- **Fix clang-analyzer/clang-diagnostic severity mapping**: Multi-segment category prefixes like `clang-analyzer` were split incorrectly, causing security-critical checks to get MEDIUM instead of HIGH severity
- **Add missing `.hh`/`.hxx` extensions**: Consistent C++ header extension support across detection, domain_runner, duplo, and CTest location extraction
- **Resolve all linting/formatting/SCA issues**: Fix unused imports, ambiguous variables, formatting violations, and upgrade 5 vulnerable dependencies (langchain-core, requests, PyJWT, Pygments, cryptography)

## Test plan

- [x] All 362 unit tests pass
- [x] LucidShark linting scan: 0 issues
- [x] LucidShark formatting scan: 0 issues
- [x] LucidShark SCA scan: 0 issues