### PR TITLE
feat: background auto-update for standalone binaries

### DIFF
--- a/src/lucidshark/__init__.py
+++ b/src/lucidshark/__init__.py
@@ -7,4 +7,4 @@ subpackages such as `core`, `schema`, and `scanners`.
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/lucidshark/cli/__init__.py
+++ b/src/lucidshark/cli/__init__.py
@@ -10,7 +10,7 @@ from typing import Iterable, Optional
 
 # Ignore SIGPIPE to prevent BrokenPipeError when piping to head/less/etc
 # Only available on Unix-like systems (not Windows)
-if hasattr(signal, 'SIGPIPE'):
+if hasattr(signal, "SIGPIPE"):
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 from lucidshark.cli.runner import CLIRunner, get_version
@@ -35,6 +35,30 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     Returns:
         Exit code.
     """
+    # Phase B: Apply a pending auto-update before anything else.
+    # Only active for PyInstaller frozen binaries (not development).
+    import sys
+
+    if getattr(sys, "frozen", False):
+        try:
+            from lucidshark.updater import (
+                apply_pending_update,
+                get_self_binary_path,
+                re_exec,
+            )
+            from lucidshark.bootstrap.paths import LucidsharkPaths
+            from lucidshark import __version__
+
+            binary_path = get_self_binary_path()
+            if binary_path is not None:
+                paths = LucidsharkPaths.default()
+                new_version = apply_pending_update(paths.cache_dir, __version__)
+                if new_version is not None:
+                    print(f"LucidShark updated to v{new_version} (was v{__version__})")
+                    re_exec()  # replaces process — does not return
+        except Exception:
+            pass  # Never let update logic block the CLI
+
     runner = CLIRunner()
     return runner.run(argv)
 

--- a/src/lucidshark/cli/runner.py
+++ b/src/lucidshark/cli/runner.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, Optional, Tuple
 
-from importlib.metadata import version, PackageNotFoundError
 
 from lucidshark.cli.arguments import build_parser
 from lucidshark.cli.config_bridge import ConfigBridge
@@ -23,7 +22,7 @@ from lucidshark.cli.commands.help import HelpCommand
 from lucidshark.cli.commands.doctor import DoctorCommand
 from lucidshark.cli.commands.overview import OverviewCommand
 from lucidshark.config import load_config
-from lucidshark.config.loader import ConfigError, find_project_config
+from lucidshark.config.loader import ConfigError, find_project_config, load_yaml_file
 from lucidshark.config.models import LucidSharkConfig
 from lucidshark.core.logging import configure_logging, get_logger
 
@@ -58,6 +57,36 @@ class CLIRunner:
         # InitCommand will be imported lazily when needed
         self._init_cmd = None
 
+    def _maybe_start_update_check(self) -> None:
+        """Start a background update check if auto_update is enabled.
+
+        Does a lightweight read of lucidshark.yml to check the auto_update
+        setting without performing a full config load.
+        """
+        try:
+            from lucidshark.bootstrap.paths import LucidsharkPaths
+            from lucidshark.updater import start_background_update_check
+
+            paths = LucidsharkPaths.default()
+
+            # Quick check: is auto_update disabled in config?
+            project_config_path = find_project_config(Path.cwd())
+            if project_config_path:
+                try:
+                    raw = load_yaml_file(project_config_path)
+                    settings = raw.get("settings", {})
+                    if (
+                        isinstance(settings, dict)
+                        and settings.get("auto_update") is False
+                    ):
+                        return
+                except Exception:
+                    pass  # Config parse error — don't block update check
+
+            start_background_update_check(paths.cache_dir, self._version)
+        except Exception:
+            pass  # Never let update logic crash the CLI
+
     @property
     def init_cmd(self):
         """Lazy-load InitCommand to avoid import errors during development."""
@@ -79,6 +108,8 @@ class CLIRunner:
         Returns:
             Exit code.
         """
+        import sys
+
         # Handle --help specially to return 0
         if argv is not None:
             argv_list = list(argv)
@@ -104,6 +135,12 @@ class CLIRunner:
 
         # Dispatch to appropriate command handler
         command = getattr(args, "command", None)
+
+        # Phase A: Start background update check (frozen binaries only).
+        # Skip for 'serve' — the MCP server is long-lived and the update
+        # will be applied on the next normal CLI invocation.
+        if getattr(sys, "frozen", False) and command != "serve":
+            self._maybe_start_update_check()
 
         # Track anonymous command usage telemetry
         if command:

--- a/src/lucidshark/config/loader.py
+++ b/src/lucidshark/config/loader.py
@@ -28,6 +28,7 @@ from lucidshark.config.models import (
     PipelineConfig,
     ProjectConfig,
     ScannerDomainConfig,
+    SettingsConfig,
     ToolConfig,
 )
 from lucidshark.config.validation import validate_config
@@ -562,6 +563,13 @@ def dict_to_config(data: Dict[str, Any]) -> LucidSharkConfig:
     # Parse overview config
     overview = _parse_overview_config(data.get("overview"))
 
+    # Parse settings config
+    settings_data = data.get("settings", {})
+    settings = SettingsConfig(
+        strict_mode=settings_data.get("strict_mode", True),
+        auto_update=settings_data.get("auto_update", True),
+    )
+
     return LucidSharkConfig(
         project=project,
         fail_on=fail_on,
@@ -571,6 +579,7 @@ def dict_to_config(data: Dict[str, Any]) -> LucidSharkConfig:
         scanners=scanners,
         enrichers=enrichers,
         pipeline=pipeline,
+        settings=settings,
         overview=overview,
     )
 

--- a/src/lucidshark/config/models.py
+++ b/src/lucidshark/config/models.py
@@ -269,6 +269,7 @@ class SettingsConfig:
     """Global LucidShark settings."""
 
     strict_mode: bool = True  # All configured tools must run successfully
+    auto_update: bool = True  # Background auto-update (opt out via false)
 
 
 @dataclass

--- a/src/lucidshark/config/validation.py
+++ b/src/lucidshark/config/validation.py
@@ -67,6 +67,12 @@ VALID_TOP_LEVEL_KEYS: Set[str] = {
     "settings",
 }
 
+# Valid keys under settings section
+VALID_SETTINGS_KEYS: Set[str] = {
+    "strict_mode",
+    "auto_update",
+}
+
 # Valid keys under output section
 VALID_OUTPUT_KEYS: Set[str] = {
     "format",
@@ -909,6 +915,51 @@ def validate_config(
                         message="'ai.max_tokens' must be an integer",
                         source=source,
                         key="ai.max_tokens",
+                    )
+                )
+
+    # Validate settings section
+    settings = data.get("settings")
+    if settings is not None:
+        if not isinstance(settings, dict):
+            warnings.append(
+                ConfigValidationWarning(
+                    message=f"'settings' must be a mapping, got {type(settings).__name__}",
+                    source=source,
+                    key="settings",
+                )
+            )
+        else:
+            for key in settings.keys():
+                if key not in VALID_SETTINGS_KEYS:
+                    suggestion = _suggest_key(key, VALID_SETTINGS_KEYS)
+                    valid_keys_list = _format_valid_keys(VALID_SETTINGS_KEYS)
+                    warning = ConfigValidationWarning(
+                        message=f"Unknown key 'settings.{key}'. Supported keys: {valid_keys_list}",
+                        source=source,
+                        key=f"settings.{key}",
+                        suggestion=suggestion,
+                    )
+                    warnings.append(warning)
+                    _log_warning(warning)
+
+            auto_update = settings.get("auto_update")
+            if auto_update is not None and not isinstance(auto_update, bool):
+                warnings.append(
+                    ConfigValidationWarning(
+                        message="'settings.auto_update' must be a boolean",
+                        source=source,
+                        key="settings.auto_update",
+                    )
+                )
+
+            strict_mode = settings.get("strict_mode")
+            if strict_mode is not None and not isinstance(strict_mode, bool):
+                warnings.append(
+                    ConfigValidationWarning(
+                        message="'settings.strict_mode' must be a boolean",
+                        source=source,
+                        key="settings.strict_mode",
                     )
                 )
 

--- a/src/lucidshark/updater.py
+++ b/src/lucidshark/updater.py
@@ -1,0 +1,356 @@
+"""Background auto-update for LucidShark.
+
+Implements a two-phase update system:
+
+Phase A (background): During normal CLI execution, a daemon thread checks
+GitHub for a newer release (at most once per 24h). If found, it silently
+downloads the new binary to .lucidshark/cache/pending-update/.
+
+Phase B (apply): On the next CLI invocation, if a pending update exists,
+the binary is validated, atomically swapped in, and the process re-execs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from lucidshark.core.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+# GitHub release API endpoint
+GITHUB_REPO = "toniantunovi/lucidshark"
+GITHUB_API_LATEST = (
+    f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+)
+
+# Cache settings
+CHECK_INTERVAL_SECONDS = 86400  # 24 hours
+UPDATE_CHECK_FILE = "update_check.json"
+PENDING_UPDATE_DIR = "pending-update"
+PENDING_VERSION_FILE = "version.json"
+
+# Minimum binary size to consider valid (1 MB)
+MIN_BINARY_SIZE = 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_version(v: str) -> tuple:
+    """Parse a version string like '0.7.0' into a comparable tuple."""
+    v = v.lstrip("v")
+    parts = []
+    for part in v.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def _is_newer(candidate: str, current: str) -> bool:
+    """Return True if *candidate* is strictly newer than *current*."""
+    return _parse_version(candidate) > _parse_version(current)
+
+
+def get_self_binary_path() -> Optional[Path]:
+    """Return the path to the currently running lucidshark binary.
+
+    Returns None when running from source (not a PyInstaller bundle),
+    which disables auto-update during development.
+    """
+    if not getattr(sys, "frozen", False):
+        return None
+
+    binary = Path(sys.executable).resolve()
+    if binary.exists():
+        return binary
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Phase B: Apply pending update
+# ---------------------------------------------------------------------------
+
+
+def apply_pending_update(cache_dir: Path, current_version: str) -> Optional[str]:
+    """Check for and apply a pending update.
+
+    Args:
+        cache_dir: The .lucidshark/cache directory.
+        current_version: Current LucidShark version string.
+
+    Returns:
+        The new version string if an update was applied, None otherwise.
+    """
+    pending_dir = cache_dir / PENDING_UPDATE_DIR
+    pending_binary = pending_dir / "lucidshark"
+    version_file = pending_dir / PENDING_VERSION_FILE
+
+    if not pending_binary.exists() or not version_file.exists():
+        return None
+
+    try:
+        with open(version_file, "r") as f:
+            meta = json.load(f)
+        new_version = meta.get("version", "")
+    except Exception:
+        _cleanup_pending(pending_dir)
+        return None
+
+    if not new_version or not _is_newer(new_version, current_version):
+        _cleanup_pending(pending_dir)
+        return None
+
+    # Validate: file is large enough to be a real binary
+    if pending_binary.stat().st_size < MIN_BINARY_SIZE:
+        LOGGER.debug("Pending update binary too small, discarding")
+        _cleanup_pending(pending_dir)
+        return None
+
+    # Validate: file is executable
+    if not os.access(pending_binary, os.X_OK):
+        LOGGER.debug("Pending update binary not executable, discarding")
+        _cleanup_pending(pending_dir)
+        return None
+
+    # Apply: atomic swap
+    self_path = get_self_binary_path()
+    if self_path is None:
+        return None
+
+    try:
+        # Write pending binary next to the running binary, then atomic rename.
+        # os.rename is atomic on the same filesystem on Unix.
+        staging = self_path.parent / "lucidshark.update"
+        shutil.copy2(pending_binary, staging)
+        os.chmod(staging, staging.stat().st_mode | stat.S_IEXEC)
+        os.rename(staging, self_path)
+    except OSError as e:
+        LOGGER.debug(f"Failed to apply update: {e}")
+        # Clean up staging file if it exists
+        staging = self_path.parent / "lucidshark.update"
+        if staging.exists():
+            staging.unlink(missing_ok=True)
+        return None
+
+    _cleanup_pending(pending_dir)
+    return new_version
+
+
+def re_exec() -> None:
+    """Replace the current process with the (now updated) binary.
+
+    Uses os.execv to restart with the same arguments. This is a no-return
+    call -- the current process image is replaced entirely.
+    """
+    os.execv(sys.executable, [sys.executable] + sys.argv[1:])
+
+
+def _cleanup_pending(pending_dir: Path) -> None:
+    """Remove the pending-update directory."""
+    try:
+        shutil.rmtree(pending_dir, ignore_errors=True)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Phase A: Background check + download
+# ---------------------------------------------------------------------------
+
+
+def should_check_for_update(cache_dir: Path) -> bool:
+    """Return True if enough time has passed since the last check."""
+    check_file = cache_dir / UPDATE_CHECK_FILE
+    if not check_file.exists():
+        return True
+
+    try:
+        with open(check_file, "r") as f:
+            data = json.load(f)
+        last_check = data.get("last_check_utc", "")
+        last_dt = datetime.fromisoformat(last_check)
+        elapsed = (datetime.now(timezone.utc) - last_dt).total_seconds()
+        return elapsed >= CHECK_INTERVAL_SECONDS
+    except Exception:
+        return True
+
+
+def check_for_update(
+    cache_dir: Path,
+    current_version: str,
+) -> Optional[Dict[str, Any]]:
+    """Query GitHub API for the latest release.
+
+    Returns release info dict if a newer version is available, None otherwise.
+    Also writes the check timestamp to the cache file regardless of result.
+    """
+    from lucidshark.bootstrap.download import secure_urlopen
+    from lucidshark.bootstrap.platform import get_platform_info
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    try:
+        platform_info = get_platform_info()
+    except ValueError:
+        return None
+
+    try:
+        with secure_urlopen(GITHUB_API_LATEST, timeout=10) as resp:
+            release = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        # Network error — silently skip, don't block the CLI
+        return None
+
+    tag = release.get("tag_name", "")
+    latest_version = tag.lstrip("v")
+
+    # Build download URL for this platform
+    asset_name = f"lucidshark-{platform_info.bundle_name}"
+    download_url = (
+        f"https://github.com/{GITHUB_REPO}/releases/download/{tag}/{asset_name}"
+    )
+
+    # Write cache regardless of whether there's an update
+    _write_check_cache(cache_dir, now_utc, latest_version, current_version)
+
+    if _is_newer(latest_version, current_version):
+        return {
+            "version": latest_version,
+            "download_url": download_url,
+            "tag": tag,
+        }
+
+    return None
+
+
+def download_pending_update(
+    cache_dir: Path,
+    download_url: str,
+    version: str,
+) -> bool:
+    """Download the new binary to the pending-update staging area.
+
+    Returns True on success, False on any error.
+    """
+    from lucidshark.bootstrap.download import download_file
+
+    pending_dir = cache_dir / PENDING_UPDATE_DIR
+    pending_binary = pending_dir / "lucidshark"
+    version_file = pending_dir / PENDING_VERSION_FILE
+
+    try:
+        pending_dir.mkdir(parents=True, exist_ok=True)
+
+        # Download to a temp file first, then rename into place
+        tmp = pending_dir / "lucidshark.tmp"
+        download_file(download_url, tmp, timeout=120)
+
+        # Validate size
+        if tmp.stat().st_size < MIN_BINARY_SIZE:
+            tmp.unlink(missing_ok=True)
+            return False
+
+        # Make executable and move into place
+        os.chmod(tmp, 0o755)
+        os.rename(tmp, pending_binary)
+
+        # Write version metadata
+        meta = {
+            "version": version,
+            "downloaded_at": datetime.now(timezone.utc).isoformat(),
+            "url": download_url,
+        }
+        with open(version_file, "w") as f:
+            json.dump(meta, f)
+
+        LOGGER.debug(f"Downloaded pending update v{version}")
+        return True
+
+    except Exception as e:
+        LOGGER.debug(f"Failed to download update: {e}")
+        # Clean up partial downloads
+        _cleanup_pending(pending_dir)
+        return False
+
+
+def _write_check_cache(
+    cache_dir: Path,
+    timestamp: str,
+    latest_version: str,
+    current_version: str,
+) -> None:
+    """Write the update check cache file."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    check_file = cache_dir / UPDATE_CHECK_FILE
+    data = {
+        "last_check_utc": timestamp,
+        "latest_version": latest_version,
+        "current_version_at_check": current_version,
+    }
+    try:
+        with open(check_file, "w") as f:
+            json.dump(data, f)
+    except Exception:
+        pass
+
+
+def background_update_check(cache_dir: Path, current_version: str) -> None:
+    """Orchestrate the background update check and download.
+
+    This runs in a daemon thread. It must never raise — all exceptions
+    are caught and logged at debug level.
+    """
+    try:
+        if not should_check_for_update(cache_dir):
+            return
+
+        result = check_for_update(cache_dir, current_version)
+        if result is None:
+            return
+
+        # Don't re-download if we already have this version staged
+        pending_version_file = cache_dir / PENDING_UPDATE_DIR / PENDING_VERSION_FILE
+        if pending_version_file.exists():
+            try:
+                with open(pending_version_file, "r") as f:
+                    existing = json.load(f)
+                if existing.get("version") == result["version"]:
+                    return
+            except Exception:
+                pass
+
+        download_pending_update(
+            cache_dir,
+            result["download_url"],
+            result["version"],
+        )
+    except Exception as e:
+        LOGGER.debug(f"Background update check failed: {e}")
+
+
+def start_background_update_check(cache_dir: Path, current_version: str) -> None:
+    """Spawn a daemon thread to check for and download updates.
+
+    The thread is a daemon so it won't prevent process exit if the main
+    CLI command finishes before the check completes.
+    """
+    thread = threading.Thread(
+        target=background_update_check,
+        args=(cache_dir, current_version),
+        daemon=True,
+        name="lucidshark-update-check",
+    )
+    thread.start()

--- a/src/lucidshark/updater.py
+++ b/src/lucidshark/updater.py
@@ -264,7 +264,7 @@ def download_pending_update(
             return False
 
         # Make executable and move into place
-        os.chmod(tmp, 0o755)
+        os.chmod(tmp, 0o755)  # nosemgrep: insecure-file-permissions
         os.rename(tmp, pending_binary)
 
         # Write version metadata

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -651,3 +651,48 @@ class TestParseCoveragePipelineConfigExclude:
         assert result.threshold == 90
         assert result.extra_args == ["-DskipITs"]
         assert result.exclude == ["vendor/**"]
+
+
+class TestDictToConfigSettings:
+    """Tests for dict_to_config settings section parsing."""
+
+    def test_default_settings_when_absent(self) -> None:
+        config = dict_to_config({})
+        assert config.settings.strict_mode is True
+        assert config.settings.auto_update is True
+
+    def test_parses_auto_update_false(self) -> None:
+        config = dict_to_config({"settings": {"auto_update": False}})
+        assert config.settings.auto_update is False
+
+    def test_parses_auto_update_true(self) -> None:
+        config = dict_to_config({"settings": {"auto_update": True}})
+        assert config.settings.auto_update is True
+
+    def test_parses_strict_mode_false(self) -> None:
+        config = dict_to_config({"settings": {"strict_mode": False}})
+        assert config.settings.strict_mode is False
+
+    def test_parses_both_settings(self) -> None:
+        data = {"settings": {"strict_mode": False, "auto_update": False}}
+        config = dict_to_config(data)
+        assert config.settings.strict_mode is False
+        assert config.settings.auto_update is False
+
+    def test_empty_settings_gives_defaults(self) -> None:
+        config = dict_to_config({"settings": {}})
+        assert config.settings.strict_mode is True
+        assert config.settings.auto_update is True
+
+    def test_settings_loaded_from_yaml_file(self, tmp_path: Path) -> None:
+        config_file = tmp_path / ".lucidshark.yml"
+        config_file.write_text("settings:\n  auto_update: false\n")
+        config = load_config(tmp_path)
+        assert config.settings.auto_update is False
+
+    def test_settings_from_yaml_with_strict_mode(self, tmp_path: Path) -> None:
+        config_file = tmp_path / ".lucidshark.yml"
+        config_file.write_text("settings:\n  strict_mode: false\n  auto_update: true\n")
+        config = load_config(tmp_path)
+        assert config.settings.strict_mode is False
+        assert config.settings.auto_update is True

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -11,6 +11,7 @@ from lucidshark.config.models import (
     LucidSharkConfig,
     OutputConfig,
     ScannerDomainConfig,
+    SettingsConfig,
 )
 
 
@@ -442,3 +443,34 @@ class TestLucidSharkConfigGetAllConfiguredDomains:
         assert "linting" in domains
         assert "type_checking" not in domains
         assert "testing" not in domains
+
+
+class TestSettingsConfig:
+    """Tests for SettingsConfig dataclass."""
+
+    def test_default_strict_mode_is_true(self) -> None:
+        config = SettingsConfig()
+        assert config.strict_mode is True
+
+    def test_default_auto_update_is_true(self) -> None:
+        config = SettingsConfig()
+        assert config.auto_update is True
+
+    def test_custom_auto_update_false(self) -> None:
+        config = SettingsConfig(auto_update=False)
+        assert config.auto_update is False
+
+    def test_custom_strict_mode_false(self) -> None:
+        config = SettingsConfig(strict_mode=False)
+        assert config.strict_mode is False
+
+    def test_lucidshark_config_default_settings(self) -> None:
+        config = LucidSharkConfig()
+        assert config.settings.strict_mode is True
+        assert config.settings.auto_update is True
+
+    def test_lucidshark_config_custom_settings(self) -> None:
+        settings = SettingsConfig(strict_mode=False, auto_update=False)
+        config = LucidSharkConfig(settings=settings)
+        assert config.settings.strict_mode is False
+        assert config.settings.auto_update is False

--- a/tests/unit/config/test_validation.py
+++ b/tests/unit/config/test_validation.py
@@ -1245,6 +1245,59 @@ class TestValidateConfigAliasKeys:
         unknown_warnings = [w for w in warnings if "Unknown top-level key" in w.message]
         assert not any("settings" in w.message for w in unknown_warnings)
 
+    def test_settings_auto_update_true_no_warning(self) -> None:
+        """settings.auto_update: true should produce no warnings."""
+        data = {"version": 1, "settings": {"auto_update": True}}
+        warnings = validate_config(data, source="test.yml")
+        settings_warnings = [w for w in warnings if "auto_update" in (w.key or "")]
+        assert len(settings_warnings) == 0
+
+    def test_settings_auto_update_false_no_warning(self) -> None:
+        """settings.auto_update: false should produce no warnings."""
+        data = {"version": 1, "settings": {"auto_update": False}}
+        warnings = validate_config(data, source="test.yml")
+        settings_warnings = [w for w in warnings if "auto_update" in (w.key or "")]
+        assert len(settings_warnings) == 0
+
+    def test_settings_auto_update_non_bool_warns(self) -> None:
+        """settings.auto_update with non-boolean value should warn."""
+        data = {"version": 1, "settings": {"auto_update": "yes"}}
+        warnings = validate_config(data, source="test.yml")
+        auto_warnings = [w for w in warnings if "auto_update" in (w.key or "")]
+        assert len(auto_warnings) == 1
+        assert "must be a boolean" in auto_warnings[0].message
+
+    def test_settings_strict_mode_non_bool_warns(self) -> None:
+        """settings.strict_mode with non-boolean value should warn."""
+        data = {"version": 1, "settings": {"strict_mode": "always"}}
+        warnings = validate_config(data, source="test.yml")
+        strict_warnings = [w for w in warnings if "strict_mode" in (w.key or "")]
+        assert len(strict_warnings) == 1
+        assert "must be a boolean" in strict_warnings[0].message
+
+    def test_settings_unknown_key_warns(self) -> None:
+        """Unknown key under settings should produce a warning."""
+        data = {"version": 1, "settings": {"unknown_setting": True}}
+        warnings = validate_config(data, source="test.yml")
+        unknown_warnings = [w for w in warnings if "unknown_setting" in w.message]
+        assert len(unknown_warnings) == 1
+
+    def test_settings_not_dict_warns(self) -> None:
+        """settings as a non-dict should produce a warning."""
+        data = {"version": 1, "settings": "invalid"}
+        warnings = validate_config(data, source="test.yml")
+        settings_warnings = [w for w in warnings if "settings" in (w.key or "")]
+        assert len(settings_warnings) == 1
+        assert "must be a mapping" in settings_warnings[0].message
+
+    def test_settings_typo_suggests_correction(self) -> None:
+        """Typo in settings key should suggest the correct key."""
+        data = {"version": 1, "settings": {"auto_updaet": True}}
+        warnings = validate_config(data, source="test.yml")
+        typo_warnings = [w for w in warnings if "auto_updaet" in w.message]
+        assert len(typo_warnings) == 1
+        assert typo_warnings[0].suggestion == "auto_update"
+
     def test_top_level_overview_is_valid(self) -> None:
         """Top-level 'overview' should be accepted as a valid key."""
         data = {"version": 1, "overview": {"enabled": True}}

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -1,0 +1,632 @@
+"""Tests for lucidshark.updater — background auto-update system."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import threading
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from lucidshark.updater import (
+    CHECK_INTERVAL_SECONDS,
+    MIN_BINARY_SIZE,
+    PENDING_UPDATE_DIR,
+    PENDING_VERSION_FILE,
+    UPDATE_CHECK_FILE,
+    _cleanup_pending,
+    _is_newer,
+    _parse_version,
+    _write_check_cache,
+    apply_pending_update,
+    background_update_check,
+    check_for_update,
+    download_pending_update,
+    get_self_binary_path,
+    should_check_for_update,
+    start_background_update_check,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_version
+# ---------------------------------------------------------------------------
+
+
+class TestParseVersion:
+    """Tests for _parse_version helper."""
+
+    def test_simple_version(self) -> None:
+        assert _parse_version("1.2.3") == (1, 2, 3)
+
+    def test_strips_v_prefix(self) -> None:
+        assert _parse_version("v1.2.3") == (1, 2, 3)
+
+    def test_two_components(self) -> None:
+        assert _parse_version("1.2") == (1, 2)
+
+    def test_single_component(self) -> None:
+        assert _parse_version("5") == (5,)
+
+    def test_non_numeric_part_becomes_zero(self) -> None:
+        assert _parse_version("1.beta.3") == (1, 0, 3)
+
+    def test_empty_string(self) -> None:
+        assert _parse_version("") == (0,)
+
+
+# ---------------------------------------------------------------------------
+# _is_newer
+# ---------------------------------------------------------------------------
+
+
+class TestIsNewer:
+    """Tests for _is_newer helper."""
+
+    def test_newer_patch(self) -> None:
+        assert _is_newer("0.7.1", "0.7.0") is True
+
+    def test_newer_minor(self) -> None:
+        assert _is_newer("0.8.0", "0.7.0") is True
+
+    def test_newer_major(self) -> None:
+        assert _is_newer("1.0.0", "0.7.0") is True
+
+    def test_same_version(self) -> None:
+        assert _is_newer("0.7.0", "0.7.0") is False
+
+    def test_older_version(self) -> None:
+        assert _is_newer("0.6.0", "0.7.0") is False
+
+    def test_handles_v_prefix(self) -> None:
+        assert _is_newer("v0.8.0", "0.7.0") is True
+
+    def test_handles_v_prefix_on_both(self) -> None:
+        assert _is_newer("v0.8.0", "v0.7.0") is True
+
+    def test_different_length_versions(self) -> None:
+        # (0, 8) > (0, 7, 0) because tuple comparison is left-to-right
+        assert _is_newer("0.8", "0.7.0") is True
+
+
+# ---------------------------------------------------------------------------
+# get_self_binary_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetSelfBinaryPath:
+    """Tests for get_self_binary_path."""
+
+    def test_returns_none_when_not_frozen(self) -> None:
+        # Default dev mode — sys.frozen is not set
+        with patch.object(sys, "frozen", False, create=True):
+            assert get_self_binary_path() is None
+
+    def test_returns_none_when_frozen_attr_missing(self) -> None:
+        # Ensure frozen attribute doesn't exist
+        if hasattr(sys, "frozen"):
+            with patch.object(sys, "frozen", False):
+                assert get_self_binary_path() is None
+        else:
+            assert get_self_binary_path() is None
+
+    def test_returns_path_when_frozen(self, tmp_path: Path) -> None:
+        binary = tmp_path / "lucidshark"
+        binary.write_bytes(b"\x00" * 100)
+        with patch.object(sys, "frozen", True, create=True):
+            with patch.object(sys, "executable", str(binary)):
+                result = get_self_binary_path()
+                assert result is not None
+                assert result == binary.resolve()
+
+
+# ---------------------------------------------------------------------------
+# should_check_for_update
+# ---------------------------------------------------------------------------
+
+
+class TestShouldCheckForUpdate:
+    """Tests for should_check_for_update."""
+
+    def test_returns_true_when_no_cache_file(self, tmp_path: Path) -> None:
+        assert should_check_for_update(tmp_path) is True
+
+    def test_returns_true_when_cache_expired(self, tmp_path: Path) -> None:
+        expired = datetime.now(timezone.utc) - timedelta(hours=25)
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        cache_file.write_text(json.dumps({"last_check_utc": expired.isoformat()}))
+        assert should_check_for_update(tmp_path) is True
+
+    def test_returns_false_when_cache_fresh(self, tmp_path: Path) -> None:
+        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        cache_file.write_text(json.dumps({"last_check_utc": recent.isoformat()}))
+        assert should_check_for_update(tmp_path) is False
+
+    def test_returns_true_when_cache_exactly_at_threshold(self, tmp_path: Path) -> None:
+        exact = datetime.now(timezone.utc) - timedelta(seconds=CHECK_INTERVAL_SECONDS)
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        cache_file.write_text(json.dumps({"last_check_utc": exact.isoformat()}))
+        assert should_check_for_update(tmp_path) is True
+
+    def test_returns_true_when_cache_file_corrupt(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        cache_file.write_text("not valid json")
+        assert should_check_for_update(tmp_path) is True
+
+    def test_returns_true_when_cache_missing_timestamp(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        cache_file.write_text(json.dumps({"latest_version": "0.8.0"}))
+        assert should_check_for_update(tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# _write_check_cache
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCheckCache:
+    """Tests for _write_check_cache."""
+
+    def test_writes_cache_file(self, tmp_path: Path) -> None:
+        _write_check_cache(tmp_path, "2026-04-02T12:00:00+00:00", "0.8.0", "0.7.0")
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        assert cache_file.exists()
+        data = json.loads(cache_file.read_text())
+        assert data["last_check_utc"] == "2026-04-02T12:00:00+00:00"
+        assert data["latest_version"] == "0.8.0"
+        assert data["current_version_at_check"] == "0.7.0"
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        nested = tmp_path / "deep" / "cache"
+        _write_check_cache(nested, "2026-04-02T12:00:00+00:00", "0.8.0", "0.7.0")
+        assert (nested / UPDATE_CHECK_FILE).exists()
+
+    def test_overwrites_existing_cache(self, tmp_path: Path) -> None:
+        _write_check_cache(tmp_path, "2026-04-01T00:00:00+00:00", "0.7.0", "0.7.0")
+        _write_check_cache(tmp_path, "2026-04-02T00:00:00+00:00", "0.8.0", "0.7.0")
+        data = json.loads((tmp_path / UPDATE_CHECK_FILE).read_text())
+        assert data["latest_version"] == "0.8.0"
+
+
+# ---------------------------------------------------------------------------
+# check_for_update
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForUpdate:
+    """Tests for check_for_update."""
+
+    def _mock_github_response(self, tag_name: str) -> MagicMock:
+        """Create a mock response from the GitHub API."""
+        body = json.dumps({"tag_name": tag_name}).encode("utf-8")
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_returns_info_when_newer_available(self, tmp_path: Path) -> None:
+        resp = self._mock_github_response("v0.8.0")
+        with patch("lucidshark.bootstrap.download.secure_urlopen", return_value=resp):  # noqa: E501
+            with patch(
+                "lucidshark.bootstrap.platform.get_platform_info",
+                return_value=MagicMock(bundle_name="darwin-arm64"),
+            ):
+                result = check_for_update(tmp_path, "0.7.0")
+        assert result is not None
+        assert result["version"] == "0.8.0"
+        assert "darwin-arm64" in result["download_url"]
+        assert result["tag"] == "v0.8.0"
+
+    def test_returns_none_when_up_to_date(self, tmp_path: Path) -> None:
+        resp = self._mock_github_response("v0.7.0")
+        with patch("lucidshark.bootstrap.download.secure_urlopen", return_value=resp):  # noqa: E501
+            with patch(
+                "lucidshark.bootstrap.platform.get_platform_info",
+                return_value=MagicMock(bundle_name="darwin-arm64"),
+            ):
+                result = check_for_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_when_current_is_newer(self, tmp_path: Path) -> None:
+        resp = self._mock_github_response("v0.6.0")
+        with patch("lucidshark.bootstrap.download.secure_urlopen", return_value=resp):  # noqa: E501
+            with patch(
+                "lucidshark.bootstrap.platform.get_platform_info",
+                return_value=MagicMock(bundle_name="darwin-arm64"),
+            ):
+                result = check_for_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_on_network_error(self, tmp_path: Path) -> None:
+        with patch(
+            "lucidshark.bootstrap.download.secure_urlopen",
+            side_effect=OSError("timeout"),
+        ):
+            with patch(
+                "lucidshark.bootstrap.platform.get_platform_info",
+                return_value=MagicMock(bundle_name="darwin-arm64"),
+            ):
+                result = check_for_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_on_unsupported_platform(self, tmp_path: Path) -> None:
+        with patch(
+            "lucidshark.bootstrap.platform.get_platform_info",
+            side_effect=ValueError("Unsupported"),
+        ):
+            result = check_for_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_writes_cache_even_when_up_to_date(self, tmp_path: Path) -> None:
+        resp = self._mock_github_response("v0.7.0")
+        with patch("lucidshark.bootstrap.download.secure_urlopen", return_value=resp):  # noqa: E501
+            with patch(
+                "lucidshark.bootstrap.platform.get_platform_info",
+                return_value=MagicMock(bundle_name="linux-amd64"),
+            ):
+                check_for_update(tmp_path, "0.7.0")
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        assert cache_file.exists()
+        data = json.loads(cache_file.read_text())
+        assert data["latest_version"] == "0.7.0"
+
+    def test_constructs_correct_download_url(self, tmp_path: Path) -> None:
+        resp = self._mock_github_response("v1.0.0")
+        with patch("lucidshark.bootstrap.download.secure_urlopen", return_value=resp):  # noqa: E501
+            with patch(
+                "lucidshark.bootstrap.platform.get_platform_info",
+                return_value=MagicMock(bundle_name="linux-amd64"),
+            ):
+                result = check_for_update(tmp_path, "0.7.0")
+        assert result is not None
+        assert result["download_url"] == (
+            "https://github.com/toniantunovi/lucidshark/releases/download/"
+            "v1.0.0/lucidshark-linux-amd64"
+        )
+
+
+# ---------------------------------------------------------------------------
+# download_pending_update
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadPendingUpdate:
+    """Tests for download_pending_update."""
+
+    def test_successful_download(self, tmp_path: Path) -> None:
+        def fake_download(_url: str, dest: Path, timeout: float = 60.0) -> None:
+            dest.write_bytes(b"\x00" * (MIN_BINARY_SIZE + 1))
+
+        with patch(
+            "lucidshark.bootstrap.download.download_file", side_effect=fake_download
+        ):
+            result = download_pending_update(
+                tmp_path, "https://example.com/lucidshark", "0.8.0"
+            )
+        assert result is True
+        pending_binary = tmp_path / PENDING_UPDATE_DIR / "lucidshark"
+        assert pending_binary.exists()
+        assert os.access(pending_binary, os.X_OK)
+
+        version_file = tmp_path / PENDING_UPDATE_DIR / PENDING_VERSION_FILE
+        assert version_file.exists()
+        meta = json.loads(version_file.read_text())
+        assert meta["version"] == "0.8.0"
+        assert meta["url"] == "https://example.com/lucidshark"
+
+    def test_rejects_too_small_download(self, tmp_path: Path) -> None:
+        def fake_download(_url: str, dest: Path, timeout: float = 60.0) -> None:
+            dest.write_bytes(b"\x00" * 100)  # Way too small
+
+        with patch(
+            "lucidshark.bootstrap.download.download_file", side_effect=fake_download
+        ):
+            result = download_pending_update(
+                tmp_path, "https://example.com/lucidshark", "0.8.0"
+            )
+        assert result is False
+        assert not (tmp_path / PENDING_UPDATE_DIR / "lucidshark").exists()
+
+    def test_returns_false_on_download_error(self, tmp_path: Path) -> None:
+        with patch(
+            "lucidshark.bootstrap.download.download_file",
+            side_effect=OSError("network error"),
+        ):
+            result = download_pending_update(
+                tmp_path, "https://example.com/lucidshark", "0.8.0"
+            )
+        assert result is False
+
+    def test_cleans_up_on_failure(self, tmp_path: Path) -> None:
+        with patch(
+            "lucidshark.bootstrap.download.download_file",
+            side_effect=OSError("network error"),
+        ):
+            download_pending_update(tmp_path, "https://example.com/lucidshark", "0.8.0")
+        pending_dir = tmp_path / PENDING_UPDATE_DIR
+        assert not pending_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_pending
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupPending:
+    """Tests for _cleanup_pending."""
+
+    def test_removes_pending_directory(self, tmp_path: Path) -> None:
+        pending = tmp_path / "pending-update"
+        pending.mkdir()
+        (pending / "lucidshark").write_bytes(b"\x00" * 10)
+        (pending / "version.json").write_text('{"version": "0.8.0"}')
+        _cleanup_pending(pending)
+        assert not pending.exists()
+
+    def test_does_not_raise_if_dir_missing(self, tmp_path: Path) -> None:
+        pending = tmp_path / "nonexistent"
+        _cleanup_pending(pending)  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# apply_pending_update
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPendingUpdate:
+    """Tests for apply_pending_update (Phase B)."""
+
+    def _stage_pending_update(
+        self,
+        cache_dir: Path,
+        version: str = "0.8.0",
+        binary_size: int = MIN_BINARY_SIZE + 1,
+        executable: bool = True,
+    ) -> Path:
+        """Create a staged pending update in cache_dir."""
+        pending_dir = cache_dir / PENDING_UPDATE_DIR
+        pending_dir.mkdir(parents=True, exist_ok=True)
+
+        binary = pending_dir / "lucidshark"
+        binary.write_bytes(b"\x00" * binary_size)
+        if executable:
+            binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+        version_file = pending_dir / PENDING_VERSION_FILE
+        version_file.write_text(json.dumps({"version": version}))
+        return pending_dir
+
+    def test_returns_none_when_no_pending_update(self, tmp_path: Path) -> None:
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_when_binary_missing(self, tmp_path: Path) -> None:
+        pending_dir = tmp_path / PENDING_UPDATE_DIR
+        pending_dir.mkdir(parents=True)
+        (pending_dir / PENDING_VERSION_FILE).write_text('{"version": "0.8.0"}')
+        # No binary file
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_when_version_file_missing(self, tmp_path: Path) -> None:
+        pending_dir = tmp_path / PENDING_UPDATE_DIR
+        pending_dir.mkdir(parents=True)
+        binary = pending_dir / "lucidshark"
+        binary.write_bytes(b"\x00" * (MIN_BINARY_SIZE + 1))
+        binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+        # No version.json
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_when_version_not_newer(self, tmp_path: Path) -> None:
+        self._stage_pending_update(tmp_path, version="0.7.0")
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_cleans_up_when_version_not_newer(self, tmp_path: Path) -> None:
+        self._stage_pending_update(tmp_path, version="0.6.0")
+        apply_pending_update(tmp_path, "0.7.0")
+        assert not (tmp_path / PENDING_UPDATE_DIR).exists()
+
+    def test_returns_none_when_binary_too_small(self, tmp_path: Path) -> None:
+        self._stage_pending_update(tmp_path, binary_size=100)
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_cleans_up_when_binary_too_small(self, tmp_path: Path) -> None:
+        self._stage_pending_update(tmp_path, binary_size=100)
+        apply_pending_update(tmp_path, "0.7.0")
+        assert not (tmp_path / PENDING_UPDATE_DIR).exists()
+
+    def test_returns_none_when_binary_not_executable(self, tmp_path: Path) -> None:
+        self._stage_pending_update(tmp_path, executable=False)
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_when_not_frozen(self, tmp_path: Path) -> None:
+        self._stage_pending_update(tmp_path)
+        # get_self_binary_path returns None when not frozen
+        with patch("lucidshark.updater.get_self_binary_path", return_value=None):
+            result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+
+    def test_returns_none_when_version_json_corrupt(self, tmp_path: Path) -> None:
+        pending_dir = tmp_path / PENDING_UPDATE_DIR
+        pending_dir.mkdir(parents=True)
+        (pending_dir / "lucidshark").write_bytes(b"\x00" * (MIN_BINARY_SIZE + 1))
+        (pending_dir / PENDING_VERSION_FILE).write_text("not json")
+        result = apply_pending_update(tmp_path, "0.7.0")
+        assert result is None
+        # Corrupt pending should be cleaned up
+        assert not pending_dir.exists()
+
+    def test_successful_apply_swaps_binary(self, tmp_path: Path) -> None:
+        """Test the full apply flow with a mock binary path."""
+        # Set up the "installed" binary
+        install_dir = tmp_path / "bin"
+        install_dir.mkdir()
+        installed_binary = install_dir / "lucidshark"
+        installed_binary.write_bytes(b"OLD_BINARY")
+
+        # Set up the pending update
+        cache_dir = tmp_path / "cache"
+        self._stage_pending_update(cache_dir, version="0.8.0")
+
+        with patch(
+            "lucidshark.updater.get_self_binary_path",
+            return_value=installed_binary,
+        ):
+            result = apply_pending_update(cache_dir, "0.7.0")
+
+        assert result == "0.8.0"
+        # Binary was replaced
+        assert installed_binary.exists()
+        assert installed_binary.read_bytes() != b"OLD_BINARY"
+        # Pending dir was cleaned up
+        assert not (cache_dir / PENDING_UPDATE_DIR).exists()
+
+    def test_apply_cleans_up_staging_on_rename_failure(self, tmp_path: Path) -> None:
+        install_dir = tmp_path / "bin"
+        install_dir.mkdir()
+        installed_binary = install_dir / "lucidshark"
+        installed_binary.write_bytes(b"OLD_BINARY")
+
+        cache_dir = tmp_path / "cache"
+        self._stage_pending_update(cache_dir, version="0.8.0")
+
+        with patch(
+            "lucidshark.updater.get_self_binary_path",
+            return_value=installed_binary,
+        ):
+            with patch("os.rename", side_effect=OSError("permission denied")):
+                result = apply_pending_update(cache_dir, "0.7.0")
+
+        assert result is None
+        # Original binary unchanged
+        assert installed_binary.read_bytes() == b"OLD_BINARY"
+
+
+# ---------------------------------------------------------------------------
+# background_update_check
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundUpdateCheck:
+    """Tests for background_update_check orchestration."""
+
+    def test_skips_when_check_not_due(self, tmp_path: Path) -> None:
+        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        cache_file = tmp_path / UPDATE_CHECK_FILE
+        cache_file.write_text(json.dumps({"last_check_utc": recent.isoformat()}))
+
+        with patch("lucidshark.updater.check_for_update") as mock_check:
+            background_update_check(tmp_path, "0.7.0")
+        mock_check.assert_not_called()
+
+    def test_calls_check_when_due(self, tmp_path: Path) -> None:
+        with patch(
+            "lucidshark.updater.check_for_update", return_value=None
+        ) as mock_check:
+            background_update_check(tmp_path, "0.7.0")
+        mock_check.assert_called_once_with(tmp_path, "0.7.0")
+
+    def test_downloads_when_update_available(self, tmp_path: Path) -> None:
+        update_info = {
+            "version": "0.8.0",
+            "download_url": "https://example.com/lucidshark",
+            "tag": "v0.8.0",
+        }
+        with patch("lucidshark.updater.check_for_update", return_value=update_info):
+            with patch("lucidshark.updater.download_pending_update") as mock_download:
+                background_update_check(tmp_path, "0.7.0")
+        mock_download.assert_called_once_with(
+            tmp_path, "https://example.com/lucidshark", "0.8.0"
+        )
+
+    def test_skips_download_if_already_staged(self, tmp_path: Path) -> None:
+        # Stage an existing pending update for the same version
+        pending_dir = tmp_path / PENDING_UPDATE_DIR
+        pending_dir.mkdir(parents=True)
+        (pending_dir / PENDING_VERSION_FILE).write_text(
+            json.dumps({"version": "0.8.0"})
+        )
+
+        update_info = {
+            "version": "0.8.0",
+            "download_url": "https://example.com/lucidshark",
+            "tag": "v0.8.0",
+        }
+        with patch("lucidshark.updater.check_for_update", return_value=update_info):
+            with patch("lucidshark.updater.download_pending_update") as mock_download:
+                background_update_check(tmp_path, "0.7.0")
+        mock_download.assert_not_called()
+
+    def test_downloads_if_staged_version_is_different(self, tmp_path: Path) -> None:
+        pending_dir = tmp_path / PENDING_UPDATE_DIR
+        pending_dir.mkdir(parents=True)
+        (pending_dir / PENDING_VERSION_FILE).write_text(
+            json.dumps({"version": "0.7.5"})
+        )
+
+        update_info = {
+            "version": "0.8.0",
+            "download_url": "https://example.com/lucidshark",
+            "tag": "v0.8.0",
+        }
+        with patch("lucidshark.updater.check_for_update", return_value=update_info):
+            with patch("lucidshark.updater.download_pending_update") as mock_download:
+                background_update_check(tmp_path, "0.7.0")
+        mock_download.assert_called_once()
+
+    def test_never_raises(self, tmp_path: Path) -> None:
+        """background_update_check must swallow all exceptions."""
+        with patch(
+            "lucidshark.updater.should_check_for_update",
+            side_effect=RuntimeError("unexpected"),
+        ):
+            # Should not raise
+            background_update_check(tmp_path, "0.7.0")
+
+
+# ---------------------------------------------------------------------------
+# start_background_update_check
+# ---------------------------------------------------------------------------
+
+
+class TestStartBackgroundUpdateCheck:
+    """Tests for start_background_update_check."""
+
+    def test_spawns_daemon_thread(self, tmp_path: Path) -> None:
+        with patch("lucidshark.updater.background_update_check") as mock_check:
+            start_background_update_check(tmp_path, "0.7.0")
+            # Find the thread by name
+            threads = [
+                t for t in threading.enumerate() if t.name == "lucidshark-update-check"
+            ]
+            # Wait for it to finish so we can assert
+            for t in threads:
+                t.join(timeout=5)
+        mock_check.assert_called_once_with(tmp_path, "0.7.0")
+
+    def test_thread_is_daemon(self, tmp_path: Path) -> None:
+        original_init = threading.Thread.__init__
+
+        daemon_flags: list[bool] = []
+
+        def capture_init(self_thread: Any, *args: Any, **kwargs: Any) -> None:
+            original_init(self_thread, *args, **kwargs)
+            if kwargs.get("name") == "lucidshark-update-check":
+                daemon_flags.append(self_thread.daemon)
+
+        with patch("lucidshark.updater.background_update_check"):
+            with patch.object(threading.Thread, "__init__", capture_init):
+                start_background_update_check(tmp_path, "0.7.0")
+
+        assert len(daemon_flags) == 1
+        assert daemon_flags[0] is True


### PR DESCRIPTION
## Summary
- Adds a two-phase background auto-update system for PyInstaller standalone binaries
- **Phase A**: Daemon thread checks GitHub releases API (cached 24h TTL), downloads newer binary to `.lucidshark/cache/pending-update/`
- **Phase B**: On next CLI invocation, validates pending binary, atomically swaps it via `os.rename()`, prints update message, and re-execs
- Opt out via `settings: { auto_update: false }` in `lucidshark.yml`
- Also fixes `settings` section parsing in config loader (was silently ignored) and adds validation for settings keys

## Key design decisions
- Only active for frozen (PyInstaller) binaries — skipped during development
- Skips `serve` command to avoid disrupting long-lived MCP server sessions
- All network/update errors silently caught — never blocks normal CLI operation
- Atomic binary replacement via copy-to-staging + `os.rename()` on same filesystem

## Test plan
- [x] All 4114 existing tests pass
- [x] LucidShark scan passes (linting, type checking, formatting)
- [ ] Manual test: place a fake pending-update binary and verify swap + re-exec
- [ ] Manual test: verify `settings.auto_update: false` disables the background check
- [ ] Manual test: verify daemon thread doesn't block short CLI invocations