### PR TITLE
fix: Ruby plugin bugs — detection, doc URLs, SimpleCov, init

### DIFF
--- a/src/lucidshark/detection/languages.py
+++ b/src/lucidshark/detection/languages.py
@@ -60,6 +60,8 @@ EXTENSION_MAP = {
     ".scala": "scala",
     ".sc": "scala",
     ".rb": "ruby",
+    ".rake": "ruby",
+    ".gemspec": "ruby",
     ".php": "php",
     ".cs": "csharp",
     ".swift": "swift",

--- a/src/lucidshark/plugins/coverage/simplecov.py
+++ b/src/lucidshark/plugins/coverage/simplecov.py
@@ -24,7 +24,6 @@ LOGGER = get_logger(__name__)
 # Common SimpleCov result file locations
 RESULTSET_PATHS = [
     "coverage/.resultset.json",
-    "coverage/.last_run.json",
 ]
 
 
@@ -36,7 +35,7 @@ class SimpleCovPlugin(CoveragePlugin):
     """
 
     def __init__(self, project_root: Optional[Path] = None):
-        self._project_root = project_root
+        super().__init__(project_root=project_root)
 
     @property
     def name(self) -> str:

--- a/src/lucidshark/plugins/linters/rubocop.py
+++ b/src/lucidshark/plugins/linters/rubocop.py
@@ -83,7 +83,7 @@ class RubocopLinter(LinterPlugin):
     """RuboCop linter plugin for Ruby code analysis."""
 
     def __init__(self, project_root: Optional[Path] = None):
-        self._project_root = project_root
+        super().__init__(project_root=project_root)
 
     @property
     def name(self) -> str:
@@ -255,7 +255,7 @@ class RubocopLinter(LinterPlugin):
                 rule_id=cop_name,
                 title=f"{cop_name}: {message}",
                 description=message,
-                documentation_url=f"https://docs.rubocop.org/rubocop/cops_{cop_name.replace('/', '_').lower()}.html"
+                documentation_url=f"https://docs.rubocop.org/rubocop/cops_{cop_name.split('/')[0].lower()}.html#{cop_name.replace('/', '').lower()}"
                 if "/" in cop_name
                 else None,
                 file_path=file_path,

--- a/src/lucidshark/plugins/test_runners/rspec.py
+++ b/src/lucidshark/plugins/test_runners/rspec.py
@@ -29,7 +29,7 @@ class RspecRunner(TestRunnerPlugin):
     """RSpec test runner plugin for Ruby test execution."""
 
     def __init__(self, project_root: Optional[Path] = None):
-        self._project_root = project_root
+        super().__init__(project_root=project_root)
 
     @property
     def name(self) -> str:

--- a/src/lucidshark/plugins/type_checkers/sorbet.py
+++ b/src/lucidshark/plugins/type_checkers/sorbet.py
@@ -56,7 +56,7 @@ class SorbetChecker(TypeCheckerPlugin):
     """Sorbet type checker plugin for Ruby code analysis."""
 
     def __init__(self, project_root: Optional[Path] = None):
-        self._project_root = project_root
+        super().__init__(project_root=project_root)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Summary
- **Missing extensions in EXTENSION_MAP**: Added `.rake` and `.gemspec` so Ruby is correctly detected in projects using only these file types, and file counts are accurate
- **Broken RuboCop doc URLs**: Fixed URL generation from `cops_style_stringliterals.html` (404) to `cops_style.html#stylestringliterals`
- **Wrong file in SimpleCov RESULTSET_PATHS**: Removed `coverage/.last_run.json` which has a completely different JSON format than `.resultset.json`
- **Missing `super().__init__()`**: RubocopLinter, SorbetChecker, RspecRunner, and SimpleCovPlugin now call `super().__init__()` consistent with other language plugins

## Test plan
- [x] All 108 Ruby plugin tests pass
- [x] All 183 detection tests pass