### PR TITLE
fix: Kotlin plugin bugs — duplicate files and unhandled RuntimeError

### DIFF
--- a/src/lucidshark/plugins/formatters/ktlint_format.py
+++ b/src/lucidshark/plugins/formatters/ktlint_format.py
@@ -61,7 +61,7 @@ class KtlintFormatter(FormatterPlugin):
         """
         try:
             jar_path = self.ensure_binary()
-        except FileNotFoundError as e:
+        except (FileNotFoundError, RuntimeError) as e:
             LOGGER.warning(str(e))
             return []
 
@@ -150,7 +150,7 @@ class KtlintFormatter(FormatterPlugin):
         """Apply formatting fixes using ktlint --format."""
         try:
             jar_path = self.ensure_binary()
-        except FileNotFoundError as e:
+        except (FileNotFoundError, RuntimeError) as e:
             LOGGER.warning(str(e))
             return FixResult()
 

--- a/src/lucidshark/plugins/linters/ktlint.py
+++ b/src/lucidshark/plugins/linters/ktlint.py
@@ -238,9 +238,14 @@ class KtlintLinter(LinterPlugin):
         if context.paths:
             search_dirs = list(context.paths)
         else:
-            for src_dir in ["src", "src/main/kotlin", "src/test/kotlin",
+            for src_dir in ["src/main/kotlin", "src/test/kotlin",
                             "src/main/java", "src/test/java"]:
                 src_path = context.project_root / src_dir
+                if src_path.exists():
+                    search_dirs.append(src_path)
+
+            if not search_dirs:
+                src_path = context.project_root / "src"
                 if src_path.exists():
                     search_dirs.append(src_path)
 

--- a/src/lucidshark/plugins/type_checkers/detekt.py
+++ b/src/lucidshark/plugins/type_checkers/detekt.py
@@ -251,18 +251,22 @@ class DetektChecker(TypeCheckerPlugin):
         if context.paths:
             return [p for p in context.paths if p.exists()]
 
-        standard_sources = [
+        specific_sources = [
             "src/main/kotlin",
             "src/test/kotlin",
             "src/main/java",
             "src/test/java",
-            "src",
         ]
 
-        for source in standard_sources:
+        for source in specific_sources:
             source_path = context.project_root / source
             if source_path.exists():
                 source_dirs.append(source_path)
+
+        if not source_dirs:
+            src_path = context.project_root / "src"
+            if src_path.exists():
+                source_dirs.append(src_path)
 
         return source_dirs
 

--- a/tests/unit/plugins/formatters/test_ktlint_format.py
+++ b/tests/unit/plugins/formatters/test_ktlint_format.py
@@ -207,6 +207,18 @@ class TestKtlintFormatterCheck:
             issues = formatter.check(context)
             assert issues == []
 
+    def test_check_runtime_error_from_ensure_binary(self) -> None:
+        """RuntimeError from ensure_binary is caught and returns empty list."""
+        formatter = KtlintFormatter()
+        context = _make_context(Path("/tmp"))
+        with patch.object(
+            formatter,
+            "ensure_binary",
+            side_effect=RuntimeError("Failed to download ktlint JAR"),
+        ):
+            issues = formatter.check(context)
+            assert issues == []
+
     def test_check_timeout(self) -> None:
         """Timeout returns empty list and records skip."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -424,6 +436,20 @@ class TestKtlintFormatterFix:
         context = _make_context(Path("/tmp"))
         with patch.object(
             formatter, "ensure_binary", side_effect=FileNotFoundError("not found")
+        ):
+            result = formatter.fix(context)
+            assert isinstance(result, FixResult)
+            assert result.files_modified == 0
+            assert result.issues_fixed == 0
+
+    def test_fix_runtime_error_from_ensure_binary(self) -> None:
+        """RuntimeError from ensure_binary is caught and returns empty FixResult."""
+        formatter = KtlintFormatter()
+        context = _make_context(Path("/tmp"))
+        with patch.object(
+            formatter,
+            "ensure_binary",
+            side_effect=RuntimeError("Failed to download ktlint JAR"),
         ):
             result = formatter.fix(context)
             assert isinstance(result, FixResult)

--- a/tests/unit/plugins/linters/test_ktlint.py
+++ b/tests/unit/plugins/linters/test_ktlint.py
@@ -314,8 +314,48 @@ class TestKtlintFindKotlinFiles:
 
             linter = KtlintLinter()
             files = linter._find_kotlin_files(context)
-            assert len(files) >= 1
-            assert any("App.kt" in f for f in files)
+            assert len(files) == 1
+            assert files[0].endswith("App.kt")
+
+    def test_no_duplicate_files_with_overlapping_dirs(self) -> None:
+        """Test that files are not duplicated when src and src/main/kotlin both exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            kotlin_dir = Path(tmpdir) / "src" / "main" / "kotlin"
+            kotlin_dir.mkdir(parents=True)
+            (kotlin_dir / "App.kt").touch()
+
+            test_dir = Path(tmpdir) / "src" / "test" / "kotlin"
+            test_dir.mkdir(parents=True)
+            (test_dir / "AppTest.kt").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[],
+                enabled_domains=[],
+            )
+
+            linter = KtlintLinter()
+            files = linter._find_kotlin_files(context)
+            assert len(files) == 2
+            assert len(set(files)) == 2  # no duplicates
+
+    def test_src_fallback_when_no_specific_dirs(self) -> None:
+        """Test src/ is used as fallback only when specific subdirs don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_dir = Path(tmpdir) / "src"
+            src_dir.mkdir()
+            (src_dir / "Main.kt").touch()
+
+            context = ScanContext(
+                project_root=Path(tmpdir),
+                paths=[],
+                enabled_domains=[],
+            )
+
+            linter = KtlintLinter()
+            files = linter._find_kotlin_files(context)
+            assert len(files) == 1
+            assert files[0].endswith("Main.kt")
 
     def test_no_kotlin_files(self) -> None:
         """Test returns empty when no Kotlin files found."""

--- a/tests/unit/plugins/type_checkers/test_detekt.py
+++ b/tests/unit/plugins/type_checkers/test_detekt.py
@@ -345,6 +345,28 @@ class TestDetektFindSourceDirectories:
 
             assert project_root / "src" in source_dirs
 
+    def test_no_duplicate_dirs_with_overlapping_sources(self) -> None:
+        """Test src/ is not added when specific subdirs already exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            (project_root / "src" / "main" / "kotlin").mkdir(parents=True)
+            (project_root / "src" / "test" / "kotlin").mkdir(parents=True)
+
+            context = ScanContext(
+                project_root=project_root,
+                paths=[],
+                enabled_domains=[],
+            )
+
+            checker = DetektChecker()
+            source_dirs = checker._find_source_directories(context)
+
+            assert project_root / "src" / "main" / "kotlin" in source_dirs
+            assert project_root / "src" / "test" / "kotlin" in source_dirs
+            # src/ should NOT be included since specific subdirs exist
+            assert project_root / "src" not in source_dirs
+
 
 class TestDetektFindConfigFile:
     """Tests for _find_config_file."""


### PR DESCRIPTION
## Summary
- **ktlint and detekt** listed both parent (`src/`) and child directories (`src/main/kotlin/`, etc.) when discovering source files, causing duplicate file processing and duplicate issues reported. Now `src/` is only used as a fallback when no specific subdirectories exist.
- **ktlint_format** `check()` and `fix()` only caught `FileNotFoundError` from `ensure_binary()`, but `RuntimeError` (JAR download failure) was unhandled and would crash the scan. Now catches both, matching ktlint linter and detekt behavior.

## Test plan
- [x] Added `test_no_duplicate_files_with_overlapping_dirs` for ktlint
- [x] Added `test_src_fallback_when_no_specific_dirs` for ktlint
- [x] Added `test_no_duplicate_dirs_with_overlapping_sources` for detekt
- [x] Added `test_check_runtime_error_from_ensure_binary` for ktlint_format
- [x] Added `test_fix_runtime_error_from_ensure_binary` for ktlint_format
- [x] All 152 Kotlin plugin tests pass