### PR TITLE
fix: enforce coverage/duplication thresholds under --base-branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Security scanner telemetry tracking** — `DomainRunner.run_security()` now correctly tracks executed scanners, fixing missing tools in scan metadata
+- **Coverage/duplication thresholds silently skipped under `--base-branch`** — `_check_domain_thresholds` iterated only over domains with surviving issues, but the changed-files filter strips the summary-only `UnifiedIssue` (`file_path=None`) emitted for coverage-below-threshold and duplication breaches. Threshold checks now iterate over every configured `fail_on` domain, so `coverage: below_threshold` and `duplication: above_threshold` correctly fail PR scans.
 
 ## [0.7.1] - 2026-04-04
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ mypy==1.19.1
 mypy_extensions==1.1.0
 nodeenv==1.10.0
 ollama==0.6.1
-openai==2.21.0
+openai==2.26.0
 orjson==3.11.7
 packaging==26.0
 pathspec==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ jsonpointer==3.0.0
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 langchain-anthropic==1.3.3
-langchain-core==1.2.28
+langchain-core==1.2.31
 langchain-ollama==1.0.1
 langchain-openai==1.1.14
 langsmith==0.7.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==2.0.0
 charset-normalizer==3.4.4
 click==8.3.1
 coverage==7.13.4
-cryptography==46.0.6
+cryptography==46.0.7
 defusedxml==0.7.1
 distro==1.9.0
 docstring_parser==0.17.0
@@ -25,10 +25,10 @@ jsonpointer==3.0.0
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 langchain-anthropic==1.3.3
-langchain-core==1.2.22
+langchain-core==1.2.28
 langchain-ollama==1.0.1
-langchain-openai==1.1.10
-langsmith==0.7.6
+langchain-openai==1.1.14
+langsmith==0.7.31
 librt==0.8.1
 MarkupSafe==3.0.3
 mcp==1.26.0
@@ -51,11 +51,11 @@ Pygments==2.20.0
 PyJWT==2.12.0
 pyproject_hooks==1.2.0
 pyright==1.1.408
-pytest==9.0.2
+pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==7.0.0
-python-dotenv==1.2.1
-python-multipart==0.0.22
+python-dotenv==1.2.2
+python-multipart==0.0.27
 PyYAML==6.0.3
 types-PyYAML==6.0.12.20250915
 types-defusedxml==0.7.0.20250822

--- a/src/lucidshark/__init__.py
+++ b/src/lucidshark/__init__.py
@@ -7,4 +7,4 @@ subpackages such as `core`, `schema`, and `scanners`.
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.6"
+__version__ = "0.7.8"

--- a/src/lucidshark/cli/commands/scan.py
+++ b/src/lucidshark/cli/commands/scan.py
@@ -980,10 +980,16 @@ class ScanCommand(Command):
                 return domain_config.threshold_scope
             return "changed"
 
-        # Check each domain against its threshold
-        for domain_name, domain_issues in issues_by_domain.items():
+        # Iterate over every configured fail_on domain — not just domains
+        # with surviving issues. Coverage and duplication produce summary-only
+        # results whose threshold issue carries no file_path, so --base-branch
+        # filtering strips them and they would otherwise be skipped.
+        from lucidshark.config.models import VALID_FAIL_ON_DOMAINS
+
+        for domain_name in VALID_FAIL_ON_DOMAINS:
             threshold = config.get_fail_on_threshold(domain_name)
             if threshold:
+                domain_issues = issues_by_domain.get(domain_name, [])
                 # Get scope for this domain
                 scope = get_scope(domain_name)
 

--- a/tests/unit/cli/commands/test_scan.py
+++ b/tests/unit/cli/commands/test_scan.py
@@ -835,6 +835,32 @@ class TestCheckDomainThresholds:
             result = ScanResult(issues=[issue])
             assert self._cmd()._check_domain_thresholds(result, config, args) is True
 
+    def test_coverage_below_threshold_fails_when_no_coverage_issue(self) -> None:
+        """Regression: --base-branch filtering strips the coverage UnifiedIssue
+        (file_path=None), but the coverage_summary.passed=False signal must
+        still drive the threshold check."""
+        config = _make_config(fail_on=FailOnConfig(coverage="below_threshold"))
+        # No issues at all — only the summary survived (mirrors what
+        # filter_issues_by_changed_files leaves behind for coverage).
+        result = ScanResult(issues=[])
+        result.coverage_summary = CoverageSummary(
+            coverage_percentage=51.8, threshold=80.0, passed=False
+        )
+        args = self._make_args(base_branch="origin/main")
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
+
+    def test_duplication_above_threshold_fails_when_no_duplication_issue(
+        self,
+    ) -> None:
+        """Same regression for duplication: summary-only signal must fail."""
+        config = _make_config(fail_on=FailOnConfig(duplication="above_threshold"))
+        result = ScanResult(issues=[])
+        result.duplication_summary = DuplicationSummary(
+            duplication_percent=15.0, threshold=10.0, passed=False
+        )
+        args = self._make_args(base_branch="origin/main")
+        assert self._cmd()._check_domain_thresholds(result, config, args) is True
+
 
 class TestDryRun:
     """Tests for _dry_run output and behavior."""


### PR DESCRIPTION
## Summary

- `_check_domain_thresholds` only iterated over domains that had post-filter issues. When `--base-branch` is set, `filter_issues_by_changed_files` drops every issue with `file_path is None` — which strips the summary-only `UnifiedIssue` emitted for `coverage_below_threshold` and duplication breaches. As a result, `coverage: below_threshold` and `duplication: above_threshold` were silently skipped on PR scans and the build exited 0 even when `coverage_summary.passed` was `False`.
- Iterate over every configured `fail_on` domain (`VALID_FAIL_ON_DOMAINS`) instead of `issues_by_domain.items()`, so summary-driven thresholds run regardless of whether any issue-form signal survives the changed-files filter. Issue-form thresholds (`any`, `error`, severity strings) still behave the same — they short-circuit on empty `domain_issues`.
- Bumps version to 0.7.8 and adds a changelog entry under `[Unreleased]`.

## Repro (the bug this fixes)

A consumer running `./lucidshark scan --all --base-branch origin/$BITBUCKET_PR_DESTINATION_BRANCH --format summary` saw:

```
COVERAGE: FAIL
Coverage: 51.8% (FAILED)
  Threshold: 80%
```

…and the pipeline still exited 0.

## Test plan

- [x] `pytest tests/unit/cli/commands/test_scan.py` — 66 passed (existing 64 + 2 new regression tests)
- [x] `pytest tests/unit/cli tests/unit/core/test_domain_runner.py tests/unit/core/test_domain_runner_formatting.py` — 294 passed
- [x] `mcp__lucidshark__scan(fix=true)` on the changed files — linting/type-checking/formatting/testing/coverage/duplication/sast all pass; remaining issues are pre-existing dependency CVEs and unrelated duplications

New regression tests:

- `test_coverage_below_threshold_fails_when_no_coverage_issue` — replicates the exact ml-service scenario (no surviving issues + `coverage_summary.passed=False` + `--base-branch`).
- `test_duplication_above_threshold_fails_when_no_duplication_issue` — same shape for duplication.