### PR TITLE
fix: pin rpds-py to 0.30.0 for Python 3.10 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ referencing==0.37.0
 regex==2026.7.19
 requests==2.34.2
 requests-toolbelt==1.0.0
-rpds-py==2026.6.3
+rpds-py==0.30.0
 sniffio==1.3.1
 sse-starlette==3.4.5
 starlette==1.3.1


### PR DESCRIPTION
The dependency refresh in #118 bumped `rpds-py` to `2026.6.3`, which **requires Python >=3.11**. The project supports Python >=3.10 (`pyproject.toml`), and the release quality-check matrix builds on 3.10/3.11/3.12, so the v0.7.9 release run failed on both `ubuntu-latest, 3.10` and `macos-latest, 3.10` with:

```
ERROR: Could not find a version that satisfies the requirement rpds-py==2026.6.3
ERROR: No matching distribution found for rpds-py==2026.6.3
```

This was missed originally because the local verification venv was Python 3.13.

**Fix:** revert `rpds-py` to `0.30.0`, the latest release that still supports Python 3.10 (and the version pinned before #118). Verified: full `requirements.txt` resolves cleanly on a real Python 3.10 interpreter.