### PR TITLE
fix: fix 8 bugs in Python plugin support

### DIFF
--- a/src/lucidshark/plugins/coverage/coverage_py.py
+++ b/src/lucidshark/plugins/coverage/coverage_py.py
@@ -97,6 +97,13 @@ class CoveragePyPlugin(CoveragePlugin):
             binary = self.ensure_binary()
         except FileNotFoundError as e:
             LOGGER.warning(str(e))
+            context.record_skip(
+                tool_name=self.name,
+                domain=ToolDomain.COVERAGE,
+                reason=SkipReason.TOOL_NOT_INSTALLED,
+                message=str(e),
+                suggestion="pip install coverage",
+            )
             return CoverageResult(threshold=threshold, tool="coverage_py")
 
         # Check if .coverage data file exists

--- a/src/lucidshark/plugins/type_checkers/mypy.py
+++ b/src/lucidshark/plugins/type_checkers/mypy.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -23,7 +22,7 @@ from lucidshark.core.models import (
 )
 from lucidshark.core.subprocess_runner import run_with_streaming
 from lucidshark.plugins.type_checkers.base import TypeCheckerPlugin
-from lucidshark.plugins.utils import get_cli_version
+from lucidshark.plugins.utils import ensure_python_binary, get_cli_version
 
 LOGGER = get_logger(__name__)
 
@@ -137,7 +136,7 @@ class MypyChecker(TypeCheckerPlugin):
         """Ensure mypy is available.
 
         Checks for mypy in:
-        1. Project's .venv/bin/mypy
+        1. Project's .venv/bin/mypy (with shebang validation)
         2. System PATH
 
         Returns:
@@ -146,19 +145,10 @@ class MypyChecker(TypeCheckerPlugin):
         Raises:
             FileNotFoundError: If mypy is not installed.
         """
-        # Check project venv first
-        if self._project_root:
-            venv_mypy = self._project_root / ".venv" / "bin" / "mypy"
-            if venv_mypy.exists():
-                return venv_mypy
-
-        # Check system PATH
-        mypy_path = shutil.which("mypy")
-        if mypy_path:
-            return Path(mypy_path)
-
-        raise FileNotFoundError(
-            "mypy is not installed. Install it with: pip install mypy"
+        return ensure_python_binary(
+            self._project_root,
+            "mypy",
+            "mypy is not installed. Install it with: pip install mypy",
         )
 
     def check(self, context: ScanContext) -> List[UnifiedIssue]:
@@ -214,7 +204,7 @@ class MypyChecker(TypeCheckerPlugin):
         # Add paths to check (filter to Python files or directories)
         # When only path is project_root (a directory), pass "." so mypy runs from cwd reliably
         if context.paths:
-            python_extensions = {".py", ".pyi", ".pyx"}
+            python_extensions = {".py", ".pyi", ".pyw"}
             filtered = [
                 p
                 for p in context.paths

--- a/src/lucidshark/plugins/type_checkers/pyright.py
+++ b/src/lucidshark/plugins/type_checkers/pyright.py
@@ -24,7 +24,9 @@ from lucidshark.core.models import (
     ToolDomain,
     UnifiedIssue,
 )
+from lucidshark.core.subprocess_runner import run_with_streaming
 from lucidshark.plugins.type_checkers.base import TypeCheckerPlugin
+from lucidshark.plugins.utils import _is_binary_executable
 
 LOGGER = get_logger(__name__)
 
@@ -82,7 +84,7 @@ class PyrightChecker(TypeCheckerPlugin):
         # Check project venv first (pip install pyright)
         if self._project_root:
             venv_pyright = self._project_root / ".venv" / "bin" / "pyright"
-            if venv_pyright.exists():
+            if venv_pyright.exists() and _is_binary_executable(venv_pyright):
                 return venv_pyright
 
         # Check project node_modules
@@ -116,6 +118,13 @@ class PyrightChecker(TypeCheckerPlugin):
             binary = self.ensure_binary()
         except FileNotFoundError as e:
             LOGGER.warning(str(e))
+            context.record_skip(
+                tool_name=self.name,
+                domain=ToolDomain.TYPE_CHECKING,
+                reason=SkipReason.TOOL_NOT_INSTALLED,
+                message=str(e),
+                suggestion="pip install pyright",
+            )
             return []
 
         # Build command
@@ -124,21 +133,53 @@ class PyrightChecker(TypeCheckerPlugin):
             "--outputjson",
         ]
 
-        # Add paths to check
-        paths = [str(p) for p in context.paths] if context.paths else ["."]
+        # Check for strict mode in config
+        if context.config and context.config.pipeline.type_checking:
+            type_config = context.config.pipeline.type_checking
+            for tool in type_config.tools:
+                if tool.strict:
+                    cmd.extend(["--level", "strict"])
+                    break
+
+        # Add paths to check (filter to Python files or directories)
+        python_extensions = {".py", ".pyi", ".pyw"}
+        if context.paths:
+            filtered = [
+                p
+                for p in context.paths
+                if p.is_dir() or p.suffix.lower() in python_extensions
+            ]
+            if not filtered:
+                LOGGER.debug(
+                    "No Python files or directories in scan paths, skipping pyright"
+                )
+                context.record_skip(
+                    tool_name=self.name,
+                    domain=ToolDomain.TYPE_CHECKING,
+                    reason=SkipReason.NO_APPLICABLE_FILES,
+                    message="No Python files or directories in scan paths",
+                )
+                return []
+            if (
+                len(filtered) == 1
+                and filtered[0].resolve() == context.project_root.resolve()
+            ):
+                paths = ["."]
+            else:
+                paths = [p.as_posix() for p in filtered]
+        else:
+            paths = ["."]
         cmd.extend(paths)
 
         LOGGER.debug(f"Running: {' '.join(cmd)}")
 
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=str(context.project_root),
-                timeout=180,  # 3 minute timeout
+            result = run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name="pyright",
+                stream_handler=context.stream_handler,
+                timeout=180,
             )
         except subprocess.TimeoutExpired:
             LOGGER.warning("pyright timed out after 180 seconds")


### PR DESCRIPTION
## Summary

- **mypy**: Fix `.pyx` (Cython) extension to `.pyw` (Windows Python) in path filter — `.pyw` files were silently skipped from type checking
- **mypy**: Use `ensure_python_binary()` with shebang validation instead of reimplementing venv lookup without it — broken venvs from other machines caused confusing runtime errors
- **pyright**: Add shebang validation via `_is_binary_executable()` for venv binaries
- **pyright**: Add `record_skip()` when tool is not installed — skips were going unreported
- **pyright**: Implement strict mode support (`--level strict`) — was declared as supported but silently ignored
- **pyright**: Filter paths to Python files only, consistent with mypy/ruff
- **pyright**: Use `run_with_streaming` instead of `subprocess.run` for real-time output
- **coverage_py**: Add `record_skip()` when tool is not installed

## Test plan

- [ ] Run `lucidshark scan` on a Python project with pyright configured in strict mode — verify `--level strict` is passed
- [ ] Run scan with pyright not installed — verify skip is reported in output
- [ ] Run scan with coverage not installed — verify skip is reported in output
- [ ] Run scan with `.pyw` files present — verify mypy type-checks them
- [ ] Run scan with a stale `.venv` (copied from another machine) — verify mypy and pyright fall back to system PATH instead of failing