### PR TITLE
fix: resolve 5 bugs in Scala language support

### DIFF
--- a/src/lucidshark/detection/languages.py
+++ b/src/lucidshark/detection/languages.py
@@ -446,8 +446,10 @@ def _detect_scala_version(project_root: Path) -> Optional[str]:
             content = build_sbt.read_text()
             # Match patterns like: scalaVersion := "3.3.1"
             # or: ThisBuild / scalaVersion := "2.13.12"
+            # or: scalaVersion in ThisBuild := "2.13.12" (older sbt 0.13 syntax)
             match = re.search(
-                r'scalaVersion\s*:=\s*["\'](\d+\.\d+(?:\.\d+)?)["\']', content
+                r'scalaVersion\s*(?:in\s+\w+\s*)?\s*:=\s*["\'](\d+\.\d+(?:\.\d+)?)["\']',
+                content,
             )
             if match:
                 return match.group(1)

--- a/src/lucidshark/plugins/formatters/scalafmt.py
+++ b/src/lucidshark/plugins/formatters/scalafmt.py
@@ -185,6 +185,9 @@ class ScalafmtFormatter(FormatterPlugin):
         if not paths:
             return FixResult()
 
+        # Get pre-fix issues
+        pre_issues = self.check(context)
+
         cmd = [str(binary)] + paths
 
         try:
@@ -199,8 +202,12 @@ class ScalafmtFormatter(FormatterPlugin):
             LOGGER.error(f"Failed to run scalafmt: {e}")
             return FixResult()
 
+        # Get post-fix issues
+        post_issues = self.check(context)
+
+        fixed_count = len(pre_issues) - len(post_issues)
         return FixResult(
-            files_modified=len(paths),
-            issues_fixed=0,
-            issues_remaining=0,
+            files_modified=max(fixed_count, 0),
+            issues_fixed=max(fixed_count, 0),
+            issues_remaining=len(post_issues),
         )

--- a/src/lucidshark/plugins/linters/scalafix.py
+++ b/src/lucidshark/plugins/linters/scalafix.py
@@ -126,12 +126,12 @@ class ScalafixLinter(LinterPlugin):
 
         LOGGER.debug(f"Running: {' '.join(cmd[:10])}...")
 
-        stdout = self._run_linter_command(cmd, context, timeout=120)
-        if stdout is None:
+        output = self._run_linter_command_with_stderr(cmd, context, timeout=120)
+        if output is None:
             return []
 
         # Parse output
-        issues = self._parse_output(stdout, context.project_root)
+        issues = self._parse_output(output, context.project_root)
 
         LOGGER.info(f"Scalafix found {len(issues)} issues")
         return issues
@@ -172,6 +172,44 @@ class ScalafixLinter(LinterPlugin):
         post_issues = self.lint(context)
 
         return self._calculate_fix_stats(pre_issues, post_issues)
+
+    def _run_linter_command_with_stderr(
+        self,
+        cmd: List[str],
+        context: ScanContext,
+        timeout: int = 120,
+    ) -> Optional[str]:
+        """Run a linter command and return combined stdout + stderr.
+
+        Scalafix may output diagnostics to either stream, so both are captured.
+        """
+        try:
+            result = run_with_streaming(
+                cmd=cmd,
+                cwd=context.project_root,
+                tool_name=self.name,
+                stream_handler=context.stream_handler,
+                timeout=timeout,
+            )
+            return (result.stdout or "") + "\n" + (result.stderr or "")
+        except subprocess.TimeoutExpired:
+            LOGGER.warning(f"scalafix timed out after {timeout} seconds")
+            context.record_skip(
+                tool_name=self.name,
+                domain=ToolDomain.LINTING,
+                reason=SkipReason.EXECUTION_FAILED,
+                message=f"scalafix timed out after {timeout} seconds",
+            )
+            return None
+        except Exception as e:
+            LOGGER.error(f"Failed to run scalafix: {e}")
+            context.record_skip(
+                tool_name=self.name,
+                domain=ToolDomain.LINTING,
+                reason=SkipReason.EXECUTION_FAILED,
+                message=f"Failed to run scalafix: {e}",
+            )
+            return None
 
     def _find_scala_files(self, context: ScanContext) -> List[str]:
         """Find Scala source files to check."""

--- a/src/lucidshark/plugins/test_runners/sbt.py
+++ b/src/lucidshark/plugins/test_runners/sbt.py
@@ -107,6 +107,10 @@ class SbtTestRunner(TestRunnerPlugin):
         else:
             return self._run_gradle_tests(binary, context)
 
+    def _tool_label(self, build_system: str) -> str:
+        """Return the tool label for a given build system."""
+        return build_system
+
     def _run_sbt_tests(
         self, binary: Path, context: ScanContext
     ) -> TestResult:
@@ -137,7 +141,7 @@ class SbtTestRunner(TestRunnerPlugin):
             LOGGER.debug(f"sbt test completed with: {e}")
 
         # Parse JUnit XML reports from sbt's test-reports directory
-        return self._parse_sbt_reports(context.project_root)
+        return self._parse_sbt_reports(context.project_root, tool_name="sbt")
 
     def _run_maven_tests(
         self, binary: Path, context: ScanContext
@@ -163,11 +167,11 @@ class SbtTestRunner(TestRunnerPlugin):
                 reason=SkipReason.EXECUTION_FAILED,
                 message="Maven test timed out after 600 seconds",
             )
-            return TestResult(tool="sbt")
+            return TestResult(tool="maven")
         except Exception as e:
             LOGGER.debug(f"Maven test completed with: {e}")
 
-        return self._parse_surefire_reports(context.project_root)
+        return self._parse_surefire_reports(context.project_root, tool_name="maven")
 
     def _run_gradle_tests(
         self, binary: Path, context: ScanContext
@@ -193,18 +197,20 @@ class SbtTestRunner(TestRunnerPlugin):
                 reason=SkipReason.EXECUTION_FAILED,
                 message="Gradle test timed out after 600 seconds",
             )
-            return TestResult(tool="sbt")
+            return TestResult(tool="gradle")
         except Exception as e:
             LOGGER.debug(f"Gradle test completed with: {e}")
 
-        return self._parse_gradle_reports(context.project_root)
+        return self._parse_gradle_reports(context.project_root, tool_name="gradle")
 
-    def _parse_sbt_reports(self, project_root: Path) -> TestResult:
+    def _parse_sbt_reports(
+        self, project_root: Path, tool_name: str = "sbt"
+    ) -> TestResult:
         """Parse sbt JUnit XML test reports.
 
         sbt generates JUnit XML reports in target/test-reports/ by default.
         """
-        result = TestResult(tool="sbt")
+        result = TestResult(tool=tool_name)
 
         report_dirs = [
             project_root / "target" / "test-reports",
@@ -223,31 +229,43 @@ class SbtTestRunner(TestRunnerPlugin):
 
         for reports_dir in report_dirs:
             if reports_dir.exists():
-                dir_result = self._parse_junit_xml_dir(reports_dir, project_root)
+                dir_result = self._parse_junit_xml_dir(
+                    reports_dir, project_root, tool_name=tool_name
+                )
                 result = self._merge_results(result, dir_result)
 
         return result
 
-    def _parse_surefire_reports(self, project_root: Path) -> TestResult:
+    def _parse_surefire_reports(
+        self, project_root: Path, tool_name: str = "maven"
+    ) -> TestResult:
         """Parse Maven Surefire JUnit XML reports."""
-        result = TestResult(tool="sbt")
+        result = TestResult(tool=tool_name)
         reports_dir = project_root / "target" / "surefire-reports"
 
-        if not reports_dir.exists():
-            for child in project_root.iterdir():
-                child_reports = child / "target" / "surefire-reports"
-                if child_reports.exists():
-                    child_result = self._parse_junit_xml_dir(
-                        child_reports, project_root
-                    )
-                    result = self._merge_results(result, child_result)
-            return result
+        # Parse root module reports if present
+        if reports_dir.exists():
+            dir_result = self._parse_junit_xml_dir(
+                reports_dir, project_root, tool_name=tool_name
+            )
+            result = self._merge_results(result, dir_result)
 
-        return self._parse_junit_xml_dir(reports_dir, project_root)
+        # Also check child modules for multi-module Maven projects
+        for child in project_root.iterdir():
+            child_reports = child / "target" / "surefire-reports"
+            if child_reports.exists():
+                child_result = self._parse_junit_xml_dir(
+                    child_reports, project_root, tool_name=tool_name
+                )
+                result = self._merge_results(result, child_result)
 
-    def _parse_gradle_reports(self, project_root: Path) -> TestResult:
+        return result
+
+    def _parse_gradle_reports(
+        self, project_root: Path, tool_name: str = "gradle"
+    ) -> TestResult:
         """Parse Gradle JUnit XML reports."""
-        result = TestResult(tool="sbt")
+        result = TestResult(tool=tool_name)
 
         report_dirs = [
             project_root / "build" / "test-results" / "test",
@@ -255,25 +273,33 @@ class SbtTestRunner(TestRunnerPlugin):
 
         for reports_dir in report_dirs:
             if reports_dir.exists():
-                dir_result = self._parse_junit_xml_dir(reports_dir, project_root)
+                dir_result = self._parse_junit_xml_dir(
+                    reports_dir, project_root, tool_name=tool_name
+                )
                 result = self._merge_results(result, dir_result)
 
         return result
 
-    def _parse_junit_xml_dir(self, reports_dir: Path, project_root: Path) -> TestResult:
+    def _parse_junit_xml_dir(
+        self, reports_dir: Path, project_root: Path, tool_name: str = "sbt"
+    ) -> TestResult:
         """Parse JUnit XML files from a directory."""
-        result = TestResult(tool="sbt")
+        result = TestResult(tool=tool_name)
 
         for xml_file in reports_dir.glob("TEST-*.xml"):
             try:
-                file_result = self._parse_junit_xml(xml_file, project_root)
+                file_result = self._parse_junit_xml(
+                    xml_file, project_root, tool_name=tool_name
+                )
                 result = self._merge_results(result, file_result)
             except Exception as e:
                 LOGGER.warning(f"Failed to parse {xml_file}: {e}")
 
         return result
 
-    def _parse_junit_xml(self, xml_file: Path, project_root: Path) -> TestResult:
+    def _parse_junit_xml(
+        self, xml_file: Path, project_root: Path, tool_name: str = "sbt"
+    ) -> TestResult:
         """Parse a single JUnit XML file."""
         try:
             tree = ET.parse(xml_file)
@@ -281,14 +307,14 @@ class SbtTestRunner(TestRunnerPlugin):
             assert root is not None
         except Exception as e:
             LOGGER.warning(f"Failed to parse JUnit XML {xml_file}: {e}")
-            return TestResult(tool="sbt")
+            return TestResult(tool=tool_name)
 
         if root.tag == "testsuite":
             testsuite = root
         else:
             found = root.find("testsuite")
             if found is None:
-                return TestResult(tool="sbt")
+                return TestResult(tool=tool_name)
             testsuite = found
 
         tests_total = int(testsuite.get("tests", 0))
@@ -304,7 +330,7 @@ class SbtTestRunner(TestRunnerPlugin):
             skipped=skipped,
             errors=errors,
             duration_ms=duration_ms,
-            tool="sbt",
+            tool=tool_name,
         )
 
         for testcase in testsuite.iter("testcase"):
@@ -313,13 +339,13 @@ class SbtTestRunner(TestRunnerPlugin):
 
             if failure is not None:
                 issue = self._testcase_to_issue(
-                    testcase, failure, project_root, "failed"
+                    testcase, failure, project_root, "failed", tool_name=tool_name
                 )
                 if issue:
                     result.issues.append(issue)
             elif error is not None:
                 issue = self._testcase_to_issue(
-                    testcase, error, project_root, "error"
+                    testcase, error, project_root, "error", tool_name=tool_name
                 )
                 if issue:
                     result.issues.append(issue)
@@ -332,6 +358,7 @@ class SbtTestRunner(TestRunnerPlugin):
         failure_elem: Element,
         project_root: Path,
         outcome: str,
+        tool_name: str = "sbt",
     ) -> Optional[UnifiedIssue]:
         """Convert JUnit XML testcase failure to UnifiedIssue."""
         try:
@@ -376,7 +403,7 @@ class SbtTestRunner(TestRunnerPlugin):
             return UnifiedIssue(
                 id=issue_id,
                 domain=ToolDomain.TESTING,
-                source_tool="sbt",
+                source_tool=tool_name,
                 severity=severity,
                 rule_id=outcome,
                 title=title,
@@ -425,7 +452,7 @@ class SbtTestRunner(TestRunnerPlugin):
             errors=result1.errors + result2.errors,
             duration_ms=result1.duration_ms + result2.duration_ms,
             issues=result1.issues + result2.issues,
-            tool="sbt",
+            tool=result1.tool,
         )
 
     def _generate_issue_id(self, test_id: str, message: str) -> str:

--- a/tests/unit/detection/test_scala_detection.py
+++ b/tests/unit/detection/test_scala_detection.py
@@ -86,6 +86,12 @@ class TestDetectScalaVersion:
         version = _detect_scala_version(tmp_path)
         assert version == "3.3.1"
 
+    def test_from_build_sbt_in_this_build(self, tmp_path: Path) -> None:
+        """Test older sbt 0.13 syntax: scalaVersion in ThisBuild := ..."""
+        (tmp_path / "build.sbt").write_text('scalaVersion in ThisBuild := "2.13.12"')
+        version = _detect_scala_version(tmp_path)
+        assert version == "2.13.12"
+
     def test_no_version_found(self, tmp_path: Path) -> None:
         version = _detect_scala_version(tmp_path)
         assert version is None

--- a/tests/unit/plugins/formatters/test_scalafmt.py
+++ b/tests/unit/plugins/formatters/test_scalafmt.py
@@ -160,3 +160,53 @@ class TestScalafmtFix:
 
                 result = plugin.fix(context)
                 assert result.files_modified == 0
+
+    def test_fix_reports_correct_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_dir = project_root / "src"
+            src_dir.mkdir()
+            (src_dir / "App.scala").write_text("object App {}")
+
+            with patch("shutil.which", return_value="/usr/local/bin/scalafmt"):
+                plugin = ScalafmtFormatter(project_root=project_root)
+                context = MagicMock()
+                context.project_root = project_root
+                context.paths = [src_dir / "App.scala"]
+                context.ignore_patterns = None
+
+                # First check: 1 issue, second check (after fix): 0 issues
+                mock_check_result = MagicMock()
+                mock_check_result.returncode = 1
+                mock_check_result.stdout = "src/App.scala\n"
+                mock_check_result.stderr = ""
+
+                mock_clean_result = MagicMock()
+                mock_clean_result.returncode = 0
+                mock_clean_result.stdout = ""
+                mock_clean_result.stderr = ""
+
+                mock_fix_result = MagicMock()
+                mock_fix_result.returncode = 0
+
+                call_count = 0
+
+                def mock_run(*args, **kwargs):
+                    nonlocal call_count
+                    call_count += 1
+                    cmd = args[0] if args else kwargs.get("cmd", [])
+                    if "--check" in cmd:
+                        # Pre-fix check returns issues, post-fix returns clean
+                        if call_count <= 1:
+                            return mock_check_result
+                        return mock_clean_result
+                    return mock_fix_result
+
+                with patch(
+                    "lucidshark.plugins.formatters.scalafmt.run_with_streaming",
+                    side_effect=mock_run,
+                ):
+                    result = plugin.fix(context)
+                    assert result.issues_fixed == 1
+                    assert result.files_modified == 1
+                    assert result.issues_remaining == 0

--- a/tests/unit/plugins/linters/test_scalafix.py
+++ b/tests/unit/plugins/linters/test_scalafix.py
@@ -189,6 +189,38 @@ class TestScalafixLint:
                 issues = plugin.lint(context)
                 assert issues == []
 
+    def test_lint_captures_stderr_diagnostics(self) -> None:
+        """Scalafix diagnostics on stderr should be parsed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            src_dir = project_root / "src" / "main" / "scala"
+            src_dir.mkdir(parents=True)
+            (src_dir / "App.scala").write_text("object App")
+
+            with patch("shutil.which", return_value="/usr/local/bin/scalafix"):
+                plugin = ScalafixLinter(project_root=project_root)
+                context = MagicMock()
+                context.project_root = project_root
+                context.paths = None
+                context.ignore_patterns = None
+
+                mock_result = MagicMock()
+                mock_result.returncode = 1
+                mock_result.stdout = ""
+                mock_result.stderr = (
+                    "src/main/scala/App.scala:1:1: error: "
+                    "[DisableSyntax] null is disabled"
+                )
+
+                with patch(
+                    "lucidshark.plugins.linters.scalafix.run_with_streaming",
+                    return_value=mock_result,
+                ):
+                    issues = plugin.lint(context)
+                    assert len(issues) == 1
+                    assert issues[0].severity == Severity.HIGH
+                    assert "DisableSyntax" in issues[0].rule_id
+
 
 class TestScalafixIssueId:
     """Tests for deterministic issue ID generation."""

--- a/tests/unit/plugins/test_runners/test_sbt.py
+++ b/tests/unit/plugins/test_runners/test_sbt.py
@@ -178,6 +178,42 @@ class TestSbtJunitParsing:
 
             assert result.passed == 1
             assert result.failed == 0
+            assert result.tool == "maven"
+
+    def test_parse_surefire_reports_multi_module(self) -> None:
+        """Root + child module reports should both be parsed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            root_report_dir = project_root / "target" / "surefire-reports"
+            root_report_dir.mkdir(parents=True)
+            (root_report_dir / "TEST-RootSpec.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="RootSpec" tests="1" failures="0" errors="0" skipped="0" time="0.1">
+    <testcase classname="RootSpec" name="test" time="0.1"/>
+</testsuite>"""
+            )
+
+            child_report_dir = (
+                project_root / "child-module" / "target" / "surefire-reports"
+            )
+            child_report_dir.mkdir(parents=True)
+            (child_report_dir / "TEST-ChildSpec.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="ChildSpec" tests="2" failures="1" errors="0" skipped="0" time="0.2">
+    <testcase classname="ChildSpec" name="pass" time="0.1"/>
+    <testcase classname="ChildSpec" name="fail" time="0.1">
+        <failure message="oops"/>
+    </testcase>
+</testsuite>"""
+            )
+
+            plugin = SbtTestRunner(project_root=project_root)
+            result = plugin._parse_surefire_reports(project_root)
+
+            assert result.passed == 2
+            assert result.failed == 1
+            assert result.tool == "maven"
 
     def test_parse_gradle_reports(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -203,6 +239,7 @@ class TestSbtJunitParsing:
             assert result.passed == 0  # 2 total - 1 failure - 0 errors - 1 skipped
             assert result.failed == 1
             assert result.skipped == 1
+            assert result.tool == "gradle"
 
 
 class TestSbtTestcaseToIssue:
@@ -231,6 +268,25 @@ class TestSbtTestcaseToIssue:
 
             assert issue is not None
             assert issue.file_path == test_dir / "MySpec.scala"
+            assert issue.source_tool == "sbt"
+
+    def test_testcase_uses_correct_tool_name(self) -> None:
+        import defusedxml.ElementTree as ET
+
+        testcase_xml = (
+            '<testcase classname="com.example.Spec" name="test" time="0.1"/>'
+        )
+        failure_xml = '<failure type="TestFailed" message="oops"/>'
+        testcase = ET.fromstring(testcase_xml)
+        failure = ET.fromstring(failure_xml)
+
+        plugin = SbtTestRunner()
+        issue = plugin._testcase_to_issue(
+            testcase, failure, Path("/project"), "failed", tool_name="maven"
+        )
+
+        assert issue is not None
+        assert issue.source_tool == "maven"
 
 
 class TestSbtRunTests:
@@ -272,6 +328,16 @@ class TestSbtMergeResults:
         assert merged.errors == 1
         assert merged.duration_ms == 300
         assert merged.tool == "sbt"
+
+    def test_merge_preserves_tool_name(self) -> None:
+        from lucidshark.plugins.test_runners.base import TestResult
+
+        plugin = SbtTestRunner()
+        r1 = TestResult(passed=1, failed=0, tool="maven")
+        r2 = TestResult(passed=2, failed=0, tool="maven")
+
+        merged = plugin._merge_results(r1, r2)
+        assert merged.tool == "maven"
 
 
 class TestSbtExtractLine:


### PR DESCRIPTION
## Summary
- **sbt test runner**: Fix hardcoded `tool="sbt"` — Maven/Gradle test results now correctly report their actual build system name in `TestResult.tool` and `UnifiedIssue.source_tool`
- **sbt surefire reports**: Fix multi-module Maven projects — root and child module `surefire-reports` are now both parsed and merged instead of only one or the other
- **scalafmt formatter**: Fix `fix()` returning `issues_fixed=0` always — now uses pre/post comparison to report accurate fix statistics
- **scalafix linter**: Fix silent data loss — diagnostics on stderr are now captured alongside stdout
- **Scala version detection**: Fix regex to also match older sbt 0.13 syntax (`scalaVersion in ThisBuild := "..."`)

## Test plan
- [x] All 118 Scala-related unit tests pass
- [x] New test: `test_from_build_sbt_in_this_build` — verifies older sbt version syntax detection
- [x] New test: `test_parse_surefire_reports_multi_module` — verifies root + child module merging
- [x] New test: `test_fix_reports_correct_counts` — verifies scalafmt fix statistics
- [x] New test: `test_lint_captures_stderr_diagnostics` — verifies scalafix stderr parsing
- [x] New test: `test_testcase_uses_correct_tool_name` — verifies Maven tool attribution in issues
- [x] New test: `test_merge_preserves_tool_name` — verifies tool name preserved through merging
- [x] Existing tests updated to assert correct `tool` values for surefire/gradle parsers