### PR TITLE
fix: PHP plugin bugs — double-counting, binary lookup, dead code

### DIFF
--- a/src/lucidshark/plugins/coverage/phpunit_coverage.py
+++ b/src/lucidshark/plugins/coverage/phpunit_coverage.py
@@ -51,14 +51,14 @@ class PhpunitCoveragePlugin(CoveragePlugin):
         # Return a dummy path; actual parsing is from files
         import shutil
 
-        phpunit = shutil.which("phpunit")
-        if phpunit:
-            return Path(phpunit)
-
         if self._project_root:
             vendor_bin = self._project_root / "vendor" / "bin" / "phpunit"
             if vendor_bin.exists():
                 return vendor_bin
+
+        phpunit = shutil.which("phpunit")
+        if phpunit:
+            return Path(phpunit)
 
         raise FileNotFoundError(
             "PHPUnit is not installed. "

--- a/src/lucidshark/plugins/test_runners/phpunit.py
+++ b/src/lucidshark/plugins/test_runners/phpunit.py
@@ -156,21 +156,14 @@ class PhpunitRunner(TestRunnerPlugin):
 
         root: Any = tree.getroot()
 
-        # Parse <testsuite> elements
-        for testsuite in root.iter("testsuite"):
+        # Parse only direct-child <testsuite> elements to avoid double counting.
+        # root.iter() would visit nested testsuites too, inflating counts.
+        for testsuite in root.findall("testsuite"):
             tests = int(testsuite.get("tests", "0"))
             failures = int(testsuite.get("failures", "0"))
             errors = int(testsuite.get("errors", "0"))
             skipped_count = int(testsuite.get("skipped", "0"))
             time_val = float(testsuite.get("time", "0"))
-
-            # Only count top-level testsuites to avoid double counting
-            if (
-                testsuite.getparent() is not None
-                if hasattr(testsuite, "getparent")
-                else False
-            ):
-                continue
 
             result.passed += tests - failures - errors - skipped_count
             result.failed += failures

--- a/src/lucidshark/plugins/type_checkers/phpstan.py
+++ b/src/lucidshark/plugins/type_checkers/phpstan.py
@@ -26,23 +26,6 @@ from lucidshark.plugins.type_checkers.base import TypeCheckerPlugin
 
 LOGGER = get_logger(__name__)
 
-# PHPStan level to severity mapping
-# Levels 0-2: low severity (basic checks)
-# Levels 3-5: medium severity (type checking)
-# Levels 6-9: high severity (strict analysis)
-LEVEL_SEVERITY = {
-    0: Severity.LOW,
-    1: Severity.LOW,
-    2: Severity.LOW,
-    3: Severity.MEDIUM,
-    4: Severity.MEDIUM,
-    5: Severity.MEDIUM,
-    6: Severity.HIGH,
-    7: Severity.HIGH,
-    8: Severity.HIGH,
-    9: Severity.HIGH,
-}
-
 
 def _find_phpstan(project_root: Optional[Path] = None) -> Path:
     """Find phpstan binary.

--- a/tests/unit/plugins/test_runners/test_phpunit.py
+++ b/tests/unit/plugins/test_runners/test_phpunit.py
@@ -126,6 +126,44 @@ class TestJunitXmlParsing:
         finally:
             junit_path.unlink()
 
+    def test_parse_nested_testsuites_no_double_counting(self) -> None:
+        """Nested testsuites must not inflate counts."""
+        runner = PhpunitRunner()
+
+        xml_content = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<testsuites>\n"
+            '  <testsuite name="All" tests="5" assertions="8" errors="0" failures="1" skipped="0" time="0.2">\n'
+            '    <testsuite name="Tests\\Unit" tests="3" assertions="5" errors="0" failures="1" skipped="0" time="0.1">\n'
+            '      <testcase name="testA" classname="Tests\\Unit\\FooTest" file="/app/tests/Unit/FooTest.php" line="10" time="0.03"/>\n'
+            '      <testcase name="testB" classname="Tests\\Unit\\FooTest" file="/app/tests/Unit/FooTest.php" line="20" time="0.03">\n'
+            '        <failure type="PHPUnit\\Framework\\ExpectationFailedException" message="Failed">Failed</failure>\n'
+            "      </testcase>\n"
+            '      <testcase name="testC" classname="Tests\\Unit\\FooTest" file="/app/tests/Unit/FooTest.php" line="30" time="0.04"/>\n'
+            "    </testsuite>\n"
+            '    <testsuite name="Tests\\Feature" tests="2" assertions="3" errors="0" failures="0" skipped="0" time="0.1">\n'
+            '      <testcase name="testD" classname="Tests\\Feature\\BarTest" file="/app/tests/Feature/BarTest.php" line="10" time="0.05"/>\n'
+            '      <testcase name="testE" classname="Tests\\Feature\\BarTest" file="/app/tests/Feature/BarTest.php" line="20" time="0.05"/>\n'
+            "    </testsuite>\n"
+            "  </testsuite>\n"
+            "</testsuites>\n"
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".xml", mode="w", delete=False) as f:
+            f.write(xml_content)
+            junit_path = Path(f.name)
+
+        try:
+            result = runner._parse_junit_xml(junit_path, Path("/app"))
+            # Should count only the top-level testsuite (tests=5, failures=1)
+            # NOT 5+3+2=10 tests and 1+1+0=2 failures from all levels
+            assert result.passed == 4
+            assert result.failed == 1
+            assert result.errors == 0
+            assert result.skipped == 0
+        finally:
+            junit_path.unlink()
+
     def test_parse_failing_tests(self) -> None:
         runner = PhpunitRunner()
 


### PR DESCRIPTION
## Summary
- **phpunit**: Fix double-counting of test results with nested `<testsuite>` elements. `root.iter("testsuite")` visited all descendants recursively; the `getparent()` guard was dead code because `defusedxml.ElementTree.Element` lacks that method. Switched to `findall()` to count only direct children, matching Maven's approach.
- **phpunit_coverage**: Fix `ensure_binary()` checking system PATH before vendor/bin — the opposite of every other PHP plugin. Vendor-local binaries should take precedence to avoid version mismatches.
- **phpstan**: Remove unused `LEVEL_SEVERITY` map (defined but never referenced; all issues were hardcoded to `Severity.HIGH`).

## Test plan
- [x] Added regression test for nested testsuites (`test_parse_nested_testsuites_no_double_counting`)
- [x] All 113 PHP plugin tests pass