### PR TITLE
fix: resolve multiple bugs in Swift language support

### DIFF
--- a/src/lucidshark/core/domain_runner.py
+++ b/src/lucidshark/core/domain_runner.py
@@ -35,6 +35,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
     "clang_tidy": ["c", "c++"],
     "rubocop": ["ruby"],
     "phpcs": ["php"],
+    "swiftlint": ["swift"],
     # Type checkers
     "mypy": ["python"],
     "pyright": ["python"],
@@ -47,6 +48,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
     "cppcheck": ["c", "c++"],
     "sorbet": ["ruby"],
     "phpstan": ["php"],
+    "swift_compiler": ["swift"],
     # Test runners
     "pytest": ["python"],
     "jest": ["javascript", "typescript"],
@@ -60,6 +62,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
     "ctest": ["c", "c++"],
     "rspec": ["ruby"],
     "phpunit": ["php"],
+    "swift_test": ["swift"],
     # Coverage
     "coverage_py": ["python"],
     "istanbul": ["javascript", "typescript"],
@@ -72,6 +75,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
     "lcov": ["c++"],
     "simplecov": ["ruby"],
     "phpunit_coverage": ["php"],
+    "swift_coverage": ["swift"],
     # Duplication detection
     "duplo": [
         "python",
@@ -84,6 +88,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
         "c++",
         "csharp",
         "go",
+        "swift",
         "ruby",
         "php",
     ],
@@ -98,6 +103,7 @@ PLUGIN_LANGUAGES: Dict[str, List[str]] = {
     "clang_format": ["c", "c++"],
     "rubocop_format": ["ruby"],
     "php_cs_fixer": ["php"],
+    "swiftformat": ["swift"],
 }
 
 # File extension to language mapping
@@ -124,6 +130,7 @@ EXTENSION_LANGUAGE: Dict[str, str] = {
     ".rb": "ruby",
     ".cs": "csharp",
     ".php": "php",
+    ".swift": "swift",
     ".tf": "terraform",
     ".yaml": "yaml",
     ".yml": "yaml",
@@ -263,6 +270,8 @@ def get_domains_for_language(language: str) -> List[str]:
     elif language in ("c", "c++"):
         domains.extend(["type_checking", "testing", "coverage", "formatting"])
     elif language == "php":
+        domains.extend(["type_checking", "testing", "coverage", "formatting"])
+    elif language == "swift":
         domains.extend(["type_checking", "testing", "coverage", "formatting"])
     elif language == "terraform":
         domains = ["iac"]

--- a/src/lucidshark/plugins/test_runners/swift_test.py
+++ b/src/lucidshark/plugins/test_runners/swift_test.py
@@ -91,8 +91,12 @@ class SwiftTestRunner(TestRunnerPlugin):
                 message="swift test timed out after 600 seconds",
             )
             return TestResult(tool="swift_test")
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
             # swift test returns non-zero on failures - that's normal
+            LOGGER.debug(f"swift test completed with: {e}")
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+        except Exception as e:
             LOGGER.debug(f"swift test completed with: {e}")
 
         combined = (stdout or "") + "\n" + (stderr or "")
@@ -142,40 +146,47 @@ class SwiftTestRunner(TestRunnerPlugin):
         return result
 
     def _extract_failed_tests(self, output: str) -> List[Tuple[str, str]]:
-        """Extract failed test names and their failure messages."""
+        """Extract failed test names and their failure messages.
+
+        Parses output sequentially: assertion failures appear before their
+        corresponding "Test Case ... failed" line, so we collect pending
+        assertions and associate them with the next failed test case.
+        """
         failed_tests = []
 
-        # Find failed test cases
-        # Pattern: Test Case '-[Module.Class testMethod]' failed (X seconds).
-        fail_pattern = r"Test Case '-\[(.+?)\]' failed"
-        failed_names = re.findall(fail_pattern, output)
+        # XCTest failure line pattern:
+        #   Test Case '-[Module.Class testMethod]' failed (X seconds).
+        fail_pattern = re.compile(r"Test Case '-\[(.+?)\]' failed")
 
-        # Also handle Swift Testing format:
-        # Test "testName" failed (X seconds).
-        swift_testing_pattern = r'Test "(.+?)" failed'
-        failed_names.extend(re.findall(swift_testing_pattern, output))
+        # Swift Testing failure line pattern:
+        #   Test "testName" failed (X seconds).
+        swift_testing_fail = re.compile(r'Test "(.+?)" failed')
 
-        # Extract assertion failures
-        # XCTAssertEqual failed: ("X") is not equal to ("Y")
+        # Assertion failure pattern (appears before the failed test case line):
+        #   /path/File.swift:25: XCTAssertEqual failed: ("1") is not equal to ("0")
         assertion_pattern = re.compile(
-            r"(.+\.swift):(\d+):\s+(XCT\w+ failed:.+?)(?:\n|$)"
+            r".+\.swift:\d+:\s+(XCT\w+ failed:.+?)$"
         )
 
-        failure_messages = {}
-        for match in assertion_pattern.finditer(output):
-            file_path = match.group(1)
-            line_num = match.group(2)
-            message = match.group(3)
-            # Associate with a test name if possible
-            failure_messages[f"{file_path}:{line_num}"] = message
+        pending_assertions: List[str] = []
 
-        for test_name in failed_names:
-            # Try to find a failure message for this test
-            message = "Test failed"
-            for key, msg in failure_messages.items():
-                message = msg
-                break
-            failed_tests.append((test_name, message))
+        for line in output.splitlines():
+            # Check for assertion failure lines
+            assertion_match = assertion_pattern.match(line.strip())
+            if assertion_match:
+                pending_assertions.append(assertion_match.group(1))
+                continue
+
+            # Check for XCTest failed test case
+            fail_match = fail_pattern.search(line)
+            if not fail_match:
+                fail_match = swift_testing_fail.search(line)
+
+            if fail_match:
+                test_name = fail_match.group(1)
+                message = "; ".join(pending_assertions) if pending_assertions else "Test failed"
+                failed_tests.append((test_name, message))
+                pending_assertions = []
 
         return failed_tests
 

--- a/src/lucidshark/plugins/type_checkers/swift_compiler.py
+++ b/src/lucidshark/plugins/type_checkers/swift_compiler.py
@@ -105,8 +105,12 @@ class SwiftCompilerChecker(TypeCheckerPlugin):
                 message="swift build timed out after 300 seconds",
             )
             return []
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
             # swift build returns non-zero on errors - that's expected
+            LOGGER.debug(f"swift build completed with: {e}")
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+        except Exception as e:
             LOGGER.debug(f"swift build completed with: {e}")
 
         # Swift compiler outputs diagnostics to stderr


### PR DESCRIPTION
## Summary
- **Swift plugins missing from PLUGIN_LANGUAGES**: All 5 Swift plugins (swiftlint, swiftformat, swift_compiler, swift_test, swift_coverage) were absent from the `PLUGIN_LANGUAGES` mapping in `domain_runner.py`. The fallback logic treated them as language-agnostic, causing them to be included for every language project (Python, JS, Go, etc.).
- **Swift missing from `get_domains_for_language()`**: Swift fell through to the default, returning only `["linting", "sast", "sca"]` — excluding type_checking, testing, coverage, and formatting domains.
- **`.swift` missing from `EXTENSION_LANGUAGE`**: Per-file language detection returned `"unknown"` for `.swift` files.
- **`"swift"` missing from duplo's language list**: Duplication detection was not available for Swift projects.
- **`_extract_failed_tests` always assigned the first failure message to every test**: The inner loop unconditionally broke on the first `failure_messages` entry. Fixed by parsing output sequentially — assertion failures appear before their corresponding "Test Case ... failed" line.
- **Exception handlers in `swift_compiler` and `swift_test` lost stdout/stderr**: When `run_with_streaming` raised `CalledProcessError`, the output was silently discarded. Now extracts `e.stdout`/`e.stderr` from the exception.

## Test plan
- [x] All 160 Swift plugin unit tests pass (swiftlint, swiftformat, swift_compiler, swift_test, swift_coverage)
- [ ] Verify Swift projects are no longer scanned by non-Swift tools
- [ ] Verify `get_domains_for_language("swift")` returns all expected domains
- [ ] Verify `detect_language(Path("foo.swift"))` returns `"swift"`