### PR TITLE
feat: add anonymous opt-out telemetry with PostHog

### DIFF
--- a/lucidshark.spec
+++ b/lucidshark.spec
@@ -37,6 +37,7 @@ a = Analysis(
         'lucidshark.generation',
         'lucidshark.mcp',
         'lucidshark.pipeline',
+        'lucidshark.telemetry',
         'lucidshark.plugins.go_utils',
         # Plugin entry points - linters
         'lucidshark.plugins.linters.ruff',
@@ -131,6 +132,7 @@ a = Analysis(
         'defusedxml',
         'tomli',
         'mcp',
+        'posthog',
     ],
     hookspath=[],
     hooksconfig={},

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ orjson==3.11.7
 packaging==26.0
 pathspec==1.0.4
 pluggy==1.6.0
+posthog>=3.0.0,<4.0.0
 prompt_toolkit==3.0.52
 pycparser==3.0
 pydantic==2.12.5

--- a/src/lucidshark/cli/commands/scan.py
+++ b/src/lucidshark/cli/commands/scan.py
@@ -99,6 +99,9 @@ class ScanCommand(Command):
             # Cache scan results for overview command
             self._save_scan_cache(args, result)
 
+            # Track anonymous telemetry
+            self._track_telemetry(args, config, result)
+
             # Determine output format: CLI > config > default (json)
             if args.format:
                 output_format = args.format
@@ -891,6 +894,80 @@ class ScanCommand(Command):
             LOGGER.debug(f"Saved scan results to {cache_path}")
         except (OSError, TypeError) as e:
             LOGGER.debug(f"Could not save scan cache: {e}")
+
+    def _track_telemetry(
+        self, args: Namespace, config: LucidSharkConfig, result: ScanResult
+    ) -> None:
+        """Send anonymous telemetry for the completed scan.
+
+        Never raises or blocks the CLI.
+
+        Args:
+            args: Parsed CLI arguments.
+            config: Loaded configuration.
+            result: Scan result.
+        """
+        try:
+            from lucidshark.telemetry import track_scan_completed
+
+            # Extract domains
+            domains = result.metadata.executed_domains if result.metadata else []
+
+            # Extract languages from config
+            languages = config.project.languages or []
+
+            # Extract tools used from metadata
+            tools_used = []
+            if result.metadata and result.metadata.scanners_used:
+                for scanner in result.metadata.scanners_used:
+                    tool_name = scanner.get("tool") or scanner.get("name", "")
+                    if tool_name and tool_name not in tools_used:
+                        tools_used.append(tool_name)
+
+            # Extract issue counts
+            total_issues = result.summary.total if result.summary else 0
+            issues_by_severity = result.summary.by_severity if result.summary else {}
+            issues_by_domain = result.summary.by_scanner if result.summary else {}
+
+            # Duration
+            duration_ms = result.metadata.duration_ms if result.metadata else 0
+
+            # Scan mode
+            scan_mode = "full" if getattr(args, "all_files", False) else "incremental"
+
+            # Output format
+            output_format = args.format or config.output.format or "json"
+
+            # Fix mode
+            fix_enabled = getattr(args, "fix", False)
+
+            # Coverage
+            coverage_pct = None
+            if result.coverage_summary:
+                coverage_pct = result.coverage_summary.coverage_percentage
+
+            # Duplication
+            duplication_pct = None
+            if result.duplication_summary:
+                duplication_pct = result.duplication_summary.duplication_percent
+
+            track_scan_completed(
+                domains=domains,
+                languages=languages,
+                tools_used=tools_used,
+                total_issues=total_issues,
+                issues_by_severity=issues_by_severity,
+                issues_by_domain=issues_by_domain,
+                duration_ms=duration_ms,
+                scan_mode=scan_mode,
+                output_format=output_format,
+                fix_enabled=fix_enabled,
+                coverage_percent=coverage_pct,
+                duplication_percent=duplication_pct,
+            )
+        except Exception:
+            # Never let telemetry affect scan results
+            pass
 
     def _check_domain_thresholds(
         self, result: ScanResult, config: LucidSharkConfig, args: Namespace

--- a/src/lucidshark/cli/runner.py
+++ b/src/lucidshark/cli/runner.py
@@ -105,6 +105,15 @@ class CLIRunner:
         # Dispatch to appropriate command handler
         command = getattr(args, "command", None)
 
+        # Track anonymous command usage telemetry
+        if command:
+            try:
+                from lucidshark.telemetry import track_command
+
+                track_command(command)
+            except Exception:
+                pass
+
         if command == "init":
             return self._handle_init(args)
         elif command == "scan":

--- a/src/lucidshark/telemetry.py
+++ b/src/lucidshark/telemetry.py
@@ -1,0 +1,283 @@
+"""Anonymous, opt-out telemetry for LucidShark.
+
+Collects anonymous usage data to help improve the product. All data is
+anonymous - no PII, no source code, no file paths, no IP addresses are stored.
+
+Opt out by setting the environment variable:
+    export LUCIDSHARK_TELEMETRY=0
+
+Or by creating a file at ~/.lucidshark/telemetry-optout
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import platform
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+# PostHog project API key (public, safe to embed - this is a write-only key)
+_POSTHOG_API_KEY = "phc_LucidShark_anonymous_telemetry_key"
+_POSTHOG_HOST = "https://us.i.posthog.com"
+
+_telemetry_client: Optional[Any] = None
+_anonymous_id: Optional[str] = None
+_enabled: Optional[bool] = None
+
+
+def _get_lucidshark_dir() -> Path:
+    """Get the ~/.lucidshark directory path."""
+    return Path.home() / ".lucidshark"
+
+
+def is_enabled() -> bool:
+    """Check if telemetry is enabled.
+
+    Telemetry is enabled by default. It can be disabled by:
+    1. Setting LUCIDSHARK_TELEMETRY=0 (or "false", "no", "off")
+    2. Setting DO_NOT_TRACK=1 (standard env var)
+    3. Creating ~/.lucidshark/telemetry-optout file
+    4. Running in CI (CI=true env var) - CI environments are excluded
+
+    Returns:
+        True if telemetry should be collected.
+    """
+    global _enabled
+    if _enabled is not None:
+        return _enabled
+
+    # Check LUCIDSHARK_TELEMETRY env var
+    telemetry_env = os.environ.get("LUCIDSHARK_TELEMETRY", "").lower().strip()
+    if telemetry_env in ("0", "false", "no", "off"):
+        _enabled = False
+        return False
+
+    # Check DO_NOT_TRACK standard env var
+    if os.environ.get("DO_NOT_TRACK", "").strip() == "1":
+        _enabled = False
+        return False
+
+    # Check CI env var - don't collect from CI runs
+    ci_env = os.environ.get("CI", "").lower().strip()
+    if ci_env in ("true", "1"):
+        _enabled = False
+        return False
+
+    # Check opt-out file
+    optout_file = _get_lucidshark_dir() / "telemetry-optout"
+    if optout_file.exists():
+        _enabled = False
+        return False
+
+    _enabled = True
+    return True
+
+
+def _get_anonymous_id() -> str:
+    """Get or create a stable anonymous identifier.
+
+    Stores a random UUID in ~/.lucidshark/anonymous-id. This ID has no
+    connection to the user's identity - it's purely for counting unique
+    installations.
+
+    Returns:
+        Anonymous UUID string.
+    """
+    global _anonymous_id
+    if _anonymous_id is not None:
+        return _anonymous_id
+
+    id_file = _get_lucidshark_dir() / "anonymous-id"
+
+    try:
+        if id_file.exists():
+            stored_id = id_file.read_text().strip()
+            if stored_id:
+                _anonymous_id = stored_id
+                return stored_id
+    except OSError:
+        pass
+
+    # Generate new ID
+    new_id = str(uuid.uuid4())
+
+    try:
+        id_file.parent.mkdir(parents=True, exist_ok=True)
+        id_file.write_text(new_id)
+    except OSError:
+        pass
+
+    _anonymous_id = new_id
+    return new_id
+
+
+def _get_client() -> Optional[Any]:
+    """Get or initialize the PostHog client.
+
+    Returns:
+        PostHog client instance, or None if unavailable.
+    """
+    global _telemetry_client
+
+    if _telemetry_client is not None:
+        return _telemetry_client
+
+    try:
+        from posthog import Posthog
+
+        client = Posthog(
+            api_key=_POSTHOG_API_KEY,
+            host=_POSTHOG_HOST,
+            sync_mode=False,
+        )
+        # Disable PostHog's own logging to avoid noise
+        client.log = logging.getLogger("posthog")
+        client.log.setLevel(logging.CRITICAL)
+
+        # Register shutdown handler to flush events
+        atexit.register(_shutdown)
+
+        _telemetry_client = client
+        return client
+    except Exception:
+        LOGGER.debug("PostHog client not available, telemetry disabled")
+        return None
+
+
+def _shutdown() -> None:
+    """Flush and shut down the telemetry client."""
+    global _telemetry_client
+    if _telemetry_client is not None:
+        try:
+            _telemetry_client.flush()
+            _telemetry_client.shutdown()
+        except Exception:
+            pass
+        _telemetry_client = None
+
+
+def _get_base_properties() -> Dict[str, Any]:
+    """Get base properties included with every event.
+
+    Returns:
+        Dictionary of anonymous system properties.
+    """
+    from lucidshark import __version__
+
+    return {
+        "lucidshark_version": __version__,
+        "os": platform.system().lower(),
+        "os_version": platform.release(),
+        "arch": platform.machine(),
+        "python_version": platform.python_version(),
+    }
+
+
+def track_event(event_name: str, properties: Optional[Dict[str, Any]] = None) -> None:
+    """Track an anonymous telemetry event.
+
+    This is fire-and-forget - it never raises exceptions or blocks the CLI.
+
+    Args:
+        event_name: Name of the event (e.g., "scan_completed").
+        properties: Optional event properties.
+    """
+    if not is_enabled():
+        return
+
+    try:
+        client = _get_client()
+        if client is None:
+            return
+
+        all_properties = _get_base_properties()
+        if properties:
+            all_properties.update(properties)
+
+        client.capture(
+            distinct_id=_get_anonymous_id(),
+            event=event_name,
+            properties=all_properties,
+        )
+    except Exception:
+        # Never let telemetry crash the CLI
+        LOGGER.debug("Failed to send telemetry event", exc_info=True)
+
+
+def track_command(command_name: str) -> None:
+    """Track a CLI command execution.
+
+    Args:
+        command_name: The command that was run (scan, init, doctor, etc.).
+    """
+    track_event("command_executed", {"command": command_name})
+
+
+def track_scan_completed(
+    domains: List[str],
+    languages: List[str],
+    tools_used: List[str],
+    total_issues: int,
+    issues_by_severity: Dict[str, int],
+    issues_by_domain: Dict[str, int],
+    duration_ms: int,
+    scan_mode: str,
+    output_format: str,
+    fix_enabled: bool,
+    coverage_percent: Optional[float] = None,
+    duplication_percent: Optional[float] = None,
+) -> None:
+    """Track a completed scan with anonymous metadata.
+
+    All data is aggregate/categorical - no file paths, code, or PII.
+
+    Args:
+        domains: List of domains scanned (e.g., ["linting", "sast"]).
+        languages: List of project languages (e.g., ["python", "typescript"]).
+        tools_used: List of tool names used (e.g., ["ruff", "trivy"]).
+        total_issues: Total number of active issues found.
+        issues_by_severity: Issue counts by severity level.
+        issues_by_domain: Issue counts by domain.
+        duration_ms: Scan duration in milliseconds.
+        scan_mode: "incremental" or "full".
+        output_format: Output format used (json, table, etc.).
+        fix_enabled: Whether --fix was used.
+        coverage_percent: Coverage percentage if coverage was run.
+        duplication_percent: Duplication percentage if duplication was run.
+    """
+    properties: Dict[str, Any] = {
+        "domains": sorted(domains),
+        "domain_count": len(domains),
+        "languages": sorted(languages),
+        "language_count": len(languages),
+        "tools_used": sorted(tools_used),
+        "tool_count": len(tools_used),
+        "total_issues": total_issues,
+        "issues_by_severity": issues_by_severity,
+        "issues_by_domain": issues_by_domain,
+        "duration_ms": duration_ms,
+        "scan_mode": scan_mode,
+        "output_format": output_format,
+        "fix_enabled": fix_enabled,
+    }
+
+    if coverage_percent is not None:
+        properties["coverage_percent"] = round(coverage_percent, 1)
+    if duplication_percent is not None:
+        properties["duplication_percent"] = round(duplication_percent, 1)
+
+    track_event("scan_completed", properties)
+
+
+def reset() -> None:
+    """Reset telemetry state. Used for testing."""
+    global _telemetry_client, _anonymous_id, _enabled
+    _shutdown()
+    _telemetry_client = None
+    _anonymous_id = None
+    _enabled = None

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,333 @@
+"""Tests for anonymous telemetry module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lucidshark import telemetry
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry():
+    """Reset telemetry state before and after each test."""
+    telemetry.reset()
+    yield
+    telemetry.reset()
+
+
+@pytest.fixture
+def _enable_telemetry(monkeypatch):
+    """Ensure telemetry is enabled for the test."""
+    monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+
+class TestIsEnabled:
+    """Tests for telemetry opt-out checks."""
+
+    def test_disabled_by_env_var_zero(self, monkeypatch):
+        monkeypatch.setenv("LUCIDSHARK_TELEMETRY", "0")
+        assert telemetry.is_enabled() is False
+
+    def test_disabled_by_env_var_false(self, monkeypatch):
+        monkeypatch.setenv("LUCIDSHARK_TELEMETRY", "false")
+        assert telemetry.is_enabled() is False
+
+    def test_disabled_by_env_var_no(self, monkeypatch):
+        monkeypatch.setenv("LUCIDSHARK_TELEMETRY", "no")
+        assert telemetry.is_enabled() is False
+
+    def test_disabled_by_env_var_off(self, monkeypatch):
+        monkeypatch.setenv("LUCIDSHARK_TELEMETRY", "off")
+        assert telemetry.is_enabled() is False
+
+    def test_disabled_by_do_not_track(self, monkeypatch):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        assert telemetry.is_enabled() is False
+
+    def test_disabled_in_ci(self, monkeypatch):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.setenv("CI", "true")
+        assert telemetry.is_enabled() is False
+
+    def test_disabled_by_optout_file(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        optout_file = tmp_path / "telemetry-optout"
+        optout_file.touch()
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        assert telemetry.is_enabled() is False
+
+    def test_enabled_by_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        # Point to a dir without optout file
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        assert telemetry.is_enabled() is True
+
+    def test_enabled_caches_result(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        assert telemetry.is_enabled() is True
+        # Should return cached value even if env changes
+        monkeypatch.setenv("LUCIDSHARK_TELEMETRY", "0")
+        assert telemetry.is_enabled() is True  # Still cached as True
+
+
+class TestAnonymousId:
+    """Tests for anonymous ID generation and persistence."""
+
+    def test_generates_uuid(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        anon_id = telemetry._get_anonymous_id()
+        assert len(anon_id) == 36  # UUID format
+        assert "-" in anon_id
+
+    def test_persists_to_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        anon_id = telemetry._get_anonymous_id()
+
+        id_file = tmp_path / "anonymous-id"
+        assert id_file.exists()
+        assert id_file.read_text().strip() == anon_id
+
+    def test_reads_existing_id(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        id_file = tmp_path / "anonymous-id"
+        id_file.write_text("existing-test-id-12345")
+
+        anon_id = telemetry._get_anonymous_id()
+        assert anon_id == "existing-test-id-12345"
+
+    def test_returns_stable_id(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+        id1 = telemetry._get_anonymous_id()
+        # Reset the cached value but keep the file
+        telemetry._anonymous_id = None
+        id2 = telemetry._get_anonymous_id()
+        assert id1 == id2
+
+    def test_handles_unwritable_dir(self, monkeypatch):
+        monkeypatch.setattr(
+            telemetry,
+            "_get_lucidshark_dir",
+            lambda: Path("/nonexistent/deeply/nested/path"),
+        )
+        # Should not raise, just generate in-memory ID
+        anon_id = telemetry._get_anonymous_id()
+        assert len(anon_id) == 36
+
+
+class TestTrackEvent:
+    """Tests for event tracking."""
+
+    def test_noop_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("LUCIDSHARK_TELEMETRY", "0")
+        # Should not raise even without posthog installed
+        telemetry.track_event("test_event", {"key": "value"})
+
+    def test_never_raises(self, monkeypatch, tmp_path):
+        """Telemetry must never crash the CLI."""
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        # Mock _get_client to raise
+        monkeypatch.setattr(
+            telemetry, "_get_client", MagicMock(side_effect=RuntimeError("boom"))
+        )
+        # Should not raise
+        telemetry.track_event("test_event")
+
+    def test_calls_posthog_capture(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(telemetry, "_get_client", lambda: mock_client)
+
+        telemetry.track_event("test_event", {"custom": "prop"})
+
+        mock_client.capture.assert_called_once()
+        call_kwargs = mock_client.capture.call_args
+        assert call_kwargs.kwargs["event"] == "test_event"
+        assert "custom" in call_kwargs.kwargs["properties"]
+        assert call_kwargs.kwargs["properties"]["custom"] == "prop"
+        # Should include base properties
+        assert "lucidshark_version" in call_kwargs.kwargs["properties"]
+        assert "os" in call_kwargs.kwargs["properties"]
+
+    def test_includes_base_properties(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(telemetry, "_get_client", lambda: mock_client)
+
+        telemetry.track_event("test_event")
+
+        props = mock_client.capture.call_args.kwargs["properties"]
+        assert "lucidshark_version" in props
+        assert "os" in props
+        assert "arch" in props
+        assert "python_version" in props
+
+
+class TestTrackCommand:
+    """Tests for command tracking."""
+
+    def test_tracks_command_name(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(telemetry, "_get_client", lambda: mock_client)
+
+        telemetry.track_command("scan")
+
+        mock_client.capture.assert_called_once()
+        call_kwargs = mock_client.capture.call_args
+        assert call_kwargs.kwargs["event"] == "command_executed"
+        assert call_kwargs.kwargs["properties"]["command"] == "scan"
+
+
+class TestTrackScanCompleted:
+    """Tests for scan completion tracking."""
+
+    def test_tracks_scan_with_all_properties(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(telemetry, "_get_client", lambda: mock_client)
+
+        telemetry.track_scan_completed(
+            domains=["linting", "sast"],
+            languages=["python", "typescript"],
+            tools_used=["ruff", "opengrep"],
+            total_issues=42,
+            issues_by_severity={"high": 5, "low": 37},
+            issues_by_domain={"linting": 30, "sast": 12},
+            duration_ms=5000,
+            scan_mode="full",
+            output_format="json",
+            fix_enabled=True,
+            coverage_percent=85.5,
+            duplication_percent=3.2,
+        )
+
+        mock_client.capture.assert_called_once()
+        props = mock_client.capture.call_args.kwargs["properties"]
+
+        assert props["domains"] == ["linting", "sast"]
+        assert props["domain_count"] == 2
+        assert props["languages"] == ["python", "typescript"]
+        assert props["language_count"] == 2
+        assert props["tools_used"] == ["opengrep", "ruff"]  # sorted
+        assert props["tool_count"] == 2
+        assert props["total_issues"] == 42
+        assert props["issues_by_severity"] == {"high": 5, "low": 37}
+        assert props["issues_by_domain"] == {"linting": 30, "sast": 12}
+        assert props["duration_ms"] == 5000
+        assert props["scan_mode"] == "full"
+        assert props["output_format"] == "json"
+        assert props["fix_enabled"] is True
+        assert props["coverage_percent"] == 85.5
+        assert props["duplication_percent"] == 3.2
+        # Base properties
+        assert "lucidshark_version" in props
+        assert "os" in props
+
+    def test_optional_coverage_and_duplication(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(telemetry, "_get_client", lambda: mock_client)
+
+        telemetry.track_scan_completed(
+            domains=["linting"],
+            languages=["python"],
+            tools_used=["ruff"],
+            total_issues=0,
+            issues_by_severity={},
+            issues_by_domain={},
+            duration_ms=100,
+            scan_mode="incremental",
+            output_format="summary",
+            fix_enabled=False,
+        )
+
+        props = mock_client.capture.call_args.kwargs["properties"]
+        assert "coverage_percent" not in props
+        assert "duplication_percent" not in props
+
+
+class TestReset:
+    """Tests for reset functionality."""
+
+    def test_reset_clears_cached_state(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("LUCIDSHARK_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(
+            telemetry, "_get_lucidshark_dir", lambda: tmp_path
+        )
+
+        # Prime caches
+        telemetry.is_enabled()
+        telemetry._get_anonymous_id()
+
+        # Reset
+        telemetry.reset()
+
+        assert telemetry._enabled is None
+        assert telemetry._anonymous_id is None
+        assert telemetry._telemetry_client is None


### PR DESCRIPTION
## Summary
- Add anonymous, opt-out telemetry using PostHog to track unique users, scan frequency, language/tool distribution, and feature adoption
- All data is fully anonymous: random UUID per installation, no PII, no file paths, no source code, no IP storage
- Opt-out via `LUCIDSHARK_TELEMETRY=0`, `DO_NOT_TRACK=1`, `~/.lucidshark/telemetry-optout` file, or automatically disabled in CI (`CI=true`)

## What's tracked
| Event | Properties |
|-------|-----------|
| `command_executed` | command name, version, OS, arch |
| `scan_completed` | domains, languages, tools used, issue counts (by severity/domain), duration, scan mode, output format, fix enabled, coverage %, duplication % |

## Implementation
- New `src/lucidshark/telemetry.py` module with fire-and-forget PostHog integration (never blocks or crashes CLI)
- Integrated into `CLIRunner.run()` for command tracking and `ScanCommand.execute()` for scan completion
- `posthog` added to `requirements.txt` and `lucidshark.spec` hidden imports
- 22 unit tests covering opt-out mechanisms, anonymous ID persistence, event tracking, and error handling

## Test plan
- [x] All 22 new telemetry unit tests pass
- [x] Full unit test suite (3772 tests) passes with no regressions
- [x] Ruff linting passes on all changed files
- [ ] CI pipeline passes on both ubuntu and macOS