### PR TITLE
feat: wire up telemetry for MCP tools and set PostHog API key

### DIFF
--- a/src/lucidshark/mcp/server.py
+++ b/src/lucidshark/mcp/server.py
@@ -316,6 +316,14 @@ class LucidSharkMCPServer:
                 except Exception as e:
                     LOGGER.debug(f"Failed to send progress notification: {e}")
 
+            # Track anonymous MCP tool usage telemetry
+            try:
+                from lucidshark.telemetry import track_command
+
+                track_command(f"mcp_{name}")
+            except Exception:
+                pass
+
             try:
                 if name == "scan":
                     result = await self.executor.scan(
@@ -338,6 +346,7 @@ class LucidSharkMCPServer:
                         ),
                         on_progress=send_progress,
                     )
+                    _track_mcp_scan_telemetry(result, arguments)
                 elif name == "check_file":
                     result = await self.executor.check_file(
                         file_path=arguments["file_path"],
@@ -388,3 +397,47 @@ class LucidSharkMCPServer:
                 write_stream,
                 self.server.create_initialization_options(),
             )
+
+
+def _track_mcp_scan_telemetry(
+    result: Dict[str, Any], arguments: Dict[str, Any]
+) -> None:
+    """Send anonymous telemetry for a completed MCP scan.
+
+    Never raises or blocks.
+    """
+    try:
+        from lucidshark.telemetry import track_scan_completed
+
+        # Extract executed domains from domain_status keys
+        domain_status = result.get("domain_status", {})
+        domains = [
+            d for d, info in domain_status.items()
+            if info.get("status") != "skipped"
+        ]
+
+        # Count issues per domain from issues_by_domain
+        issues_by_domain = {
+            domain: len(issues)
+            for domain, issues in result.get("issues_by_domain", {}).items()
+        }
+
+        coverage = result.get("coverage_summary", {})
+        duplication = result.get("duplication_summary", {})
+
+        track_scan_completed(
+            domains=domains,
+            languages=[],
+            tools_used=[],
+            total_issues=result.get("total_issues", 0),
+            issues_by_severity=result.get("severity_counts", {}),
+            issues_by_domain=issues_by_domain,
+            duration_ms=0,
+            scan_mode="full" if arguments.get("all_files") else "incremental",
+            output_format="mcp",
+            fix_enabled=arguments.get("fix", False),
+            coverage_percent=coverage.get("coverage_percentage"),
+            duplication_percent=duplication.get("duplication_percent"),
+        )
+    except Exception:
+        pass

--- a/src/lucidshark/telemetry.py
+++ b/src/lucidshark/telemetry.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 LOGGER = logging.getLogger(__name__)
 
 # PostHog project API key (public, safe to embed - this is a write-only key)
-_POSTHOG_API_KEY = "phc_LucidShark_anonymous_telemetry_key"
+_POSTHOG_API_KEY = "phc_jQ0TDwA4tX7DkP5Rf1Pmr6mu9mPgtNmYh2QYkFjNmWP"
 _POSTHOG_HOST = "https://us.i.posthog.com"
 
 _telemetry_client: Optional[Any] = None


### PR DESCRIPTION
Track all MCP tool calls via track_command() and scan results via track_scan_completed(). Use the same PostHog project key as the landing page.